### PR TITLE
Provide an interface for the random string generator

### DIFF
--- a/spec/Drupal/Driver/Cores/Drupal7Spec.php
+++ b/spec/Drupal/Driver/Cores/Drupal7Spec.php
@@ -2,14 +2,13 @@
 
 namespace spec\Drupal\Driver\Cores;
 
-use Drupal\Component\Utility\Random;
-
+use Drupal\Component\Utility\RandomInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class Drupal7Spec extends ObjectBehavior
 {
-    function let(Random $random)
+    function let(RandomInterface $random)
     {
         $this->beConstructedWith('path', 'http://www.example.com', $random);
     }

--- a/spec/Drupal/Driver/Cores/Drupal7Spec.php
+++ b/spec/Drupal/Driver/Cores/Drupal7Spec.php
@@ -20,6 +20,6 @@ class Drupal7Spec extends ObjectBehavior
 
     function it_should_return_a_random_generator()
     {
-        $this->getRandom()->shouldBeAnInstanceOf('Drupal\Component\Utility\Random');
+        $this->getRandom()->shouldBeAnInstanceOf('Drupal\Component\Utility\RandomInterface');
     }
 }

--- a/spec/Drupal/Driver/Cores/Drupal8Spec.php
+++ b/spec/Drupal/Driver/Cores/Drupal8Spec.php
@@ -2,14 +2,14 @@
 
 namespace spec\Drupal\Driver\Cores;
 
