### PR TITLE
Use autoload.php in favour of core/vendor/autoload.php

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -27,7 +27,7 @@ class Drupal8 extends AbstractCore {
 
     // Bootstrap Drupal.
     chdir(DRUPAL_ROOT);
-    $autoloader = DRUPAL_ROOT . '/autoload.php';
+    $autoloader = require DRUPAL_ROOT . '/autoload.php';
     require_once DRUPAL_ROOT . '/core/includes/bootstrap.inc';
     $this->validateDrupalSite();
 


### PR DESCRIPTION
Core introduced the autoload.php a while ago. Changed the bootstrap in Drupal8, its follows very close what we have in [index.php](https://github.com/drupal/drupal/blob/8.0.x/index.php#L17).