### PR TITLE
Fixes issue #15.

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -34,9 +34,12 @@ class Drupal7 extends AbstractCore {
   /**
    * {@inheritDoc}
    */
-  public function __construct($drupalRoot, $uri = 'default', Random $random) {
+  public function __construct($drupalRoot, $uri = 'default', Random $random = NULL) {
     $this->drupalRoot = realpath($drupalRoot);
     $this->uri = $uri;
+    if (!isset($random)) {
+      $random = new Random();
+    }
     $this->random = $random;
   }
 


### PR DESCRIPTION
- Unify the `__constructor()` for D7 and D8 cores.