### PR TITLE
Term Reference Field Handling

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal7/TaxonomyTermReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/TaxonomyTermReferenceHandler.php
@@ -30,7 +30,9 @@ class TaxonomyTermReferenceHandler extends AbstractHandler {
   /**
    * Attempt to determine the vocabulary for which the field is configured.
    *
-   * @return string|NULL
+   * @return mixed
+   *   Returns a string containing the vocabulary in which the term must be
+   *   found or NULL if unable to determine.
    */
   protected function getVocab() {
     if (!empty($this->field_info['settings']['allowed_values'][0]['vocabulary'])) {

--- a/src/Drupal/Driver/Fields/Drupal7/TaxonomyTermReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/TaxonomyTermReferenceHandler.php
@@ -37,4 +37,5 @@ class TaxonomyTermReferenceHandler extends AbstractHandler {
       return $this->field_info['settings']['allowed_values'][0]['vocabulary'];
     }
   }
+
 }

--- a/src/Drupal/Driver/Fields/Drupal7/TaxonomyTermReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/TaxonomyTermReferenceHandler.php
@@ -19,12 +19,23 @@ class TaxonomyTermReferenceHandler extends AbstractHandler {
   public function expand($values) {
     $return = array();
     foreach ($values as $name) {
-      $terms = taxonomy_get_term_by_name($name);
+      $terms = taxonomy_get_term_by_name($name, $this->getVocab());
       if (!$terms) {
         throw new \Exception(sprintf("No term '%s' exists.", $name));
       }
       $return[$this->language][] = array('tid' => array_shift($terms)->tid);
     }
     return $return;
+  }
+
+  /**
+   * Attempt to determine the vocabulary for which the field is configured.
+   *
+   * @return string|NULL
+   */
+  protected function getVocab() {
+    if (!empty($this->field_info['settings']['allowed_values'][0]['vocabulary'])) {
+      return $this->field_info['settings']['allowed_values'][0]['vocabulary'];
+    }
   }
 }

--- a/src/Drupal/Driver/Fields/Drupal8/AbstractHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/AbstractHandler.php
@@ -10,15 +10,22 @@ namespace Drupal\Driver\Fields\Drupal8;
 use Drupal\Driver\Fields\FieldHandlerInterface;
 
 /**
- * Base class for field handlers in Drupal 7.
+ * Base class for field handlers in Drupal 8.
  */
 abstract class AbstractHandler implements FieldHandlerInterface {
   /**
    * Field storage definition.
    *
-   * @var array
+   * @var \Drupal\field\Entity\FieldStorageConfig
    */
   protected $fieldInfo = array();
+
+  /**
+   * Field configuration definition.
+   *
+   * @var \Drupal\field\Entity\FieldConfig
+   */
+  protected $fieldConfig = array();
 
   /**
    * Constructs an AbstractHandler object.
@@ -29,10 +36,24 @@ abstract class AbstractHandler implements FieldHandlerInterface {
    *   The entity type.
    * @param string $field_name
    *   The field name.
+   *
+   * @throws \Exception
    */
   public function __construct(\stdClass $entity, $entity_type, $field_name) {
     $fields = \Drupal::entityManager()->getFieldStorageDefinitions($entity_type);
     $this->fieldInfo = $fields[$field_name];
+
+    $bundle_key = \Drupal::entityManager()->getDefinition($entity_type)->getKey('bundle');
+    if (empty($entity->{$bundle_key})) {
+      throw new \Exception(sprintf('Invalid %s entity bundle key "%s" not set.', $entity_type, $bundle_key));
+    }
+    $bundle = $entity->{$bundle_key};
+
+    $fields = \Drupal::entityManager()->getFieldDefinitions($entity_type, $bundle);
+    if (empty($fields[$field_name])) {
+      throw new \Exception(sprintf('Invalid bundle "%s" on entity type "%s".', $bundle_key, $entity_type));
+    }
+    $this->fieldConfig = $fields[$field_name];
   }
 
 }

--- a/src/Drupal/Driver/Fields/Drupal8/AbstractHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/AbstractHandler.php
@@ -38,6 +38,8 @@ abstract class AbstractHandler implements FieldHandlerInterface {
    *   The field name.
    *
    * @throws \Exception
+   *   Missing or invalid bundle property for entity type, or invalid field_name
+   *   for entity and bundle.
    */
   public function __construct(\stdClass $entity, $entity_type, $field_name) {
     $fields = \Drupal::entityManager()->getFieldStorageDefinitions($entity_type);

--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -22,10 +22,9 @@ class EntityReferenceHandler extends AbstractHandler {
     $label_key = $entity_definition->getKey('label');
 
     // Determine target bundle restrictions.
-    $settings = $this->fieldConfig->getSettings();
-    if (!empty($settings['handler_settings']['target_bundles'])) {
+    $target_bundle_key = NULL;
+    if (!$target_bundles = $this->getTargetBundles()) {
       $target_bundle_key = $entity_definition->getKey('bundle');
-      $target_bundles = $settings['handler_settings']['target_bundles'];
     }
 
     foreach ($values as $value) {
@@ -41,6 +40,19 @@ class EntityReferenceHandler extends AbstractHandler {
       }
     }
     return $return;
+  }
+
+  /**
+   * Retrieves bundles for which the field is configured to reference.
+   *
+   * @return mixed
+   *   Array of bundle names, or NULL if not able to determine bundles.
+   */
+  protected function getTargetBundles() {
+    $settings = $this->fieldConfig->getSettings();
+    if (!empty($settings['handler_settings']['target_bundles'])) {
+      return $settings['handler_settings']['target_bundles'];
+    }
   }
 
 }

--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -29,7 +29,7 @@ class EntityReferenceHandler extends AbstractHandler {
 
     foreach ($values as $value) {
       $query = \Drupal::entityQuery($entity_type_id)->condition($label_key, $value);
-      if (isset($target_bundles)) {
+      if ($target_bundles && $target_bundle_key) {
         $query->condition($target_bundle_key, $target_bundles, 'IN');
       }
       if ($entities = $query->execute()) {

--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -19,13 +19,22 @@ class EntityReferenceHandler extends AbstractHandler {
     $return = array();
     $entity_type_id = $this->fieldInfo->getSetting('target_type');
     $entity_definition = \Drupal::entityManager()->getDefinition($entity_type_id);
-    $label = $entity_definition->getKey('label');
+    $label_key = $entity_definition->getKey('label');
+
+    // Determine target bundle restrictions.
+    $settings = $this->fieldConfig->getSettings();
+    if (!empty($settings['handler_settings']['target_bundles'])) {
+      $target_bundle_key = $entity_definition->getKey('bundle');
+      $target_bundles = $settings['handler_settings']['target_bundles'];
+    }
+
     foreach ($values as $value) {
-      $entities = \Drupal::entityManager()
-        ->getStorage($entity_type_id)
-        ->loadByProperties(array($label => $value));
-      if ($entities) {
-        $return[] = array_shift($entities)->id();
+      $query = \Drupal::entityQuery($entity_type_id)->condition($label_key, $value);
+      if (isset($target_bundles)) {
+        $query->condition($target_bundle_key, $target_bundles, 'IN');
+      }
+      if ($entities = $query->execute()) {
+        $return[] = array_shift($entities);
       }
       else {
         throw new \Exception(sprintf("No entity '%s' of type '%s' exists.", $value, $entity_type_id));


### PR DESCRIPTION
The current TaxonomyTermReferenceHandler just plucks the first term found by `taxonomy_get_term_by_name()`. If there are multiple terms with the same name this can cause issues when an entity is assigned a term from the wrong vocabulary.

This patch includes that attempts to determine the vocabulary/bundle for which the field is configured and restricts the `taxonomy_get_term_by_name()` call to said vocabulary.

If unable to field's configured vocabulary, behavior will revert to the current behavior of looking up across all vocabularies.