### PR TITLE
Adding node and user alter functionality

### DIFF
--- a/src/Drupal/Driver/BaseDriver.php
+++ b/src/Drupal/Driver/BaseDriver.php
@@ -45,6 +45,20 @@ abstract class BaseDriver implements DriverInterface {
   /**
    * {@inheritdoc}
    */
+  public function nodeDeleteMultiple(array $nids){
+    throw new UnsupportedDriverActionException($this->errorString('node delete multiple'), $this);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function userDeleteMultiple(array $uids){
+    throw new UnsupportedDriverActionException($this->errorString('user delete multiple'), $this);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function userDelete(\stdClass $user) {
     throw new UnsupportedDriverActionException($this->errorString('delete users'), $this);
   }

--- a/src/Drupal/Driver/BaseDriver.php
+++ b/src/Drupal/Driver/BaseDriver.php
@@ -45,14 +45,14 @@ abstract class BaseDriver implements DriverInterface {
   /**
    * {@inheritdoc}
    */
-  public function nodeDeleteMultiple(array $nids){
+  public function nodeDeleteMultiple(array $nids) {
     throw new UnsupportedDriverActionException($this->errorString('node delete multiple'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function userDeleteMultiple(array $uids){
+  public function userDeleteMultiple(array $uids) {
     throw new UnsupportedDriverActionException($this->errorString('user delete multiple'), $this);
   }
 

--- a/src/Drupal/Driver/BaseDriver.php
+++ b/src/Drupal/Driver/BaseDriver.php
@@ -31,6 +31,13 @@ abstract class BaseDriver implements DriverInterface {
   /**
    * {@inheritdoc}
    */
+  public function userAlter($user, $values) {
+    throw new UnsupportedDriverActionException($this->errorString('alter users'), $this);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function userCreate(\stdClass $user) {
     throw new UnsupportedDriverActionException($this->errorString('create users'), $this);
   }
@@ -75,6 +82,13 @@ abstract class BaseDriver implements DriverInterface {
    */
   public function clearStaticCaches() {
     throw new UnsupportedDriverActionException($this->errorString('clear static caches'), $this);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function nodeAlter($node, $values) {
+    throw new UnsupportedDriverActionException($this->errorString('alter nodes'), $this);
   }
 
   /**

--- a/src/Drupal/Driver/Cores/AbstractCore.php
+++ b/src/Drupal/Driver/Cores/AbstractCore.php
@@ -97,6 +97,14 @@ abstract class AbstractCore implements CoreInterface {
   /**
    * {@inheritdoc}
    */
+  public function nodeLoad($nid) {
+
+    throw new UnsupportedDriverActionException(sprintf('%s::%s line %s: functionality not yet supported for this Drupal Driver.', get_class($this), __FUNCTION__, __LINE__));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function nodeAlter($node, $values) {
 
     throw new UnsupportedDriverActionException(sprintf('%s::%s line %s: functionality not yet supported for this Drupal Driver.', get_class($this), __FUNCTION__, __LINE__));
@@ -105,8 +113,78 @@ abstract class AbstractCore implements CoreInterface {
   /**
    * {@inheritdoc}
    */
+  public function userLoad($uid) {
+    throw new UnsupportedDriverActionException(sprintf('%s::%s line %s: functionality not yet supported for this Drupal Driver.', get_class($this), __FUNCTION__, __LINE__));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function userAlter($user, $values) {
 
+    throw new UnsupportedDriverActionException(sprintf('%s::%s line %s: functionality not yet supported for this Drupal Driver.', get_class($this), __FUNCTION__, __LINE__));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function termLoad($tid, $vocabulary = NULL) {
+    throw new UnsupportedDriverActionException(sprintf('%s::%s line %s: functionality not yet supported for this Drupal Driver.', get_class($this), __FUNCTION__, __LINE__));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function termCreate(\stdClass $term) {
+    throw new UnsupportedDriverActionException(sprintf('%s::%s line %s: functionality not yet supported for this Drupal Driver.', get_class($this), __FUNCTION__, __LINE__));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function termDelete(\stdClass $term) {
+    throw new UnsupportedDriverActionException(sprintf('%s::%s line %s: functionality not yet supported for this Drupal Driver.', get_class($this), __FUNCTION__, __LINE__));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function roleLoad($role_name) {
+    throw new UnsupportedDriverActionException(sprintf('%s::%s line %s: functionality not yet supported for this Drupal Driver.', get_class($this), __FUNCTION__, __LINE__));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function roleCreate(array $permissions) {
+    throw new UnsupportedDriverActionException(sprintf('%s::%s line %s: functionality not yet supported for this Drupal Driver.', get_class($this), __FUNCTION__, __LINE__));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function roleDelete($role_name) {
+    throw new UnsupportedDriverActionException(sprintf('%s::%s line %s: functionality not yet supported for this Drupal Driver.', get_class($this), __FUNCTION__, __LINE__));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function languageLoad($language_name) {
+    throw new UnsupportedDriverActionException(sprintf('%s::%s line %s: functionality not yet supported for this Drupal Driver.', get_class($this), __FUNCTION__, __LINE__));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function languageCreate(\stdClass $language) {
+    throw new UnsupportedDriverActionException(sprintf('%s::%s line %s: functionality not yet supported for this Drupal Driver.', get_class($this), __FUNCTION__, __LINE__));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function languageDelete(\stdClass $language) {
     throw new UnsupportedDriverActionException(sprintf('%s::%s line %s: functionality not yet supported for this Drupal Driver.', get_class($this), __FUNCTION__, __LINE__));
   }
 

--- a/src/Drupal/Driver/Cores/AbstractCore.php
+++ b/src/Drupal/Driver/Cores/AbstractCore.php
@@ -99,4 +99,17 @@ abstract class AbstractCore implements CoreInterface {
   public function clearStaticCaches() {
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function nodeDeleteMultiple(array $nids){
+    throw new UnsupportedDriverActionException(sprintf("%s::%s line %s: functionality not yet supported for this Drupal Driver.", get_class($this), __FUNCTION__, __LINE__));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function userDeleteMultiple(array $uids){
+    throw new UnsupportedDriverActionException(sprintf("%s::%s line %s: functionality not yet supported for this Drupal Driver.", get_class($this), __FUNCTION__, __LINE__));
+  }
 }

--- a/src/Drupal/Driver/Cores/AbstractCore.php
+++ b/src/Drupal/Driver/Cores/AbstractCore.php
@@ -9,7 +9,6 @@ use Symfony\Component\DependencyInjection\Container;
  * Base class for core drivers.
  */
 abstract class AbstractCore implements CoreInterface {
-
   /**
    * System path to the Drupal installation.
    *
@@ -35,6 +34,7 @@ abstract class AbstractCore implements CoreInterface {
    * {@inheritdoc}
    */
   public function __construct($drupal_root, $uri = 'default', Random $random = NULL) {
+
     $this->drupalRoot = realpath($drupal_root);
     $this->uri = $uri;
     if (!isset($random)) {
@@ -47,6 +47,7 @@ abstract class AbstractCore implements CoreInterface {
    * {@inheritdoc}
    */
   public function getRandom() {
+
     return $this->random;
   }
 
@@ -54,6 +55,7 @@ abstract class AbstractCore implements CoreInterface {
    * {@inheritdoc}
    */
   public function getFieldHandler($entity, $entity_type, $field_name) {
+
     $reflection = new \ReflectionClass($this);
     $core_namespace = $reflection->getShortName();
     $field_types = $this->getEntityFieldTypes($entity_type);
@@ -63,6 +65,7 @@ abstract class AbstractCore implements CoreInterface {
     if (class_exists($class_name)) {
       return new $class_name($entity, $entity_type, $field_name);
     }
+
     return new $default_class($entity, $entity_type, $field_name);
   }
 
@@ -73,6 +76,7 @@ abstract class AbstractCore implements CoreInterface {
    *   Entity object.
    */
   protected function expandEntityFields($entity_type, \stdClass $entity) {
+
     $field_types = $this->getEntityFieldTypes($entity_type);
     foreach ($field_types as $field_name => $type) {
       if (isset($entity->$field_name)) {
@@ -81,35 +85,44 @@ abstract class AbstractCore implements CoreInterface {
       }
     }
   }
+
   /**
    * {@inheritdoc}
    */
   public function nodeAlter($node, $values) {
-    throw new UnsupportedDriverActionException(sprintf("%s::%s line %s: functionality not yet supported for this Drupal Driver.", get_class($this), __FUNCTION__, __LINE__));
+
+    throw new UnsupportedDriverActionException(sprintf('%s::%s line %s: functionality not yet supported for this Drupal Driver.', get_class($this), __FUNCTION__, __LINE__));
   }
+
   /**
    * {@inheritdoc}
    */
   public function userAlter($user, $values) {
-    throw new UnsupportedDriverActionException(sprintf("%s::%s line %s: functionality not yet supported for this Drupal Driver.", get_class($this), __FUNCTION__, __LINE__));
+
+    throw new UnsupportedDriverActionException(sprintf('%s::%s line %s: functionality not yet supported for this Drupal Driver.', get_class($this), __FUNCTION__, __LINE__));
   }
+
   /**
    * {@inheritdoc}
    */
   public function clearStaticCaches() {
+
   }
 
   /**
    * {@inheritdoc}
    */
-  public function nodeDeleteMultiple(array $nids){
-    throw new UnsupportedDriverActionException(sprintf("%s::%s line %s: functionality not yet supported for this Drupal Driver.", get_class($this), __FUNCTION__, __LINE__));
+  public function nodeDeleteMultiple(array $nids) {
+
+    throw new UnsupportedDriverActionException(sprintf('%s::%s line %s: functionality not yet supported for this Drupal Driver.', get_class($this), __FUNCTION__, __LINE__));
   }
 
   /**
    * {@inheritdoc}
    */
-  public function userDeleteMultiple(array $uids){
-    throw new UnsupportedDriverActionException(sprintf("%s::%s line %s: functionality not yet supported for this Drupal Driver.", get_class($this), __FUNCTION__, __LINE__));
+  public function userDeleteMultiple(array $uids) {
+
+    throw new UnsupportedDriverActionException(sprintf('%s::%s line %s: functionality not yet supported for this Drupal Driver.', get_class($this), __FUNCTION__, __LINE__));
   }
+
 }

--- a/src/Drupal/Driver/Cores/AbstractCore.php
+++ b/src/Drupal/Driver/Cores/AbstractCore.php
@@ -89,6 +89,13 @@ abstract class AbstractCore implements CoreInterface {
   /**
    * {@inheritdoc}
    */
+  public function clearStaticCaches() {
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function nodeAlter($node, $values) {
 
     throw new UnsupportedDriverActionException(sprintf('%s::%s line %s: functionality not yet supported for this Drupal Driver.', get_class($this), __FUNCTION__, __LINE__));
@@ -100,13 +107,6 @@ abstract class AbstractCore implements CoreInterface {
   public function userAlter($user, $values) {
 
     throw new UnsupportedDriverActionException(sprintf('%s::%s line %s: functionality not yet supported for this Drupal Driver.', get_class($this), __FUNCTION__, __LINE__));
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function clearStaticCaches() {
-
   }
 
   /**

--- a/src/Drupal/Driver/Cores/AbstractCore.php
+++ b/src/Drupal/Driver/Cores/AbstractCore.php
@@ -4,6 +4,7 @@ namespace Drupal\Driver\Cores;
 
 use Drupal\Component\Utility\Random;
 use Symfony\Component\DependencyInjection\Container;
+use Drupal\Driver\DriverInterface\UnsupportedDriverActionException;
 
 /**
  * Base class for core drivers.

--- a/src/Drupal/Driver/Cores/AbstractCore.php
+++ b/src/Drupal/Driver/Cores/AbstractCore.php
@@ -81,7 +81,18 @@ abstract class AbstractCore implements CoreInterface {
       }
     }
   }
-
+  /**
+   * {@inheritdoc}
+   */
+  public function nodeAlter($node, $values) {
+    throw new UnsupportedDriverActionException(sprintf("%s::%s line %s: functionality not yet supported for this Drupal Driver.", get_class($this), __FUNCTION__, __LINE__));
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function userAlter($user, $values) {
+    throw new UnsupportedDriverActionException(sprintf("%s::%s line %s: functionality not yet supported for this Drupal Driver.", get_class($this), __FUNCTION__, __LINE__));
+  }
   /**
    * {@inheritdoc}
    */

--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -58,6 +58,17 @@ interface CoreInterface {
   public function runCron();
 
   /**
+   * Loads a node.
+   *
+   * @param int $nid
+   *   The int or string node id of the node to load.
+   *
+   * @return object
+   *   The fully loaded drupal node.
+   */
+  public function nodeLoad($nid);
+
+  /**
    * Deletes a node.
    *
    * @param object $node
@@ -80,6 +91,17 @@ interface CoreInterface {
    *   A fully loaded drupal node.
    */
   public function nodeDelete($node);
+
+  /**
+   * Loads a user.
+   *
+   * @param int $uid
+   *   The int or string user id of the user to load.
+   *
+   * @return object
+   *   The fully loaded drupal user.
+   */
+  public function userLoad($uid);
 
   /**
    * Alters an existing user.
@@ -128,6 +150,17 @@ interface CoreInterface {
   public function processBatch();
 
   /**
+   * Loads a term.
+   *
+   * @param int $tid
+   *   The int or string term id of the term to load.
+   *
+   * @return object
+   *   The fully loaded drupal taxonomy term.
+   */
+  public function termLoad($tid);
+
+  /**
    * Create a taxonomy term.
    */
   public function termCreate(\stdClass $term);
@@ -136,6 +169,17 @@ interface CoreInterface {
    * Deletes a taxonomy term.
    */
   public function termDelete(\stdClass $term);
+
+  /**
+   * Loads a role.
+   *
+   * @param string $role_name
+   *   The role name of the role to load.
+   *
+   * @return object
+   *   The fully loaded drupal taxonomy role.
+   */
+  public function roleLoad($role_name);
 
   /**
    * Creates a role.

--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -75,7 +75,7 @@ interface CoreInterface {
 
   /**
    * Delete a node.
-   * @param  object/int $node A fully loaded drupal node, or the node id of one.
+   * @param  object $node A fully loaded drupal node.
    */
   public function nodeDelete($node);
 

--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -75,6 +75,7 @@ interface CoreInterface {
 
   /**
    * Delete a node.
+   * @param  object/int $node A fully loaded drupal node, or the node id of one.
    */
   public function nodeDelete($node);
 

--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -58,6 +58,17 @@ interface CoreInterface {
   public function runCron();
 
   /**
+   * Deletes a node.
+   *
+   * @param object $node
+   *   Fully loaded node object.
+   * @param object $values
+   *   a plain object with field names as properties, and
+   *                        field values as property values.
+   */
+  public function nodeAlter($node, $values);
+
+  /**
    * Create a node.
    */
   public function nodeCreate($node);
@@ -66,6 +77,17 @@ interface CoreInterface {
    * Delete a node.
    */
   public function nodeDelete($node);
+
+  /**
+   * Alters an existing user.
+   *
+   * @param object $user
+   *   Fully loaded drupal user object.
+   * @param object $values
+   *   a plain object with field names as properties, and
+   *   field values as property values.
+   */
+  public function userAlter($user, $values);
 
   /**
    * Create a user.

--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -238,5 +238,18 @@ interface CoreInterface {
    *   Value to associate with identifier.
    */
   public function configSet($name, $key, $value);
-
+  /**
+   * Deletes multiple nodes
+   * @param  array  $nids An array of node ids (integers or numeric strings)
+   *                      to delete
+   * @return NULL
+   */
+  public function nodeDeleteMultiple(array $nids);
+  /**
+   * Deletes multiple users
+   * @param  array  $uids An array of user ids (integers or numeric strings)
+   *                      to delete
+   * @return NULL
+   */
+  public function userDeleteMultiple(array $uids);
 }

--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -63,8 +63,8 @@ interface CoreInterface {
    * @param object $node
    *   Fully loaded node object.
    * @param object $values
-   *   a plain object with field names as properties, and
-   *                        field values as property values.
+   *   A plain object with field names as properties, and
+   *   field values as property values.
    */
   public function nodeAlter($node, $values);
 
@@ -75,7 +75,9 @@ interface CoreInterface {
 
   /**
    * Delete a node.
-   * @param  object $node A fully loaded drupal node.
+   *
+   * @param object $node
+   *   A fully loaded drupal node.
    */
   public function nodeDelete($node);
 
@@ -85,7 +87,7 @@ interface CoreInterface {
    * @param object $user
    *   Fully loaded drupal user object.
    * @param object $values
-   *   a plain object with field names as properties, and
+   *   A plain object with field names as properties, and
    *   field values as property values.
    */
   public function userAlter($user, $values);
@@ -238,18 +240,23 @@ interface CoreInterface {
    *   Value to associate with identifier.
    */
   public function configSet($name, $key, $value);
+
   /**
-   * Deletes multiple nodes
-   * @param  array  $nids An array of node ids (integers or numeric strings)
-   *                      to delete
-   * @return NULL
+   * Deletes multiple nodes.
+   *
+   * @param array $nids
+   *   An array of node ids (integers or numeric strings) to
+   *   delete.
    */
   public function nodeDeleteMultiple(array $nids);
+
   /**
-   * Deletes multiple users
-   * @param  array  $uids An array of user ids (integers or numeric strings)
-   *                      to delete
-   * @return NULL
+   * Deletes multiple users.
+   *
+   * @param array $uids
+   *   An array of user ids (integers or numeric strings) to
+   *   delete.
    */
   public function userDeleteMultiple(array $uids);
+
 }

--- a/src/Drupal/Driver/Cores/Drupal6.php
+++ b/src/Drupal/Driver/Cores/Drupal6.php
@@ -89,7 +89,7 @@ class Drupal6 extends AbstractCore {
    * {@inheritdoc}
    */
   public function nodeDelete($node) {
-    if(is_numeric($node)){
+    if (is_numeric($node)) {
       return node_delete($node);
     }
     return node_delete($node->nid);

--- a/src/Drupal/Driver/Cores/Drupal6.php
+++ b/src/Drupal/Driver/Cores/Drupal6.php
@@ -96,6 +96,15 @@ class Drupal6 extends AbstractCore {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function nodeDeleteMultiple(array $nids) {
+    foreach($nids as $nid){
+      node_delete($nid);
+    }
+  }
+
+  /**
    * Implements CoreInterface::runCron().
    */
   public function runCron() {
@@ -134,7 +143,19 @@ class Drupal6 extends AbstractCore {
   public function userDelete(\stdClass $user) {
     $current_path = getcwd();
     chdir(DRUPAL_ROOT);
-    user_delete((array) $user, $user->uid);
+    user_delete(array(), $user->uid);
+    chdir($current_path);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function userDeleteMultiple(array $uids) {
+    $current_path = getcwd();
+    chdir(DRUPAL_ROOT);
+    foreach($uids as $uid){
+      user_delete(array(), $uid);
+    }
     chdir($current_path);
   }
 

--- a/src/Drupal/Driver/Cores/Drupal6.php
+++ b/src/Drupal/Driver/Cores/Drupal6.php
@@ -89,7 +89,10 @@ class Drupal6 extends AbstractCore {
    * {@inheritdoc}
    */
   public function nodeDelete($node) {
-    node_delete($node->nid);
+    if(is_numeric($node)){
+      return node_delete($node);
+    }
+    return node_delete($node->nid);
   }
 
   /**

--- a/src/Drupal/Driver/Cores/Drupal6.php
+++ b/src/Drupal/Driver/Cores/Drupal6.php
@@ -99,7 +99,7 @@ class Drupal6 extends AbstractCore {
    * {@inheritdoc}
    */
   public function nodeDeleteMultiple(array $nids) {
-    foreach($nids as $nid){
+    foreach ($nids as $nid) {
       node_delete($nid);
     }
   }
@@ -153,7 +153,7 @@ class Drupal6 extends AbstractCore {
   public function userDeleteMultiple(array $uids) {
     $current_path = getcwd();
     chdir(DRUPAL_ROOT);
-    foreach($uids as $uid){
+    foreach ($uids as $uid) {
       user_delete(array(), $uid);
     }
     chdir($current_path);

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -39,6 +39,13 @@ class Drupal7 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
+  public function nodeLoad($nid) {
+    return node_load($nid);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function nodeCreate($node) {
     // Set original if not set.
     if (!isset($node->original)) {
@@ -113,6 +120,13 @@ class Drupal7 extends AbstractCore {
    */
   public function runCron() {
     return drupal_cron_run();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function userLoad($uid) {
+    return user_load($uid);
   }
 
   /**
@@ -344,6 +358,16 @@ class Drupal7 extends AbstractCore {
         continue;
       }
     }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function termLoad($tid, $vocabulary = NULL) {
+    if (is_numeric($tid)) {
+      return taxonomy_term_load($tid);
+    }
+    return taxonomy_get_term_by_name($tid, $vocabulary);
   }
 
   /**

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -433,6 +433,9 @@ class Drupal7 extends AbstractCore {
    * {@inheritdoc}
    */
   public function languageCreate(\stdClass $language) {
+    if (!module_exists('locale')) {
+      throw new \Exception(sprintf("%s::%s line %s: This driver requires the 'locale' module be enabled in order to create languages", get_class($this), __FUNCTION__, __LINE__));
+    }
     include_once DRUPAL_ROOT . '/includes/iso.inc';
     include_once DRUPAL_ROOT . '/includes/locale.inc';
 

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -71,24 +71,21 @@ class Drupal7 extends AbstractCore {
   public function nodeDelete($node) {
     return node_delete($node->nid);
   }
+
   /**
    * {@inheritdoc}
    */
-  public function nodeDeleteMultiple(array $nids){
+  public function nodeDeleteMultiple(array $nids) {
     return node_delete_multiple($nids);
   }
+
   /**
    * {@inheritdoc}
    *
    * @param object $node
-   *   A drupal node object
+   *   A drupal node object.
    * @param object $values
-   *   An object with field/value parameters
-   *
-   * @return NULL
-   *
-   * @throws \Exception If anything goes wrong with the alteration. Details of
-   *          error will be in the exception.
+   *   An object with field/value parameters.
    */
   public function nodeAlter($node, $values) {
     if (empty($node) || !isset($node->nid)) {
@@ -110,6 +107,7 @@ class Drupal7 extends AbstractCore {
     }
     node_save($node);
   }
+
   /**
    * Implements CoreInterface::runCron().
    */
@@ -145,14 +143,9 @@ class Drupal7 extends AbstractCore {
    * {@inheritdoc}
    *
    * @param object $user
-   *   A drupal user object
+   *   A drupal user object.
    * @param object $values
-   *   An object with field/value parameters
-   *
-   * @return NULL
-   *
-   * @throws \Exception If anything goes wrong with the alteration. Details of
-   *          error will be in the exception.
+   *   An object with field/value parameters.
    */
   public function userAlter($user, $values) {
     if (empty($user) || !isset($user->uid)) {
@@ -166,18 +159,21 @@ class Drupal7 extends AbstractCore {
     }
     user_save($user);
   }
+
   /**
    * {@inheritdoc}
    */
   public function userDelete(\stdClass $user) {
     user_cancel(array(), $user->uid, 'user_cancel_delete');
   }
+
   /**
    * {@inheritdoc}
    */
-  public function userDeleteMultiple(array $uids){
+  public function userDeleteMultiple(array $uids) {
     return user_delete_multiple($uids);
   }
+
   /**
    * {@inheritdoc}
    */

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -166,7 +166,10 @@ class Drupal7 extends AbstractCore {
       var_dump(array_keys(get_object_vars($user)));
       throw new \Exception(sprintf("%s::%s: User was empty or had no id", get_class($this), __FUNCTION__));
     }
-    // Attempt to decipher any fields that may be specified.
+    // Reload user from the db so we ensure we're dealing with an unmodified
+    // version of the user.  Reset flag is critical here.
+    $user = user_load($user->uid, TRUE);
+    // Attempt to decipher any fields that may be specified in values.
     $this->expandEntityFields('user', $values);
     foreach ($values as $k => $v) {
       $user->{$k} = $v;

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -382,7 +382,7 @@ class Drupal7 extends AbstractCore {
     }
 
     if (empty($term->vid)) {
-      throw new \Exception(sprintf('No "%s" vocabulary found.'));
+      throw new \Exception(sprintf('%s::%s line %s: Could not load term.', get_class($this), __FUNCTION__, __LINE__));
     }
 
     // Attempt to decipher any fields that may be specified.

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -73,6 +73,12 @@ class Drupal7 extends AbstractCore {
   }
   /**
    * {@inheritdoc}
+   */
+  public function nodeDeleteMultiple(array $nids){
+    return node_delete_multiple($nids);
+  }
+  /**
+   * {@inheritdoc}
    *
    * @param object $node
    *   A drupal node object
@@ -166,7 +172,12 @@ class Drupal7 extends AbstractCore {
   public function userDelete(\stdClass $user) {
     user_cancel(array(), $user->uid, 'user_cancel_delete');
   }
-
+  /**
+   * {@inheritdoc}
+   */
+  public function userDeleteMultiple(array $uids){
+    return user_delete_multiple($uids);
+  }
   /**
    * {@inheritdoc}
    */

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -102,6 +102,8 @@ class Drupal7 extends AbstractCore {
     // Assign type (really, bundle) to values so that expansion functions will
     // work properly.
     $values->type = $node->type;
+    //Reload node object to ensure only passed values get overwritten.
+    //$node = node_load($node->nid, TRUE);
     $this->expandEntityProperties($values);
 
     // Attempt to decipher any fields that may be specified.

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -102,8 +102,8 @@ class Drupal7 extends AbstractCore {
     // Assign type (really, bundle) to values so that expansion functions will
     // work properly.
     $values->type = $node->type;
-    //Reload node object to ensure only passed values get overwritten.
-    //$node = node_load($node->nid, TRUE);
+    // Reload node object to ensure only passed values get overwritten.
+    // $node = node_load($node->nid, TRUE);.
     $this->expandEntityProperties($values);
 
     // Attempt to decipher any fields that may be specified.

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -104,8 +104,6 @@ class Drupal7 extends AbstractCore {
       if(!property_exists($node, $k)){
         throw new \Exception(sprintf("%s::%s line %s: Attempt to modify an invalid field: %s", get_class($this), __LINE__, __FUNCTION__, $k));
       }
-      $old_value = (is_scalar($node->{$k})) ? $node->{$k} : print_r($node->{$k}, TRUE);
-      $new_value = (is_scalar($v)) ? $v : print_r($v, TRUE);
       $node->{$k} = $v;
     }
     node_save($node);
@@ -155,22 +153,13 @@ class Drupal7 extends AbstractCore {
    *          error will be in the exception.
    */
   public function userAlter($user, $values) {
-    //throw new \Exception(sprintf("%s::%s line %s: function is not yet implemented", get_class($this), __FUNCTION__, __LINE__));
     if (empty($user) || !isset($user->uid)) {
       var_dump(array_keys(get_object_vars($user)));
       throw new \Exception(sprintf("%s::%s: User was empty or had no id", get_class($this), __FUNCTION__));
     }
     // Attempt to decipher any fields that may be specified.
     $this->expandEntityFields('user', $values);
-    //$node_wrapper = entity_metadata_wrapper('node', $node);
-    //print sprintf("%s::%s line %s: Updated values: %s\n", get_class($this), __FUNCTION__, __LINE__, print_r($values, TRUE));
-    //var_dump($node);
     foreach ($values as $k => $v) {
-      $old_value = (is_scalar($user->{$k})) ? $user->{$k} : print_r($user->{$k}, TRUE);
-      $new_value = (is_scalar($v)) ? $v : print_r($v, TRUE);
-      //print sprintf("%s::%s line %s: Updating the value of field %s.  Current value: %s, New value: %s\n", get_class($this), __FUNCTION__, __LINE__, $k, $old_value, $new_value);
-      // if the field is multi-value, transform non-array arguments into an
-      // array for the update process.
       $user->{$k} = $v;
     }
     user_save($user);

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -69,7 +69,10 @@ class Drupal7 extends AbstractCore {
    * {@inheritdoc}
    */
   public function nodeDelete($node) {
-    node_delete($node->nid);
+    if(is_numeric($node)){
+      return node_delete($node);
+    }
+    return node_delete($node->nid);
   }
   /**
    * {@inheritdoc}

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -327,6 +327,9 @@ class Drupal7 extends AbstractCore {
    *   The entity object.
    */
   protected function expandEntityProperties(\stdClass $entity) {
+    if (!isset($entity->type)) {
+      throw new \Exception(sprintf("%s::%s line %s: Entity argument is missing a value for the key 'type'", get_class($this), __FUNCTION__, __LINE__))
+    }
     // The created field may come in as a readable date, rather than a
     // timestamp.
     if (isset($entity->created) && !is_numeric($entity->created)) {

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -174,6 +174,9 @@ class Drupal7 extends AbstractCore {
     // Attempt to decipher any fields that may be specified in values.
     $this->expandEntityFields('user', $values);
     foreach ($values as $k => $v) {
+      if (!property_exists($user, $k)) {
+        throw new \Exception(sprintf("%s::%s line %s: Attempt to modify an invalid field: %s", get_class($this), __LINE__, __FUNCTION__, $k));
+      }
       $user->{$k} = $v;
     }
     user_save($user);

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -69,9 +69,6 @@ class Drupal7 extends AbstractCore {
    * {@inheritdoc}
    */
   public function nodeDelete($node) {
-    if(is_numeric($node)){
-      return node_delete($node);
-    }
     return node_delete($node->nid);
   }
   /**

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -96,7 +96,6 @@ class Drupal7 extends AbstractCore {
    */
   public function nodeAlter($node, $values) {
     if (empty($node) || !isset($node->nid)) {
-      var_dump(array_keys(get_object_vars($node)));
       throw new \Exception(sprintf("%s::%s: Node was empty or had no id", get_class($this), __FUNCTION__));
     }
     // Assign type (really, bundle) to values so that expansion functions will

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @file
- */
-
 namespace Drupal\Driver\Cores;
 
 use Drupal\Driver\Exception\BootstrapException;
@@ -93,15 +89,15 @@ class Drupal7 extends AbstractCore {
       var_dump(array_keys(get_object_vars($node)));
       throw new \Exception(sprintf("%s::%s: Node was empty or had no id", get_class($this), __FUNCTION__));
     }
-    //assign type (really, bundle) to values so that expansion functions will
-    //work properly.
+    // Assign type (really, bundle) to values so that expansion functions will
+    // work properly.
     $values->type = $node->type;
     $this->expandEntityProperties($values);
 
     // Attempt to decipher any fields that may be specified.
     $this->expandEntityFields('node', $values);
     foreach ($values as $k => $v) {
-      if(!property_exists($node, $k)){
+      if (!property_exists($node, $k)) {
         throw new \Exception(sprintf("%s::%s line %s: Attempt to modify an invalid field: %s", get_class($this), __LINE__, __FUNCTION__, $k));
       }
       $node->{$k} = $v;
@@ -123,7 +119,7 @@ class Drupal7 extends AbstractCore {
     if (!isset($user->status)) {
       $user->status = 1;
     }
-    if(isset($user->roles) && is_string($user->roles)){
+    if (isset($user->roles) && is_string($user->roles)) {
       $user->roles = array_map('trim', explode(',', $user->roles));
     }
     // Clone user object, otherwise user_save() changes the password to the
@@ -164,7 +160,7 @@ class Drupal7 extends AbstractCore {
     }
     user_save($user);
   }
-  /*
+  /**
    * {@inheritdoc}
    */
   public function userDelete(\stdClass $user) {

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -185,7 +185,7 @@ class Drupal7 extends AbstractCore {
    * {@inheritdoc}
    */
   public function userDeleteMultiple(array $uids) {
-    return user_delete_multiple($uids);
+    user_delete_multiple($uids);
   }
 
   /**
@@ -433,9 +433,11 @@ class Drupal7 extends AbstractCore {
    * {@inheritdoc}
    */
   public function languageCreate(\stdClass $language) {
+    if (!module_exists('locale')) {
+      throw new \Exception(sprintf("%s::%s line %s: This driver requires the 'locale' module be enabled in order to create languages", get_class($this), __FUNCTION__, __LINE__));
+    }
     include_once DRUPAL_ROOT . '/includes/iso.inc';
     include_once DRUPAL_ROOT . '/includes/locale.inc';
-
     // Get all predefined languages, regardless if they are enabled or not.
     $predefined_languages = _locale_get_predefined_list();
 

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -328,7 +328,7 @@ class Drupal7 extends AbstractCore {
    */
   protected function expandEntityProperties(\stdClass $entity) {
     if (!isset($entity->type)) {
-      throw new \Exception(sprintf("%s::%s line %s: Entity argument is missing a value for the key 'type'", get_class($this), __FUNCTION__, __LINE__))
+      throw new \Exception(sprintf("%s::%s line %s: Entity argument is missing a value for the key 'type'", get_class($this), __FUNCTION__, __LINE__));
     }
     // The created field may come in as a readable date, rather than a
     // timestamp.

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -94,6 +94,16 @@ class Drupal8 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
+  public function nodeDeleteMultiple(array $nids) {
+    foreach($nids as $nid){
+      $node = Node::load($node->nid);
+      $node->delete();
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function runCron() {
     return \Drupal::service('cron')->run();
   }
@@ -230,6 +240,17 @@ class Drupal8 extends AbstractCore {
    */
   public function userDelete(\stdClass $user) {
     user_cancel(array(), $user->uid, 'user_cancel_delete');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function userDeleteMultiple(array $uids) {
+    foreach($uids as $uid){
+      $user = new \stdClass();
+      $user->uid = $uid;
+      $this->userDelete($user);
+    }
   }
 
   /**

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -85,9 +85,6 @@ class Drupal8 extends AbstractCore {
    * {@inheritdoc}
    */
   public function nodeDelete($node) {
-    if(is_numeric($node)){
-      $node = Node::load($node);
-    }
     $node = $node instanceof NodeInterface ? $node : Node::load($node->nid);
     if ($node instanceof NodeInterface) {
       $node->delete();

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -95,7 +95,7 @@ class Drupal8 extends AbstractCore {
    * {@inheritdoc}
    */
   public function nodeDeleteMultiple(array $nids) {
-    foreach($nids as $nid){
+    foreach ($nids as $nid) {
       $node = Node::load($node->nid);
       $node->delete();
     }
@@ -246,7 +246,7 @@ class Drupal8 extends AbstractCore {
    * {@inheritdoc}
    */
   public function userDeleteMultiple(array $uids) {
-    foreach($uids as $uid){
+    foreach ($uids as $uid) {
       $user = new \stdClass();
       $user->uid = $uid;
       $this->userDelete($user);

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -85,6 +85,9 @@ class Drupal8 extends AbstractCore {
    * {@inheritdoc}
    */
   public function nodeDelete($node) {
+    if(is_numeric($node)){
+      $node = Node::load($node);
+    }
     $node = $node instanceof NodeInterface ? $node : Node::load($node->nid);
     if ($node instanceof NodeInterface) {
       $node->delete();

--- a/src/Drupal/Driver/DriverInterface.php
+++ b/src/Drupal/Driver/DriverInterface.php
@@ -111,8 +111,8 @@ interface DriverInterface {
   /**
    * Deletes a node.
    *
-   * @param object/int $node
-   *   Fully loaded node object, or the nid of a drupal node
+   * @param object $node
+   *   Fully loaded node object.
    */
   public function nodeDelete($node);
 

--- a/src/Drupal/Driver/DriverInterface.php
+++ b/src/Drupal/Driver/DriverInterface.php
@@ -33,7 +33,7 @@ interface DriverInterface {
    * @param object $user
    *   Fully loaded drupal user object.
    * @param object $values
-   *   a plain object with field names as properties, and
+   *   A plain object with field names as properties, and
    *   field values as property values.
    */
   public function userAlter($user, $values);
@@ -103,7 +103,7 @@ interface DriverInterface {
    * @param object $node
    *   Fully loaded node object.
    * @param object $values
-   *   a plain object with field names as properties, and
+   *   A plain object with field names as properties, and
    *                        field values as property values.
    */
   public function nodeAlter($node, $values);
@@ -199,18 +199,23 @@ interface DriverInterface {
    *   Value to associate with identifier.
    */
   public function configSet($name, $key, $value);
+
   /**
-   * Deletes multiple nodes
-   * @param  array  $nids An array of node ids (integers or numeric strings)
-   *                      to delete
-   * @return NULL
+   * Deletes multiple nodes.
+   *
+   * @param array $nids
+   *   An array of node ids (integers or numeric strings)
+   *   to delete.
    */
   public function nodeDeleteMultiple(array $nids);
+
   /**
-   * Deletes multiple users
-   * @param  array  $uids An array of user ids (integers or numeric strings)
-   *                      to delete
-   * @return NULL
+   * Deletes multiple users.
+   *
+   * @param array $uids
+   *   An array of user ids (integers or numeric strings) to
+   *   delete.
    */
   public function userDeleteMultiple(array $uids);
+
 }

--- a/src/Drupal/Driver/DriverInterface.php
+++ b/src/Drupal/Driver/DriverInterface.php
@@ -111,8 +111,8 @@ interface DriverInterface {
   /**
    * Deletes a node.
    *
-   * @param object $node
-   *   Fully loaded node object.
+   * @param object/int $node
+   *   Fully loaded node object, or the nid of a drupal node
    */
   public function nodeDelete($node);
 

--- a/src/Drupal/Driver/DriverInterface.php
+++ b/src/Drupal/Driver/DriverInterface.php
@@ -28,6 +28,17 @@ interface DriverInterface {
   public function userCreate(\stdClass $user);
 
   /**
+   * Alters an existing user.
+   *
+   * @param object $user
+   *   Fully loaded drupal user object.
+   * @param object $values
+   *   a plain object with field names as properties, and
+   *   field values as property values.
+   */
+  public function userAlter($user, $values);
+
+  /**
    * Deletes a user.
    */
   public function userDelete(\stdClass $user);
@@ -85,6 +96,17 @@ interface DriverInterface {
    *   The node object including the node ID in the case of new nodes.
    */
   public function createNode($node);
+
+  /**
+   * Deletes a node.
+   *
+   * @param object $node
+   *   Fully loaded node object.
+   * @param object $values
+   *   a plain object with field names as properties, and
+   *                        field values as property values.
+   */
+  public function nodeAlter($node, $values);
 
   /**
    * Deletes a node.

--- a/src/Drupal/Driver/DriverInterface.php
+++ b/src/Drupal/Driver/DriverInterface.php
@@ -199,5 +199,18 @@ interface DriverInterface {
    *   Value to associate with identifier.
    */
   public function configSet($name, $key, $value);
-
+  /**
+   * Deletes multiple nodes
+   * @param  array  $nids An array of node ids (integers or numeric strings)
+   *                      to delete
+   * @return NULL
+   */
+  public function nodeDeleteMultiple(array $nids);
+  /**
+   * Deletes multiple users
+   * @param  array  $uids An array of user ids (integers or numeric strings)
+   *                      to delete
+   * @return NULL
+   */
+  public function userDeleteMultiple(array $uids);
 }

--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -42,7 +42,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface {
   /**
    * Drupal core version.
    *
-   * @var integer
+   * @var int
    */
   public $version;
 

--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -336,14 +336,15 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface {
   /**
    * {@inheritdoc}
    */
-  public function nodeDeleteMultiple(array $nids){
+  public function nodeDeleteMultiple(array $nids) {
     $this->getCore()->nodeDeleteMultiple($nids);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function userDeleteMultiple(array $uids){
+  public function userDeleteMultiple(array $uids) {
     $this->getCore()->userDeleteMultiple($uids);
   }
+
 }

--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -333,4 +333,17 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface {
     $this->getCore()->clearStaticCaches();
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function nodeDeleteMultiple(array $nids){
+    $this->getCore()->nodeDeleteMultiple($nids);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function userDeleteMultiple(array $uids){
+    $this->getCore()->userDeleteMultiple($uids);
+  }
 }

--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -99,6 +99,13 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface {
   /**
    * {@inheritdoc}
    */
+  public function userAlter($user, $values) {
+    return $this->getCore()->userAlter($user, $values);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function userDelete(\stdClass $user) {
     $this->getCore()->userDelete($user);
   }
@@ -231,6 +238,13 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface {
    */
   public function createNode($node) {
     return $this->getCore()->nodeCreate($node);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function nodeAlter($node, $values) {
+    return $this->getCore()->nodeAlter($node, $values);
   }
 
   /**

--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -152,6 +152,13 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
+  public function userDeleteMultiple(array $uids) {
+    $this->getCore()->userDeleteMultiple($uids);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function userAddRole(\stdClass $user, $role) {
     $arguments = array(
       sprintf('"%s"', $role),
@@ -206,6 +213,13 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
+  public function nodeDeleteMultiple(array $nids) {
+    $this->getCore()->nodeDeleteMultiple($nids);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function createTerm(\stdClass $term) {
     $result = $this->drush('behat', array('create-term', escapeshellarg(json_encode($term))), array());
     return json_decode($result);
@@ -228,7 +242,11 @@ class DrushDriver extends BaseDriver {
     // Drush Driver to work with certain built-in Drush capabilities (e.g.
     // creating users) even if the Behat Drush Endpoint is not available.
     try {
-      $result = $this->drush('behat', array('is-field', escapeshellarg(json_encode(array($entity_type, $field_name)))), array());
+      $result = $this->drush('behat', array(
+        'is-field',
+        escapeshellarg(json_encode(array($entity_type, $field_name))),
+      ),
+      array());
       return json_decode($result);
     }
     catch (\Exception $e) {

--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -228,7 +228,12 @@ class DrushDriver extends BaseDriver {
     // Drush Driver to work with certain built-in Drush capabilities (e.g.
     // creating users) even if the Behat Drush Endpoint is not available.
     try {
-      $result = $this->drush('behat', array('is-field', escapeshellarg(json_encode(array($entity_type, $field_name)))), array());
+      $result = $this->drush('behat', array(
+        'is-field',
+        escapeshellarg(json_encode(array($entity_type, $field_name))),
+      ),
+        array()
+      );
       return json_decode($result);
     }
     catch (\Exception $e) {

--- a/src/Drupal/Driver/Fields/Drupal7/EntityreferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/EntityreferenceHandler.php
@@ -22,10 +22,10 @@ class EntityreferenceHandler extends AbstractHandler {
     foreach ($values as $value) {
       $query = db_select($entity_info['base table'], 't')
         ->fields('t', array($entity_info['entity keys']['id']));
-      if(is_numeric($value)){
+      if (is_numeric($value)) {
         $query->condition('t.' . $entity_info['entity keys']['id'], $value);
       }
-      else{
+      else {
         $query->condition('t.' . $entity_info['entity keys']['label'], $value);
       }
       $str_query = (string) $query;

--- a/src/Drupal/Driver/Fields/Drupal7/EntityreferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/EntityreferenceHandler.php
@@ -11,6 +11,7 @@ class EntityreferenceHandler extends AbstractHandler {
    * {@inheritdoc}
    */
   public function expand($values) {
+    $result = array();
     $entity_type = $this->fieldInfo['settings']['target_type'];
     $entity_info = entity_get_info($entity_type);
     // For users set label to username.
@@ -18,17 +19,23 @@ class EntityreferenceHandler extends AbstractHandler {
       $entity_info['entity keys']['label'] = 'name';
     }
 
-    $return = array();
     foreach ($values as $value) {
-      $target_id = db_select($entity_info['base table'], 't')
-        ->fields('t', array($entity_info['entity keys']['id']))
-        ->condition('t.' . $entity_info['entity keys']['label'], $value)
-        ->execute()->fetchField();
+      $query = db_select($entity_info['base table'], 't')
+        ->fields('t', array($entity_info['entity keys']['id']));
+      if(is_numeric($value)){
+        $query->condition('t.' . $entity_info['entity keys']['id'], $value);
+      }
+      else{
+        $query->condition('t.' . $entity_info['entity keys']['label'], $value);
+      }
+      $str_query = (string) $query;
+      $str_arguments = print_r($query->getArguments(), TRUE);
+      $target_id = $query->execute()->fetchField();
       if ($target_id) {
-        $return[$this->language][] = array('target_id' => $target_id);
+        $result[$this->language][] = array('target_id' => $target_id);
       }
     }
-    return $return;
+    return $result;
   }
 
 }

--- a/src/Drupal/Driver/Fields/Drupal7/ListTextHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/ListTextHandler.php
@@ -12,21 +12,22 @@ class ListTextHandler extends AbstractHandler {
    */
   public function expand($values) {
     $return = array();
+    $allowed_values = array();
     if (!empty($this->fieldInfo['settings']['allowed_values_function'])) {
       $cacheable = TRUE;
       $callback = $this->fieldInfo['settings']['allowed_values_function'];
-      $allowed_values = call_user_func($callback, $this->fieldInfo, $this, $this->entityType, $this->entity, $cacheable);
+      $fn_allowed_values = call_user_func($callback, $this->fieldInfo, $this, $this->entityType, $this->entity, $cacheable);
+      $options = array_flip($fn_allowed_values);
     }
     else {
-      $allowed_values = array();
       $options = array_flip($this->fieldInfo['settings']['allowed_values']);
-      foreach ($values as $value) {
-        if (array_key_exists($value, $options)) {
-          $allowed_values[$value] = $options[$value];
-        }
-        else {
-          $allowed_values[$value] = $value;
-        }
+    }
+    foreach ($values as $value) {
+      if (array_key_exists($value, $options)) {
+        $allowed_values[$value] = $options[$value];
+      }
+      else {
+        $allowed_values[$value] = $value;
       }
     }
     foreach ($values as $value) {


### PR DESCRIPTION
This is a continuation of the thread [here](https://github.com/jhedstrom/drupalextension/issues/276).  I had thought that I didn't need alteration functionality, but I've expanded the extension capabilities to the point where I needed to have this thing in the core driver, and I felt it might be a useful general addition.

I'm currently using my own fork of DrupalDriver within DrupalExtension that contains this code. I think it's a useful general addition, so I'm submitting the pull request.  The alter functions expect fully loaded drupal objects for the first argument.

This is currently a D7 only implementation.  I'm game to implement in D8 as well eventually, when we aren't so under the gun at my shop. 

One area I need to highlight is the modification to userCreate to deal with the handling for user roles.  I'm not sure that exploding the string there is the best solution to the problem - I welcome input.
