### PR TITLE
Add missing dependency to symfony/dependency-injection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
      }
   ],
   "require": {
-    "symfony/process": "~2.5"
+    "symfony/process": "~2.5",
+    "symfony/dependency-injection": "~2.6"
   },
   "require-dev": {
     "phpspec/phpspec": "~2.0",


### PR DESCRIPTION
Working with field handlers using DrupalDriver as a standalone library has uncovered a missing dependency to ```symfony/dependency-injection```: this pull request takes care of that by adding it to composer.json.