### PR TITLE
Fix tests failing due to change in behavior of 'isField'

### DIFF
--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -227,8 +227,18 @@ class DrushDriver extends BaseDriver {
    * {@inheritdoc}
    */
   public function isField($entity_type, $field_name) {
-    $result = $this->drush('behat', array('is-field', escapeshellarg(json_encode(array($entity_type, $field_name)))), array());
-    return json_decode($result);
+    // If the Behat Drush Endpoint is not installed on the site-under-test,
+    // then the drush() method will throw an exception. In this instance, we
+    // want to treat all potential fields as non-fields.  This allows the
+    // Drush Driver to work with certain built-in Drush capabilities (e.g.
+    // creating users) even if the Behat Drush Endpoint is not available.
+    try {
+      $result = $this->drush('behat', array('is-field', escapeshellarg(json_encode(array($entity_type, $field_name)))), array());
+      return json_decode($result);
+    }
+    catch (\Exception $e) {
+      return FALSE;
+    }
   }
 
   /**


### PR DESCRIPTION
When the Behat Drush Endpoint is not available, the `isField` method is now throwing an exception.  Previously, this method always returned `false`, so the exception causes tests that used to work to now fail.  This PR ensures that `isField` will once again return `false` when the Behat Drush Endpoint is not installed.

I recommend that you merge https://github.com/jhedstrom/drupalextension/pull/222 before merging this fix.  That PR is showing as "failing", but that is expected! Really, you want to merge it -- please read that issue.  Once you have merged 222, then if you merge this PR and force the drupalextension tests to run again, and they will turn green.  (Spoiler: drupalextension tests are currently failing, but are being marked as 'passing' due to a bug fixed in 222.)  Thanks!