### PR TITLE
Use named columns if they are available.

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/LinkHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/LinkHandler.php
@@ -17,8 +17,8 @@ class LinkHandler extends AbstractHandler {
         // 'options' is required to be an array, otherwise the utility class
         // Drupal\Core\Utility\UnroutedUrlAssembler::assemble() will complain.
         'options' => array(),
-        'title' => $value[0],
-        'uri' => $value[1],
+        'title' => isset($value['title']) ? $value['title'] : $value[0],
+        'uri' => isset($value['uri']) ? $value['uri'] : $value[1],
       );
     }
     return $return;


### PR DESCRIPTION
Since we can specify complex fields with `field_name:column_name`, the LinkHandler should recognize those values.

Eg:

```
  I am viewing a "movie" content:
    | title                     | Test                             |
    | field_movie_facebook:uri     | https://www.facebook.com         |
    | field_movie_facebook:title   | Facebook                         |
    | field_movie_facebook:options |                                  |
```

I'm not sure how to handle `options`... Suggestions?
