### PR TITLE
Error: unable to determine Drupal core version

### DIFF
--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -64,8 +64,8 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface {
    *   Thrown when the Drupal installation is not found in the given root path.
    */
   public function __construct($drupal_root, $uri) {
-    $this->drupal_root = realpath($drupal_root);
-    if (!$this->drupal_root) {
+    $this->drupalRoot = realpath($drupal_root);
+    if (!$this->drupalRoot) {
       throw new BootstrapException(sprintf('No Drupal installation found at %s', $drupal_root));
     }
     $this->uri = $uri;


### PR DESCRIPTION
When I was fixing the code sniffer warnings I changed some property names to camelcase to be compliant with the standards. However I forgot to update the `$this->drupalRoot` property in `DrupalDriver`. This now causes the following exception to be thrown when Drupal is bootstrapped:

```
Unable to determine Drupal core version. Supported versions are 6, 7, and 8.
```