### PR TITLE
Stop clearStaticCache from throwing warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "1.2.x-dev"
+      "dev-master": "1.1.x-dev"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "1.1.x-dev"
+      "dev-master": "1.2.x-dev"
     }
   }
 }

--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -260,6 +260,13 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
+  public function clearStaticCaches() {
+    // Be very very quiet.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function processBatch() {
     // Do nothing. Drush should internally handle any needs for processing
     // batch ops.


### PR DESCRIPTION
A few contexts don't like this function and add warnings to my output.
the api_driver is set to 'drush'

```
  ╳  No ability to clear static caches in Drupal\Driver\DrushDriver. Put `@api` into your feature and add an API driver (ex: `api_driver: drupal`) in behat.yml. (Drupal\Driver\Exception\UnsupportedDriverActionException)
  │
  └─ @AfterScenario @api # Drupal\DrupalExtension\Context\DrupalContext::clearStaticCaches()
  │
  ╳  No ability to clear static caches in Drupal\Driver\DrushDriver. Put `@api` into your feature and add an API driver (ex: `api_driver: drupal`) in behat.yml. (Drupal\Driver\Exception\UnsupportedDriverActionException)
  │
  └─ @AfterScenario @api # Drupal\DrupalExtension\Context\MessageContext::clearStaticCaches()
  │
  ╳  No ability to clear static caches in Drupal\Driver\DrushDriver. Put `@api` into your feature and add an API driver (ex: `api_driver: drupal`) in behat.yml. (Drupal\Driver\Exception\UnsupportedDriverActionException)
  │
  └─ @AfterScenario @api # Drupal\DrupalExtension\Context\DrushContext::clearStaticCaches()
```