### PR TITLE
File field handler usage

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal7/FileHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/FileHandler.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Driver\Fields\Drupal7\FileHandler.
+ */
+
+namespace Drupal\Driver\Fields\Drupal7;
+
+/**
+ * File field handler for Drupal 7.
+ */
+class FileHandler extends AbstractHandler {
+
+  /**
+   * {@inheritdoc}
+   *
+   * Specify files in file fields by their filename.
+   */
+  public function expand($values) {
+    $return = array();
+
+    foreach ($values as $value) {
+      $query = new \EntityFieldQuery();
+
+      $query->entityCondition('entity_type', 'file')
+        ->propertyCondition('filename', $value)
+        ->propertyOrderBy('timestamp', 'DESC')
+        ->range(0, 1);
+
+      $result = $query->execute();
+
+      if (!empty($result['file'])) {
+        $files = entity_load('file', array_keys($result['file']));
+        $file = current($files);
+
+        $return[$this->language][] = array(
+          'filename' => $file->filename,
+          'uri' => $file->uri,
+          'fid' => $file->fid,
+          'display' => 1,
+        );
+      }
+    }
+
+    return $return;
+  }
+
+}

--- a/src/Drupal/Driver/Fields/Drupal7/FileHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/FileHandler.php
@@ -41,6 +41,9 @@ class FileHandler extends AbstractHandler {
           'display' => 1,
         );
       }
+      else {
+        throw new \Exception(sprintf('File with filename "%s" not found.', $value));
+      }
     }
 
     return $return;

--- a/src/Drupal/Driver/Fields/Drupal7/ImageHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/ImageHandler.php
@@ -10,22 +10,5 @@ namespace Drupal\Driver\Fields\Drupal7;
 /**
  * Image field handler for Drupal 7.
  */
-class ImageHandler extends AbstractHandler {
-
-  /**
-   * {@inheritdoc}
-   */
-  public function expand($values) {
-    $return = array();
-    foreach ($values as $value) {
-      $return[$this->language][] = array(
-        'filename' => $value[0],
-        'uri' => $value[1],
-        'fid' => $value[2],
-        'display' => isset($value[3]) ? $value[3] : 1,
-      );
-    }
-    return $return;
-  }
-
+class ImageHandler extends FileHandler {
 }

--- a/tests/Drupal/Tests/Driver/Drupal7FieldHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Drupal7FieldHandlerTest.php
@@ -161,33 +161,6 @@ class Drupal7FieldHandlerTest extends FieldHandlerAbstractTest {
           ),
         ),
       ),
-
-      // Test image field provided as array.
-      array(
-        'ImageHandler',
-        (object) array(
-          'field_image' => array(
-            array(
-              'test.png',
-              'public://images/test.png',
-              1,
-              1,
-            ),
-          ),
-        ),
-        'node',
-        array('field_name' => 'field_image'),
-        array(
-          'en' => array(
-            array(
-              'filename' => 'test.png',
-              'uri' => 'public://images/test.png',
-              'fid' => 1,
-              'display' => 1,
-            ),
-          ),
-        ),
-      ),
     );
   }
 


### PR DESCRIPTION
This pull request is half question, half suggestion: how is the image field handler intended to be used? When I try to use it, I have to know an existing `fid`, which is generally not possible from the context where I'm using it (in a Behat test).

For my use cases, it would make sense for it to behave more similarly to the `EntityreferenceHandler`, using filename values to match a Drupal-managed file, if available. This will require some additional code in the cores, and probably also in `jhedstrom/drupalextension`.

This PR adds `\Drupal\Driver\Fields\Drupal7\FileHandler` with filename-based field values, and tweaked `\Drupal\Driver\Fields\Drupal7\ImageHandler` to extend on that. This does break with the current behavior.

In order to be complete, this PR would need the following (but I didn't want to proceed if there's a better way to use the `ImageHandler`):

- [ ] Make sure that the filename lookup works for D8 as well as D7
- [ ] Add file creation and deletion to the D7 and D8 cores
- [ ] Add file creation and cleanup to the drupal-extension

Does this approach make sense?