### PR TITLE
Test list boolean field with blank 'On' and 'Off' values.

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal7/ListBooleanHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/ListBooleanHandler.php
@@ -9,9 +9,26 @@ namespace Drupal\Driver\Fields\Drupal7;
 
 /**
  * ListBoolean field handler for Drupal 7.
- *
- * Nothing to do here, the expand() method from ListTextHandler is used.
  */
-class ListBooleanHandler extends ListTextHandler {
+class ListBooleanHandler extends AbstractHandler {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function expand($values) {
+    $return = array();
+    $allowed_values = $this->fieldInfo['settings']['allowed_values'];
+    // If values are blank then use keys as value.
+    foreach ($allowed_values as $key => $value) {
+      if ($value == '') {
+        $allowed_values[$key] = $key;
+      }
+    }
+    $allowed_values = array_flip($allowed_values);
+    foreach ($values as $value) {
+      $return[$this->language][] = array('value' => $allowed_values[$value]);
+    }
+    return $return;
+  }
 
 }

--- a/tests/Drupal/Tests/Driver/Drupal7FieldHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Drupal7FieldHandlerTest.php
@@ -111,6 +111,29 @@ class Drupal7FieldHandlerTest extends FieldHandlerAbstractTest {
           ),
         ),
       ),
+
+      // Test list boolean field with blank 'On' and 'Off' values.
+      array(
+        'ListBooleanHandler',
+        (object) array('field_list_boolean' => array(0)),
+        'node',
+        array(
+          'field_name' => 'field_list_boolean',
+          'settings' => array(
+            'allowed_values' => array(
+              0 => '',
+              1 => '',
+            ),
+          ),
+        ),
+        array(
+          'en' => array(
+            array(
+              'value' => 0,
+            ),
+          ),
+        ),
+      ),
     );
   }
 


### PR DESCRIPTION
I've noticed a bug if I am trying to set the value '0' for a list boolean field when the Off value is blank in the settings.