### PR TITLE
Change field_info to fieldInfo to match actual property name

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal7/TaxonomyTermReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/TaxonomyTermReferenceHandler.php
@@ -30,8 +30,8 @@ class TaxonomyTermReferenceHandler extends AbstractHandler {
    *   found or NULL if unable to determine.
    */
   protected function getVocab() {
-    if (!empty($this->field_info['settings']['allowed_values'][0]['vocabulary'])) {
-      return $this->field_info['settings']['allowed_values'][0]['vocabulary'];
+    if (!empty($this->fieldInfo['settings']['allowed_values'][0]['vocabulary'])) {
+      return $this->fieldInfo['settings']['allowed_values'][0]['vocabulary'];
     }
   }
 


### PR DESCRIPTION
The property name "field_info" isn't right, which is preventing getVocab() from succeeding, in the Drupal 7 taxonomy term reference field handler.