### PR TITLE
Avoid invalid argument DefaultHandler.php non array.

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal7/DefaultHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/DefaultHandler.php
@@ -18,7 +18,7 @@ class DefaultHandler extends AbstractHandler {
    */
   public function expand($values) {
     $return = array();
-    foreach ($values as $value) {
+    foreach ((array)$values as $value) {
       $return[$this->language][] = array('value' => $value);
     }
     return $return;


### PR DESCRIPTION
Pull request for changes proposed in https://github.com/jhedstrom/DrupalDriver/issues/14.

Fix avoid problem on PHP 5.4.38.