### PR TITLE
Drupal7::isField() does not check entity type

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -371,6 +371,6 @@ class Drupal7 extends AbstractCore {
    */
   public function isField($entity_type, $field_name) {
     $map = field_info_field_map();
-    return isset($map[$field_name]);
+    return !empty($map[$field_name]) && array_key_exists($entity_type, $map[$field_name]['bundles']);
   }
 }

--- a/src/Drupal/Driver/DriverInterface.php
+++ b/src/Drupal/Driver/DriverInterface.php
@@ -133,8 +133,12 @@ interface DriverInterface {
    * Check if the specified field is an actual Drupal field.
    *
    * @param $entity_type
+   *   The entity type to which the field should belong.
    * @param $field_name
+   *   The name of the field.
+   *
    * @return boolean
+   *   TRUE if the field exists in the entity type, FALSE if not.
    */
   public function isField($entity_type, $field_name);
 }


### PR DESCRIPTION
`Drupal7::isField()` does not check the entity type, it returns `TRUE` if the field exists in any entity.