### PR TITLE
Core now returns an array of Extension objects.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-php: [5.6, 5.5, 5.4, 5.3, hhvm]
+php: [5.6, 5.5, 5.4, hhvm]
 
 install:
   - composer install --dev --prefer-source

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -307,7 +307,7 @@ class Drupal8 extends AbstractCore {
    * {@inheritDoc}
    */
   public function getModuleList() {
-    return \Drupal::moduleHandler()->getModuleList();
+    return array_keys(\Drupal::moduleHandler()->getModuleList());
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/jhedstrom/drupalextension/issues/170.
