### PR TITLE
Support allowed_values_function field setting in ListTextHandler:expand()

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal7/ListTextHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/ListTextHandler.php
@@ -17,7 +17,14 @@ class ListTextHandler extends AbstractHandler {
    */
   public function expand($values) {
     $return = array();
-    $allowed_values = array_flip($this->fieldInfo['settings']['allowed_values']);
+    if (isset($this->field_info['settings']['allowed_values_function'])) {
+      $function = $this->field_info['settings']['allowed_values_function'];
+      $allowed_values = $function();
+    }
+    else {
+      $allowed_values = $this->field_info['settings']['allowed_values'];
+    }
+    $allowed_values = array_flip($allowed_values);
     foreach ($values as $value) {
       $return[$this->language][] = array('value' => $allowed_values[$value]);
     }

--- a/tests/Drupal/Tests/Driver/Drupal7FieldHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Drupal7FieldHandlerTest.php
@@ -162,6 +162,49 @@ class Drupal7FieldHandlerTest extends FieldHandlerAbstractTest {
         ),
       ),
 
+      // Test list text field with allowed values.
+      array(
+        'ListTextHandler',
+        (object) array('field_list_text_allowed_values' => array('one')),
+        'node',
+        array(
+          'field_name' => 'field_list_text_allowed_values',
+          'settings' => array(
+            'allowed_values' => array(
+              'zero' => 'zero',
+              'one' => 'one',
+            ),
+          ),
+        ),
+        array(
+          'en' => array(
+            array(
+              'value' => 'one',
+            ),
+          ),
+        ),
+      ),
+
+      // Test list text field with allowed values.
+      array(
+        'ListTextHandler',
+        (object) array('field_list_text_allowed_values_function' => array('system')),
+        'node',
+        array(
+          'field_name' => 'field_list_text_allowed_values_function',
+          'settings' => array(
+            'allowed_values_function' => 'module_list',
+          ),
+        ),
+        array(
+          'en' => array(
+            array(
+              'value' => 'system',
+            ),
+          ),
+        ),
+      ),
+
       // Test image field provided as array.
       array(
         'ImageHandler',


### PR DESCRIPTION
Currently the Drupal 7 `expand()` method in `ListTextHandler` examines the values in allowed_values. If a field has an `allowed_values_function` set, an incorrect list of allowed values is examined.

There doesn't appear to be equivalent Drupal 8 code.

Commit f879b5e addresses this issue by drawing allowed values from an `allowed_values_function`, if set.

Commit 6b003c1 roughs in possible testing (untested!).
