### PR TITLE
Throw an exception if the node type is missing or does not exist

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -53,6 +53,14 @@ class Drupal8 extends AbstractCore {
    * {@inheritdoc}
    */
   public function nodeCreate($node) {
+    // Throw an exception if the node type is missing or does not exist.
+    if (!isset($node->type) || !$node->type) {
+      throw new \Exception("Cannot create content because it is missing the required property 'type'.");
+    }
+    $bundles = \Drupal::entityManager()->getBundleInfo('node');
+    if (!in_array($node->type, array_keys($bundles))) {
+      throw new \Exception("Cannot create content because provided content type '$node->type' does not exist.");
+    }
     // Default status to 1 if not set.
     if (!isset($node->status)) {
       $node->status = 1;


### PR DESCRIPTION
Used "content" and "content type" in the exception messages; i don't think developers will be confused and potential non-developers getting the exception because of a Behat test referring to a non-existent content type will immediately know what to fix.

Related to https://github.com/jhedstrom/drupalextension/issues/265