### PR TITLE
Add list_boolean field handler

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal7/ListBooleanHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/ListBooleanHandler.php
@@ -10,7 +10,7 @@ namespace Drupal\Driver\Fields\Drupal7;
 /**
  * ListBoolean field handler for Drupal 7.
  *
- * Nothing to do here, standard ListTextHandler methods are used.
+ * Nothing to do here, the expand() method from ListTextHandler is used.
  */
 class ListBooleanHandler extends ListTextHandler {
 

--- a/src/Drupal/Driver/Fields/Drupal7/ListBooleanHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/ListBooleanHandler.php
@@ -9,6 +9,7 @@ namespace Drupal\Driver\Fields\Drupal7;
 
 /**
  * ListBoolean field handler for Drupal 7.
+ * 
  * Nothing to do here, standard ListTextHandler methods are used.
  */
 class ListBooleanHandler extends ListTextHandler {

--- a/src/Drupal/Driver/Fields/Drupal7/ListBooleanHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/ListBooleanHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Driver\Fields\Drupal7\ListBooleanHandler
+ */
+
+namespace Drupal\Driver\Fields\Drupal7;
+
+/**
+ * Class ListBooleanHandler
+ * @package Drupal\Driver\Fields\Drupal7
+ */
+class ListBooleanHandler extends ListTextHandler {
+    // Nothing to do here, standard ListTextHandler methods are used.
+}

--- a/src/Drupal/Driver/Fields/Drupal7/ListBooleanHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/ListBooleanHandler.php
@@ -9,8 +9,8 @@ namespace Drupal\Driver\Fields\Drupal7;
 
 /**
  * ListBoolean field handler for Drupal 7.
+ * Nothing to do here, standard ListTextHandler methods are used.
  */
 class ListBooleanHandler extends ListTextHandler {
-  // Nothing to do here, standard ListTextHandler methods are used.
 
 }

--- a/src/Drupal/Driver/Fields/Drupal7/ListBooleanHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/ListBooleanHandler.php
@@ -2,15 +2,15 @@
 
 /**
  * @file
- * Contains \Drupal\Driver\Fields\Drupal7\ListBooleanHandler
+ * Contains \Drupal\Driver\Fields\Drupal7\ListBooleanHandler.
  */
 
 namespace Drupal\Driver\Fields\Drupal7;
 
 /**
- * Class ListBooleanHandler
- * @package Drupal\Driver\Fields\Drupal7
+ * ListBoolean field handler for Drupal 7.
  */
 class ListBooleanHandler extends ListTextHandler {
-    // Nothing to do here, standard ListTextHandler methods are used.
+  // Nothing to do here, standard ListTextHandler methods are used.
+
 }

--- a/src/Drupal/Driver/Fields/Drupal7/ListBooleanHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/ListBooleanHandler.php
@@ -9,7 +9,7 @@ namespace Drupal\Driver\Fields\Drupal7;
 
 /**
  * ListBoolean field handler for Drupal 7.
- * 
+ *
  * Nothing to do here, standard ListTextHandler methods are used.
  */
 class ListBooleanHandler extends ListTextHandler {


### PR DESCRIPTION
The list_boolean field type (defined in List core module) is not correctly handled in current implementation: this handler forces the field type to be correctly handled as a "list"