### PR TITLE
Make Drupal 7 and 6 drivers return the rid from roleCreate()

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal6.php
+++ b/src/Drupal/Driver/Cores/Drupal6.php
@@ -219,7 +219,7 @@ class Drupal6 extends AbstractCore {
     // Add permissions to role.
     $rid = db_last_insert_id('role', 'rid');
     db_query("INSERT INTO {permission} (rid, perm) VALUES (%d, '%s')", $rid, implode(', ', $permissions));
-    return $name;
+    return $rid;
   }
 
   /**

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -190,7 +190,7 @@ class Drupal7 extends AbstractCore {
     user_role_grant_permissions($role->rid, $permissions);
 
     if ($role && !empty($role->rid)) {
-      return $role->name;
+      return $role->rid;
     }
 
     throw new \RuntimeException(sprintf('Failed to create a role with "" permission(s).', implode(', ', $permissions)));


### PR DESCRIPTION
The interface defines:
```php
/**
   * Create a role
   *
   * @param array $permissions
   *   An array of permissions to create the role with.
   *
   * @return integer
   *   The created role name.
   */
  public function roleCreate(array $permissions);
```

this contract is broken by the Drupal 7 driver that returns the role name.
This then in turn breaks the DrupalExtension behat step:
```php
/**
   * @Given I am logged in as a user with the :permissions permission(s)
   */
  public function assertLoggedInWithPermissions($permissions){}
```