### PR TITLE
Update Drupal7.php

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -339,7 +339,7 @@ class Drupal7 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
-  public function languageCreate(\stdClass $language) {    
+  public function languageCreate(\stdClass $language) {
     if (!module_exists('locale')) {
       throw new \Exception(sprintf("%s::%s line %s: This driver requires the 'locale' module be enabled in order to create languages", get_class($this), __FUNCTION__, __LINE__));
     }

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -339,7 +339,10 @@ class Drupal7 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
-  public function languageCreate(\stdClass $language) {
+  public function languageCreate(\stdClass $language) {    
+    if (!module_exists('locale')) {
+      throw new \Exception(sprintf("%s::%s line %s: This driver requires the 'locale' module be enabled in order to create languages", get_class($this), __FUNCTION__, __LINE__));
+    }
     include_once DRUPAL_ROOT . '/includes/iso.inc';
     include_once DRUPAL_ROOT . '/includes/locale.inc';
 


### PR DESCRIPTION
This came about as I was testing the driver independently of the Travis CI environment, and couldn't figure out why I kept getting such strange errors from the languageCreate D7 function with my basic site install.  Come to find out that without the locale module, the languages table doesn't even exist, and boostrapping locale.inc won't make the 'locale_language_list' function available without that module being enabled.  

This just adds a check for the 'locale' module before doing any language work.  Probably very edge case, but why not.
