### PR TITLE
Make field lookup more efficient

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -359,7 +359,7 @@ class Drupal7 extends AbstractCore {
     $return = array();
     $fields = field_info_field_map();
     foreach ($fields as $field_name => $field) {
-      if ($this->isField($entity_type, $field_name)) {
+      if (array_key_exists($entity_type, $field['bundles'])) {
         $return[$field_name] = $field['type'];
       }
     }


### PR DESCRIPTION
In `Drupal7::getEntityFieldTypes()` the field lookup is delegated to `isField()` but this is memory inefficient for sites with lots of fields. The necessary data from `field_info_field_map()` is already available in `getEntityFieldTypes()` so we can simply make use of it.

`isField()` does its own call to `field_info_field_map()` and in traditional Drupal 7 fashion this data is represented in an array which is passed through a bunch of functions and methods. Every time an array in passed additional memory will be allocated and the data will be copied in it. We can avoid this and gain a little bit of memory efficiency.