### PR TITLE
  Add support for Image fields in Drupal 7

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal7/ImageHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/ImageHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Driver\Fields\Drupal7\ImageHandler
+ */
+
+namespace Drupal\Driver\Fields\Drupal7;
+
+/**
+ * Class ImageHandler
+ * @package Drupal\Driver\Fields\Drupal7
+ */
+class ImageHandler extends AbstractHandler {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function expand($values) {
+    $return = array();
+    foreach ($values as $value) {
+      $return[$this->language][] = array(
+        'filename' => $value[0],
+        'uri' => $value[1],
+        'fid' => $value[2],
+        'display' => isset($value[3]) ? $value[3] : 1,
+      );
+    }
+    return $return;
+  }
+}

--- a/src/Drupal/Driver/Fields/Drupal7/ImageHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/ImageHandler.php
@@ -2,19 +2,18 @@
 
 /**
  * @file
- * Contains \Drupal\Driver\Fields\Drupal7\ImageHandler
+ * Contains \Drupal\Driver\Fields\Drupal7\ImageHandler.
  */
 
 namespace Drupal\Driver\Fields\Drupal7;
 
 /**
- * Class ImageHandler
- * @package Drupal\Driver\Fields\Drupal7
+ * Image field handler for Drupal 7.
  */
 class ImageHandler extends AbstractHandler {
 
   /**
-   * {@inheritDoc}
+   * {@inheritdoc}
    */
   public function expand($values) {
     $return = array();
@@ -28,4 +27,5 @@ class ImageHandler extends AbstractHandler {
     }
     return $return;
   }
+
 }

--- a/tests/Drupal/Tests/Driver/Drupal7FieldHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Drupal7FieldHandlerTest.php
@@ -134,6 +134,15 @@ class Drupal7FieldHandlerTest extends FieldHandlerAbstractTest {
           ),
         ),
       ),
+
+      // Test image field provided as array.
+      array(
+        'ImageHandler',
+        (object) array('field_image' => array(array('test.png', 'public://images/test.png', 1, 1))),
+        'node',
+        array('field_name' => 'field_image'),
+        array('en' => array(array('filename' => 'test.png', 'uri' => 'public://images/test.png', 'fid' => 1, 'display' => 1))),
+      ),
     );
   }
 

--- a/tests/Drupal/Tests/Driver/Drupal7FieldHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Drupal7FieldHandlerTest.php
@@ -138,10 +138,28 @@ class Drupal7FieldHandlerTest extends FieldHandlerAbstractTest {
       // Test image field provided as array.
       array(
         'ImageHandler',
-        (object) array('field_image' => array(array('test.png', 'public://images/test.png', 1, 1))),
+        (object) array(
+          'field_image' => array(
+            array(
+              'test.png',
+              'public://images/test.png',
+              1,
+              1,
+            ),
+          ),
+        ),
         'node',
         array('field_name' => 'field_image'),
-        array('en' => array(array('filename' => 'test.png', 'uri' => 'public://images/test.png', 'fid' => 1, 'display' => 1))),
+        array(
+          'en' => array(
+            array(
+              'filename' => 'test.png',
+              'uri' => 'public://images/test.png',
+              'fid' => 1,
+              'display' => 1,
+            ),
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
This adds an ImageHandler class to parse an array of values and add the required attributes for an image field. Have tested this locally using beforeNodeCreation hook like so

````
  /**
   * Hook into node creation to test `@beforeNodeCreate`
   *
   * @beforeNodeCreate
   */
  public function alterNodeParameters(BeforeNodeCreateScope $scope) {
    $node = $scope->getEntity();
    // Parse the node image.
    if (isset($node->main_image)) {
      $value = $node->main_image;
      unset($node->main_image);

      $path = $this->getMinkParameter('files_path') . $value;
      $file_contents = file_get_contents($path);

      $dirname = "public://behat_test_images";
      if (file_prepare_directory($dirname, FILE_CREATE_DIRECTORY)) {
        $file = file_save_data(
          $file_contents,
          $dirname . '/' . $value,
          FILE_EXISTS_REPLACE
        );
        $file_properties = array(
          'filename' => $file->filename,
          'uri' => $file->uri,
          'fid' => $file->fid,
          'display' => 1
        );
        $node->field_image = implode(' - ', $file_properties);
      }
    }
  }
````

I feel like the simplicity of my approach might reflect my little understanding about this library so if I've gone about it completely wrong please let me know. This worked with the drupaldriver as well when adding a hyphen separated string into a "Given :type nodes:" step.

Cheers