### PR TITLE
Add support for creating and deleting languages

### DIFF
--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -172,7 +172,7 @@ interface CoreInterface {
    *   An object with the following properties:
    *   - langcode: the langcode of the language to create.
    */
-  public function languageCreate($language);
+  public function languageCreate(\stdClass $language);
 
   /**
    * Deletes a language.
@@ -181,6 +181,6 @@ interface CoreInterface {
    *   An object with the following properties:
    *   - langcode: the langcode of the language to delete.
    */
-  public function languageDelete($language);
+  public function languageDelete(\stdClass $language);
 
 }

--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -165,4 +165,22 @@ interface CoreInterface {
    */
   public function getEntityFieldTypes($entity_type);
 
+  /**
+   * Creates a language.
+   *
+   * @param \stdClass $language
+   *   An object with the following properties:
+   *   - langcode: the langcode of the language to create.
+   */
+  public function languageCreate($language);
+
+  /**
+   * Deletes a language.
+   *
+   * @param \stdClass $language
+   *   An object with the following properties:
+   *   - langcode: the langcode of the language to delete.
+   */
+  public function languageDelete($language);
+
 }

--- a/src/Drupal/Driver/Cores/Drupal6.php
+++ b/src/Drupal/Driver/Cores/Drupal6.php
@@ -475,4 +475,5 @@ class Drupal6 extends AbstractCore {
   public function languageDelete(\stdClass $language) {
     throw new \Exception('Deleting languages is not yet implemented for Drupal 6.');
   }
+
 }

--- a/src/Drupal/Driver/Cores/Drupal6.php
+++ b/src/Drupal/Driver/Cores/Drupal6.php
@@ -462,4 +462,17 @@ class Drupal6 extends AbstractCore {
     return isset($map[$field_name]);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function languageCreate(\stdClass $language) {
+    throw new \Exception('Creating languages is not yet implemented for Drupal 6.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function languageDelete(\stdClass $language) {
+    throw new \Exception('Deleting languages is not yet implemented for Drupal 6.');
+  }
 }

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -364,7 +364,10 @@ class Drupal7 extends AbstractCore {
     $enabled_languages = locale_language_list();
     if (!isset($enabled_languages[$language->langcode])) {
       locale_add_language($language->langcode);
+      return $language;
     }
+
+    return FALSE;
   }
 
   /**

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -348,7 +348,7 @@ class Drupal7 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
-  public function languageCreate($language) {
+  public function languageCreate(\stdClass $language) {
     include_once DRUPAL_ROOT . '/includes/iso.inc';
     include_once DRUPAL_ROOT . '/includes/locale.inc';
 
@@ -370,7 +370,7 @@ class Drupal7 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
-  public function languageDelete($language) {
+  public function languageDelete(\stdClass $language) {
     $langcode = $language->langcode;
     // Do not remove English or the default language.
     if (!in_array($langcode, array(language_default('language'), 'en'))) {

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -348,13 +348,13 @@ class Drupal8 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
-  public function languageCreate($langcode) {
+  public function languageCreate(\stdClass $language) {
   }
 
   /**
    * {@inheritdoc}
    */
-  public function languageDelete($langcode) {
+  public function languageDelete(\stdClass $language) {
   }
 
 }

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -345,4 +345,16 @@ class Drupal8 extends AbstractCore {
     return (isset($fields[$field_name]) && $fields[$field_name] instanceof FieldStorageConfig);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function languageCreate($langcode) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function languageDelete($langcode) {
+  }
+
 }

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -9,8 +9,10 @@ namespace Drupal\Driver\Cores;
 
 use Drupal\Component\Utility\Random;
 use Drupal\Core\DrupalKernel;
+use Drupal\Core\Language\Language;
 use Drupal\Driver\Exception\BootstrapException;
 use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\Entity\Term;
@@ -349,12 +351,27 @@ class Drupal8 extends AbstractCore {
    * {@inheritdoc}
    */
   public function languageCreate(\stdClass $language) {
+    $langcode = $language->langcode;
+
+    // Enable a language only if it has not been enabled already.
+    if (!ConfigurableLanguage::load($langcode)) {
+      $created_language = ConfigurableLanguage::createFromLangcode($language->langcode);
+      if (!$created_language) {
+        throw new InvalidArgumentException("There is no predefined language with langcode '{$langcode}'.");
+      }
+      $created_language->save();
+      return $language;
+    }
+
+    return FALSE;
   }
 
   /**
    * {@inheritdoc}
    */
   public function languageDelete(\stdClass $language) {
+    $configurable_language = ConfigurableLanguage::load($language->langcode);
+    $configurable_language->delete();
   }
 
 }

--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -302,4 +302,18 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface {
     return $this->getCore()->isField($entity_type, $field_name);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function languageCreate($language) {
+    return $this->getCore()->languageCreate($language);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function languageDelete($language) {
+    $this->getCore()->languageDelete($language);
+  }
+
 }


### PR DESCRIPTION
It would be nice if we could manage languages. This pull request adds basic support for creating and deleting languages in Drupal 7 and 8.