### PR TITLE
[WIP] Add support for installing and uninstalling modules

### DIFF
--- a/src/Drupal/Driver/BaseDriver.php
+++ b/src/Drupal/Driver/BaseDriver.php
@@ -153,6 +153,13 @@ abstract class BaseDriver implements DriverInterface {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function getModuleList() {
+    throw new UnsupportedDriverActionException($this->errorString('get module list'), $this);
+  }
+
+  /**
    * Error printing exception.
    *
    * @param string $error

--- a/src/Drupal/Driver/BaseDriver.php
+++ b/src/Drupal/Driver/BaseDriver.php
@@ -139,6 +139,20 @@ abstract class BaseDriver implements DriverInterface {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function installModules(array $modules) {
+    throw new UnsupportedDriverActionException($this->errorString('install modules'), $this);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function uninstallModules(array $modules) {
+    throw new UnsupportedDriverActionException($this->errorString('uninstall modules'), $this);
+  }
+
+  /**
    * Error printing exception.
    *
    * @param string $error

--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -63,17 +63,12 @@ interface CoreInterface {
    *
    * @param array $modules
    *   A list of modules to uninstall.
-   * @param bool $uninstall_dependents
-   *   Whether or not to uninstall the dependents of each module in the list.
-   *   This incurs a performance cost, so set this to FALSE if you know that
-   *   the list of modules already contains all dependents in the correct order.
-   *   Defaults to TRUE.
    *
    * @throws \Drupal\Driver\Exception\ModuleUninstallException
    *   Thrown when the modules could not be uninstalled, for example because a
-   *   dependent module is still installed and $uninstall_dependents is FALSE.
+   *   dependent module is still installed.
    */
-  public function uninstallModules(array $modules, $uninstall_dependents = TRUE);
+  public function uninstallModules(array $modules);
 
   /**
    * Returns a list of all extension absolute paths.

--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -42,6 +42,40 @@ interface CoreInterface {
   public function getModuleList();
 
   /**
+   * Installs the given modules.
+   *
+   * @param array $modules
+   *   A list of modules to install.
+   * @param bool $install_dependencies
+   *   Whether or not to install the dependencies of each module in the list.
+   *   This incurs a performance cost, so set this to FALSE if you know that
+   *   the list of modules already contains all dependencies in the correct
+   *   order. Defaults to TRUE.
+   *
+   * @throws \Drupal\Driver\Exception\ModuleInstallException
+   *   Thrown when the modules could not be installed, for example because a
+   *   dependency is missing.
+   */
+  public function installModules(array $modules, $install_dependencies = TRUE);
+
+  /**
+   * Uninstalls the given modules.
+   *
+   * @param array $modules
+   *   A list of modules to uninstall.
+   * @param bool $uninstall_dependents
+   *   Whether or not to uninstall the dependents of each module in the list.
+   *   This incurs a performance cost, so set this to FALSE if you know that
+   *   the list of modules already contains all dependents in the correct order.
+   *   Defaults to TRUE.
+   *
+   * @throws \Drupal\Driver\Exception\ModuleUninstallException
+   *   Thrown when the modules could not be uninstalled, for example because a
+   *   dependent module is still installed and $uninstall_dependents is FALSE.
+   */
+  public function uninstallModules(array $modules, $uninstall_dependents = TRUE);
+
+  /**
    * Returns a list of all extension absolute paths.
    *
    * @return array

--- a/src/Drupal/Driver/Cores/Drupal6.php
+++ b/src/Drupal/Driver/Cores/Drupal6.php
@@ -432,10 +432,10 @@ class Drupal6 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
-  public function uninstallModules(array $modules, $uninstall_dependents = TRUE) {
-    // Drupal 6 does not support the optional uninstallation of dependents. It
-    // also doesn't actually uninstall modules, they can only be disabled. Since
-    // no value is returned we cannot know if the uninstallation was successful.
+  public function uninstallModules(array $modules) {
+    // Drupal 6 doesn't actually uninstall modules, they can only be disabled.
+    // Since no value is returned we cannot know if the uninstallation was
+    // successful.
     module_disable($modules);
   }
 

--- a/src/Drupal/Driver/Cores/Drupal6.php
+++ b/src/Drupal/Driver/Cores/Drupal6.php
@@ -422,6 +422,26 @@ class Drupal6 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
+  public function installModules(array $modules, $install_dependencies = TRUE) {
+    // Drupal 6 does not support the optional installation of dependencies. This
+    // does not have a return value so we cannot detect if the installation was
+    // successful.
+    module_enable($modules);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function uninstallModules(array $modules, $uninstall_dependents = TRUE) {
+    // Drupal 6 does not support the optional uninstallation of dependents. It
+    // also doesn't actually uninstall modules, they can only be disabled. Since
+    // no value is returned we cannot know if the uninstallation was successful.
+    module_disable($modules);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getExtensionPathList() {
     $paths = array();
 

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -8,6 +8,8 @@
 namespace Drupal\Driver\Cores;
 
 use Drupal\Driver\Exception\BootstrapException;
+use Drupal\Driver\Exception\ModuleInstallException;
+use Drupal\Driver\Exception\ModuleUninstallException;
 
 /**
  * Drupal 7 core.
@@ -424,6 +426,28 @@ class Drupal7 extends AbstractCore {
    */
   public function getModuleList() {
     return module_list();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function installModules(array $modules, $install_dependencies = TRUE) {
+    // In Drupal 7 you still "enable" modules. This also installs them.
+    if (!module_enable($modules, $install_dependencies)) {
+      throw new ModuleInstallException('The modules could not be installed because one or more dependencies are missing.');
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function uninstallModules(array $modules, $uninstall_dependents = TRUE) {
+    // In Drupal 7 modules first need to be disabled before they can be
+    // uninstalled.
+    module_disable($modules, $uninstall_dependents);
+    if (!drupal_uninstall_modules($modules, $uninstall_dependents)) {
+      throw new ModuleUninstallException('The modules could not be uninstalled because it is required by one or more modules.');
+    }
   }
 
   /**

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -441,12 +441,12 @@ class Drupal7 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
-  public function uninstallModules(array $modules, $uninstall_dependents = TRUE) {
+  public function uninstallModules(array $modules) {
     // In Drupal 7 modules first need to be disabled before they can be
     // uninstalled.
-    module_disable($modules, $uninstall_dependents);
-    if (!drupal_uninstall_modules($modules, $uninstall_dependents)) {
-      throw new ModuleUninstallException('The modules could not be uninstalled because it is required by one or more modules.');
+    module_disable($modules);
+    if (!drupal_uninstall_modules($modules)) {
+      throw new ModuleUninstallException('The modules could not be uninstalled. They are required by one or more dependant modules.');
     }
   }
 

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -9,6 +9,8 @@ namespace Drupal\Driver\Cores;
 
 use Drupal\Core\DrupalKernel;
 use Drupal\Driver\Exception\BootstrapException;
+use Drupal\Driver\Exception\ModuleInstallException;
+use Drupal\Driver\Exception\ModuleUninstallException;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\node\Entity\Node;
@@ -328,6 +330,30 @@ class Drupal8 extends AbstractCore {
    */
   public function getModuleList() {
     return array_keys(\Drupal::moduleHandler()->getModuleList());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function installModules(array $modules, $install_dependencies = TRUE) {
+    try {
+      \Drupal::service('module_installer')->install($modules, $install_dependencies);
+    }
+    catch (\Exception $e) {
+      throw new ModuleInstallException('The modules could not be installed because an error occurred.', 0, $e);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function uninstallModules(array $modules, $uninstall_dependents = TRUE) {
+    try {
+      \Drupal::service('module_installer')->uninstall($modules, $uninstall_dependents);
+    }
+    catch (\Exception $e) {
+      throw new ModuleUninstallException('The modules could not be uninstalled because an error occurred.', 0, $e);
+    }
   }
 
   /**

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -347,9 +347,9 @@ class Drupal8 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
-  public function uninstallModules(array $modules, $uninstall_dependents = TRUE) {
+  public function uninstallModules(array $modules) {
     try {
-      \Drupal::service('module_installer')->uninstall($modules, $uninstall_dependents);
+      \Drupal::service('module_installer')->uninstall($modules);
     }
     catch (\Exception $e) {
       throw new ModuleUninstallException('The modules could not be uninstalled because an error occurred.', 0, $e);

--- a/src/Drupal/Driver/DriverInterface.php
+++ b/src/Drupal/Driver/DriverInterface.php
@@ -158,4 +158,20 @@ interface DriverInterface {
    */
   public function isField($entity_type, $field_name);
 
+  /**
+   * Installs the given modules.
+   *
+   * @param array $modules
+   *   A list of machine names of modules to install.
+   */
+  public function installModules(array $modules);
+
+  /**
+   * Uninstalls the given modules.
+   *
+   * @param array $modules
+   *   A list of machine names of modules to uninstall.
+   */
+  public function uninstallModules(array $modules);
+
 }

--- a/src/Drupal/Driver/DriverInterface.php
+++ b/src/Drupal/Driver/DriverInterface.php
@@ -174,4 +174,12 @@ interface DriverInterface {
    */
   public function uninstallModules(array $modules);
 
+  /**
+   * Returns a list of active modules.
+   *
+   * @return array
+   *   A list of machine names of active modules.
+   */
+  public function getModuleList();
+
 }

--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -321,6 +321,13 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface {
   /**
    * {@inheritdoc}
    */
+  public function getModuleList() {
+    return $this->getCore()->getModuleList();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function clearStaticCaches() {
     $this->getCore()->clearStaticCaches();
   }

--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -307,6 +307,20 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface {
   /**
    * {@inheritdoc}
    */
+  public function installModules(array $modules) {
+    $this->getCore()->installModules($modules);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function uninstallModules(array $modules) {
+    $this->getCore()->uninstallModules($modules);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function clearStaticCaches() {
     $this->getCore()->clearStaticCaches();
   }

--- a/src/Drupal/Driver/Exception/BootstrapException.php
+++ b/src/Drupal/Driver/Exception/BootstrapException.php
@@ -10,20 +10,5 @@ namespace Drupal\Driver\Exception;
 /**
  * Bootstrap exception.
  */
-class BootstrapException extends Exception {
-
-  /**
-   * Initializes exception.
-   *
-   * @param string $message
-   *   The exception message.
-   * @param int $code
-   *   Optional exception code. Defaults to 0.
-   * @param \Exception $previous
-   *   Optional previous exception that was thrown.
-   */
-  public function __construct($message, $code = 0, \Exception $previous = NULL) {
-    parent::__construct($message, NULL, $code, $previous);
-  }
-
+class BootstrapException extends CoreException {
 }

--- a/src/Drupal/Driver/Exception/CoreException.php
+++ b/src/Drupal/Driver/Exception/CoreException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Driver\Exception\CoreException.
+ */
+
+namespace Drupal\Driver\Exception;
+
+/**
+ * Base class for exceptions thrown in classes implementing CoreInterface.
+ */
+abstract class CoreException extends Exception {
+
+  /**
+   * Initializes exception.
+   *
+   * @param string $message
+   *   The exception message.
+   * @param int $code
+   *   Optional exception code. Defaults to 0.
+   * @param \Exception $previous
+   *   Optional previous exception that was thrown.
+   */
+  public function __construct($message, $code = 0, \Exception $previous = NULL) {
+    parent::__construct($message, NULL, $code, $previous);
+  }
+
+}

--- a/src/Drupal/Driver/Exception/ModuleInstallException.php
+++ b/src/Drupal/Driver/Exception/ModuleInstallException.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Driver\Exception\ModuleInstallException.
+ */
+
+namespace Drupal\Driver\Exception;
+
+/**
+ * Module install exception.
+ */
+class ModuleInstallException extends CoreException {
+}

--- a/src/Drupal/Driver/Exception/ModuleUninstallException.php
+++ b/src/Drupal/Driver/Exception/ModuleUninstallException.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Driver\Exception\ModuleUninstallException.
+ */
+
+namespace Drupal\Driver\Exception;
+
+/**
+ * Module uninstall exception.
+ */
+class ModuleUninstallException extends CoreException {
+}


### PR DESCRIPTION
I'm using DrupalDriver to test a distribution with a whole bunch of optional features. I would like to be able to install and uninstall them.

This pull request adds the basic functionality to install and uninstall modules. It is not tested at all yet. It's my intention to integrate this in the Behat Drupal Extension and add some tests there.

I have omitted the enabling and disabling of modules since this has been removed from Drupal 8 for good reasons. It now only adds support for installing and uninstalling. I'm willing to add support for enabling and disabling as well if somebody thinks it is necessary, but I don't really see the need at this point.
