### PR TITLE
Protect against a failure from hook_taxonomy_term_insert() in pathauto

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -423,7 +423,11 @@ class Drupal7 implements CoreInterface {
       throw new \Exception(sprintf('No "%s" vocabulary found.'));
     }
 
+    // Protect against a failure from hook_taxonomy_term_insert() in pathauto.
+    $current_path = getcwd();
+    chdir(DRUPAL_ROOT);
     \taxonomy_term_save($term);
+    chdir($current_path);
 
     // Loading a term by name returns an array of term objects, but there should
     // only be one matching term in a testing context, so take the first match


### PR DESCRIPTION
I added this as an issue a few days ago (see https://www.drupal.org/node/2396373) and thought perhaps a pull request would be easier than a patch. termCreate() runs taxonomy hooks that, when pathauto has group-specific paths defined, causes a fatal error if DRUPAL_ROOT != getcwd().

I'm loving behat and the drupal-extension - thank you!
