### PR TITLE
D7 - Update the roles just added.

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -134,6 +134,9 @@ class Drupal7 extends AbstractCore {
     }
 
     user_multiple_role_edit(array($user->uid), 'add_role', $role->rid);
+    $account = user_load($user->uid);
+    $user->roles = $account->roles;
+
   }
 
   /**


### PR DESCRIPTION
The current user is used to validate field permissions.

The current $user has no roles field so when used fails in user.module

![drupal7_php](https://cloud.githubusercontent.com/assets/371014/9871554/cf9c4bb2-5b94-11e5-9232-048ffd099e6b.png)