-use Drupal\Component\Utility\Random;
+use Drupal\Component\Utility\RandomInterface;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class Drupal8Spec extends ObjectBehavior
 {
-    function let(Random $random)
+    function let(RandomInterface $random)
     {
         $this->beConstructedWith('path', 'http://www.example.com', $random);
     }

--- a/src/Drupal/Component/Utility/Random.php
+++ b/src/Drupal/Component/Utility/Random.php
@@ -10,7 +10,7 @@ namespace Drupal\Component\Utility;
 /**
  * Defines a utility class for creating random data.
  */
-class Random {
+class Random implements RandomInterface {
 
   /**
    * The maximum number of times name() and string() can loop.
@@ -37,24 +37,7 @@ class Random {
   protected $names = array();
 
   /**
-   * Generates a random string of ASCII characters of codes 32 to 126.
-   *
-   * The generated string includes alpha-numeric characters and common
-   * miscellaneous characters. Use this method when testing general input
-   * where the content is not restricted.
-   *
-   * @param int $length
-   *   Length of random string to generate.
-   * @param bool $unique
-   *   (optional) If TRUE ensures that the random string returned is unique.
-   *   Defaults to FALSE.
-   * @param callable $validator
-   *   (optional) A callable to validate the the string. Defaults to NULL.
-   *
-   * @return string
-   *   Randomly generated string.
-   *
-   * @see \Drupal\Component\Utility\Random::name()
+   * {@inheritdoc}
    */
   public function string($length = 8, $unique = FALSE, $validator = NULL) {
     $counter = 0;
@@ -91,24 +74,7 @@ class Random {
   }
 
   /**
-   * Generates a random string containing letters and numbers.
-   *
-   * The string will always start with a letter. The letters may be upper or
-   * lower case. This method is better for restricted inputs that do not
-   * accept certain characters. For example, when testing input fields that
-   * require machine readable values (i.e. without spaces and non-standard
-   * characters) this method is best.
-   *
-   * @param int $length
-   *   Length of random string to generate.
-   * @param bool $unique
-   *   (optional) If TRUE ensures that the random string returned is unique.
-   *   Defaults to FALSE.
-   *
-   * @return string
-   *   Randomly generated string.
-   *
-   * @see \Drupal\Component\Utility\Random::string()
+   * {@inheritdoc}
    */
   public function name($length = 8, $unique = FALSE) {
     $values = array_merge(range(65, 90), range(97, 122), range(48, 57));
@@ -134,14 +100,7 @@ class Random {
   }
 
   /**
-   * Generates a random PHP object.
-   *
-   * @param int $size
-   *   The number of random keys to add to the object.
-   *
-   * @return \stdClass
-   *   The generated object, with the specified number of random keys. Each key
-   *   has a random string value.
+   * {@inheritdoc}
    */
   public function object($size = 4) {
     $object = new \stdClass();

--- a/src/Drupal/Component/Utility/RandomInterface.php
+++ b/src/Drupal/Component/Utility/RandomInterface.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Component\Utility\RandomInterface.
+ */
+
+namespace Drupal\Component\Utility;
+
+/**
+ * Defines a utility class for creating random data.
+ */
+interface RandomInterface {
+
+  /**
+   * Generates a random string of ASCII characters of codes 32 to 126.
+   *
+   * The generated string includes alpha-numeric characters and common
+   * miscellaneous characters. Use this method when testing general input
+   * where the content is not restricted.
+   *
+   * @param int $length
+   *   Length of random string to generate.
+   * @param bool $unique
+   *   (optional) If TRUE ensures that the random string returned is unique.
+   *   Defaults to FALSE.
+   * @param callable $validator
+   *   (optional) A callable to validate the the string. Defaults to NULL.
+   *
+   * @return string
+   *   Randomly generated string.
+   *
+   * @see \Drupal\Component\Utility\Random::name()
+   */
+  public function string($length = 8, $unique = FALSE, $validator = NULL);
+
+  /**
+   * Generates a random string containing letters and numbers.
+   *
+   * The string will always start with a letter. The letters may be upper or
+   * lower case. This method is better for restricted inputs that do not
+   * accept certain characters. For example, when testing input fields that
+   * require machine readable values (i.e. without spaces and non-standard
+   * characters) this method is best.
+   *
+   * @param int $length
+   *   Length of random string to generate.
+   * @param bool $unique
+   *   (optional) If TRUE ensures that the random string returned is unique.
+   *   Defaults to FALSE.
+   *
+   * @return string
+   *   Randomly generated string.
+   *
+   * @see \Drupal\Component\Utility\Random::string()
+   */
+  public function name($length = 8, $unique = FALSE);
+
+  /**
+   * Generates a random PHP object.
+   *
+   * @param int $size
+   *   The number of random keys to add to the object.
+   *
+   * @return \stdClass
+   *   The generated object, with the specified number of random keys. Each key
+   *   has a random string value.
+   */
+  public function object($size = 4);
+
+}

--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\Driver\Cores;
 
-use Drupal\Component\Utility\Random;
+use Drupal\Component\Utility\RandomInterface;
 
 /**
  * Drupal core interface.
@@ -16,13 +16,15 @@ interface CoreInterface {
    * @param string $uri
    *   URI that is accessing Drupal. Defaults to 'default'.
    *
-   * @param \Drupal\Component\Utility\Random $random
+   * @param \Drupal\Component\Utility\RandomInterface $random
    *   Random string generator.
    */
-  public function __construct($drupalRoot, $uri = 'default', Random $random);
+  public function __construct($drupalRoot, $uri = 'default', RandomInterface $random);
 
   /**
    * Return random generator.
+   *
+   * @return \Drupal\Component\Utility\RandomInterface
    */
   public function getRandom();
 

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -3,6 +3,7 @@
 namespace Drupal\Driver\Cores;
 
 use Drupal\Component\Utility\Random;
+use Drupal\Component\Utility\RandomInterface;
 use Drupal\Driver\Exception\BootstrapException;
 
 /**
@@ -26,14 +27,14 @@ class Drupal7 implements CoreInterface {
   /**
    * Random generator.
    *
-   * @var \Drupal\Component\Utility\Random
+   * @var \Drupal\Component\Utility\RandomInterface
    */
   private $random;
 
   /**
    * {@inheritDoc}
    */
-  public function __construct($drupalRoot, $uri = 'default', Random $random) {
+  public function __construct($drupalRoot, $uri = 'default', RandomInterface $random) {
     $this->drupalRoot = realpath($drupalRoot);
     $this->uri = $uri;
     $this->random = $random;

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -3,6 +3,7 @@
 namespace Drupal\Driver\Cores;
 
 use Drupal\Component\Utility\Random;
+use Drupal\Component\Utility\RandomInterface;
 use Drupal\Driver\Exception\BootstrapException;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
@@ -36,9 +37,11 @@ class Drupal8 implements CoreInterface {
   /**
    * {@inheritDoc}
    */
-  public function __construct($drupalRoot, $uri = 'default', Random $random = NULL) {
+  public function __construct($drupalRoot, $uri = 'default', RandomInterface $random = NULL) {
     $this->drupalRoot = realpath($drupalRoot);
     $this->uri = $uri;
+
+    // @todo This should not be optional but injected by a factory method.
     if (!isset($random)) {
       $random = new Random();
     }

--- a/src/Drupal/Driver/DriverInterface.php
+++ b/src/Drupal/Driver/DriverInterface.php
@@ -9,6 +9,8 @@ interface DriverInterface {
 
   /**
    * Returns a random generator.
+   *
+   * @return \Drupal\Component\Utility\RandomInterface
    */
   public function getRandom();
 

--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -3,6 +3,7 @@
 namespace Drupal\Driver;
 
 use Drupal\Component\Utility\Random;
+use Drupal\Component\Utility\RandomInterface;
 use Drupal\Driver\Exception\BootstrapException;
 
 use Symfony\Component\Process\Process;
@@ -41,7 +42,7 @@ class DrushDriver extends BaseDriver {
   /**
    * Random generator.
    *
-   * @var \Drupal\Component\Utility\Random
+   * @var \Drupal\Component\Utility\RandomInterface
    */
   private $random;
 
@@ -61,12 +62,12 @@ class DrushDriver extends BaseDriver {
    *   The root path of the Drupal install. This is an alternative to using aliases.
    * @param string $binary
    *   The path to the drush binary.
-   * @param \Drupal\Component\Utility\Random $random
+   * @param \Drupal\Component\Utility\RandomInterface $random
    *   Random generator.
    *
    * @throws \Drupal\Driver\Exception\BootstrapException
    */
-  public function __construct($alias = NULL, $root_path = NULL, $binary = 'drush', Random $random = NULL) {
+  public function __construct($alias = NULL, $root_path = NULL, $binary = 'drush', RandomInterface $random = NULL) {
     if (!empty($alias)) {
       // Trim off the '@' symbol if it has been added.
       $alias = ltrim($alias, '@');
@@ -82,6 +83,7 @@ class DrushDriver extends BaseDriver {
 
     $this->binary = $binary;
 
+    // @todo This should not be optional but injected by a factory method.
     if (!isset($random)) {
       $random = new Random();
     }


### PR DESCRIPTION
The random string generator `\Drupal\Component\Utility\Random` is currently hardcoded in the project. It would be better if this conformed to an interface so it can be properly injected. This would allow us to override it, and it allow the methods to be autocompleted by IDEs.
