### PR TITLE
Add support for field columns to the default field handler

### DIFF
--- a/src/Drupal/Driver/BaseDriver.php
+++ b/src/Drupal/Driver/BaseDriver.php
@@ -78,6 +78,13 @@ abstract class BaseDriver implements DriverInterface {
   /**
    * {@inheritdoc}
    */
+  public function clearStaticCaches() {
+    throw new UnsupportedDriverActionException($this->errorString('clear static caches'), $this);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function createNode($node) {
     throw new UnsupportedDriverActionException($this->errorString('create nodes'), $this);
   }

--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -191,4 +191,9 @@ interface CoreInterface {
    */
   public function languageDelete(\stdClass $language);
 
+  /**
+   * Clears the static caches.
+   */
+  public function clearStaticCaches();
+
 }

--- a/src/Drupal/Driver/Cores/Drupal6.php
+++ b/src/Drupal/Driver/Cores/Drupal6.php
@@ -491,4 +491,11 @@ class Drupal6 extends AbstractCore {
     throw new \Exception('Deleting languages is not yet implemented for Drupal 6.');
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function clearStaticCaches() {
+    // Drupal 6 doesn't have a way of clearing all static caches.
+  }
+
 }

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -467,4 +467,11 @@ class Drupal7 extends AbstractCore {
     return !empty($map[$field_name]) && array_key_exists($entity_type, $map[$field_name]['bundles']);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function clearStaticCaches() {
+    drupal_static_reset();
+  }
+
 }

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -388,4 +388,12 @@ class Drupal8 extends AbstractCore {
     $configurable_language->delete();
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function clearStaticCaches() {
+    drupal_static_reset();
+    \Drupal::service('cache_tags.invalidator')->resetChecksums();
+  }
+
 }

--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -304,4 +304,11 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface {
     $this->getCore()->languageDelete($language);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function clearStaticCaches() {
+    $this->getCore()->clearStaticCaches();
+  }
+
 }

--- a/src/Drupal/Driver/Fields/Drupal7/DefaultHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/DefaultHandler.php
@@ -18,7 +18,11 @@ class DefaultHandler extends AbstractHandler {
   public function expand($values) {
     $return = array();
     foreach ($values as $value) {
-      $return[$this->language][] = array('value' => $value);
+      // Use the column name 'value' by default if the value is not an array.
+      if (!is_array($value)) {
+        $value = array('value' => $value);
+      }
+      $return[$this->language][] = $value;
     }
     return $return;
   }

--- a/tests/Drupal/Tests/Driver/Drupal7FieldHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Drupal7FieldHandlerTest.php
@@ -66,6 +66,33 @@ class Drupal7FieldHandlerTest extends FieldHandlerAbstractTest {
         array('en' => array(array('value' => 'Text'))),
       ),
 
+      // Test default field handler using custom field columns.
+      array(
+        'DefaultHandler',
+        (object) array(
+          'field_addressfield' => array(
+            array(
+              'country' => 'BE',
+              'locality' => 'Brussels',
+              'thoroughfare' => 'Grote Markt 1',
+              'postal_code' => '1000',
+            ),
+          ),
+        ),
+        'node',
+        array('field_name' => 'field_addressfield'),
+        array(
+          'en' => array(
+            array(
+              'country' => 'BE',
+              'locality' => 'Brussels',
+              'thoroughfare' => 'Grote Markt 1',
+              'postal_code' => '1000',
+            ),
+          ),
+        ),
+      ),
+
       // Test single-value date field provided as simple text.
       array(
         'DatetimeHandler',


### PR DESCRIPTION
Currently the default field handler only supports fields that have a single column, and will hard code the column name to 'value'. This is fine for something like a regular text field, but it cannot be used for fields that have multiple columns, or use a different column name.

I propose to allow the use of arrays for the field items in `DefaultHandler::expand()` that are keyed on the column name.

For example this would allow us to support a complex field such as AddressField without having to write a custom handler:

```
$values = [
  0 => [
    'country' => 'BE',
    'locality' => 'Brussel',
    'thoroughfare' => 'Louisalaan 1',
    'postal_code' => '1000',
  ],
];
```