### PR TITLE
Two additional date field handlers for D7

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal7/AbstractDateHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/AbstractDateHandler.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\Driver\Fields\Drupal7;
+
+/**
+ * A base handler for the various types of Date fields in Drupal 7.
+ */
+abstract class AbstractDateHandler extends AbstractHandler {
+
+  /**
+   * Get the format in which the dates are saved in Drupal's database.
+   *
+   * @return string
+   *   The format in which the dates are saved in Drupal's database.
+   */
+  abstract protected function getDateFormat();
+
+  /**
+   * Converts a date string into the format expected by Drupal.
+   *
+   * @return string
+   *   The re-formatted date string.
+   */
+  protected function formatDateValue($value) {
+
+    $date = new DateTime($value);
+    return $date->format($this->getDateFormat());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function expand($values) {
+
+    $return = array();
+    if (isset($this->fieldInfo['columns']['value2'])) {
+      foreach ($values as $value) {
+        $return[$this->language][] = array(
+          'value' => $this->formatDateValue($value[0]),
+          'value2' => $this->formatDateValue($value[1]),
+        );
+      }
+    }
+    else {
+      foreach ($values as $value) {
+        $return[$this->language][] = array(
+          'value' => $this->formatDateValue($value),
+        );
+      }
+    }
+    return $return;
+  }
+
+}

--- a/src/Drupal/Driver/Fields/Drupal7/AbstractDateHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/AbstractDateHandler.php
@@ -8,12 +8,11 @@ namespace Drupal\Driver\Fields\Drupal7;
 abstract class AbstractDateHandler extends AbstractHandler {
 
   /**
-   * Get the format in which the dates are saved in Drupal's database.
+   * The format in which the dates are saved in Drupal's database.
    *
-   * @return string
-   *   The format in which the dates are saved in Drupal's database.
+   * @var string
    */
-  abstract protected function getDateFormat();
+  protected $dateFormat = NULL;
 
   /**
    * Converts a date string into the format expected by Drupal.
@@ -23,8 +22,12 @@ abstract class AbstractDateHandler extends AbstractHandler {
    */
   protected function formatDateValue($value) {
 
+    if (empty($this->dateFormat)) {
+      return $value;
+    }
+
     $date = new \DateTime($value);
-    return $date->format($this->getDateFormat());
+    return $date->format($this->dateFormat);
   }
 
   /**

--- a/src/Drupal/Driver/Fields/Drupal7/AbstractDateHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/AbstractDateHandler.php
@@ -36,16 +36,14 @@ abstract class AbstractDateHandler extends AbstractHandler {
   public function expand($values) {
 
     $return = array();
-    if (isset($this->fieldInfo['columns']['value2'])) {
-      foreach ($values as $value) {
+    foreach ($values as $value) {
+      if (is_array($value) && isset($this->fieldInfo['columns']['value2'])) {
         $return[$this->language][] = array(
           'value' => $this->formatDateValue($value[0]),
           'value2' => $this->formatDateValue($value[1]),
         );
       }
-    }
-    else {
-      foreach ($values as $value) {
+      else {
         $return[$this->language][] = array(
           'value' => $this->formatDateValue($value),
         );

--- a/src/Drupal/Driver/Fields/Drupal7/AbstractDateHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/AbstractDateHandler.php
@@ -23,7 +23,7 @@ abstract class AbstractDateHandler extends AbstractHandler {
    */
   protected function formatDateValue($value) {
 
-    $date = new DateTime($value);
+    $date = new \DateTime($value);
     return $date->format($this->getDateFormat());
   }
 

--- a/src/Drupal/Driver/Fields/Drupal7/DateHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/DateHandler.php
@@ -5,5 +5,13 @@ namespace Drupal\Driver\Fields\Drupal7;
 /**
  * Date field handler for Drupal 7.
  */
-class DateHandler extends DatetimeHandler {
+class DateHandler extends AbstractDateHandler {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getDateFormat() {
+    return 'Y-m-d\Th:m:s';
+  }
+
 }

--- a/src/Drupal/Driver/Fields/Drupal7/DateHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/DateHandler.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Drupal\Driver\Fields\Drupal7;
+
+/**
+ * Date field handler for Drupal 7.
+ */
+class DateHandler extends DatetimeHandler {
+}

--- a/src/Drupal/Driver/Fields/Drupal7/DateHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/DateHandler.php
@@ -10,8 +10,6 @@ class DateHandler extends AbstractDateHandler {
   /**
    * {@inheritdoc}
    */
-  protected function getDateFormat() {
-    return 'Y-m-d\TH:I:s';
-  }
+  protected $dateFormat = 'Y-m-d\TH:i:s';
 
 }

--- a/src/Drupal/Driver/Fields/Drupal7/DateHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/DateHandler.php
@@ -11,7 +11,7 @@ class DateHandler extends AbstractDateHandler {
    * {@inheritdoc}
    */
   protected function getDateFormat() {
-    return 'Y-m-d\Th:m:s';
+    return 'Y-m-d\TH:I:s';
   }
 
 }

--- a/src/Drupal/Driver/Fields/Drupal7/DatestampHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/DatestampHandler.php
@@ -5,5 +5,13 @@ namespace Drupal\Driver\Fields\Drupal7;
 /**
  * Datestamp field handler for Drupal 7.
  */
-class DatestampHandler extends DatetimeHandler {
+class DatestampHandler extends AbstractDateHandler {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getDateFormat() {
+    return 'U';
+  }
+
 }

--- a/src/Drupal/Driver/Fields/Drupal7/DatestampHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/DatestampHandler.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Drupal\Driver\Fields\Drupal7;
+
+/**
+ * Datestamp field handler for Drupal 7.
+ */
+class DatestampHandler extends DatetimeHandler {
+}

--- a/src/Drupal/Driver/Fields/Drupal7/DatestampHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/DatestampHandler.php
@@ -10,8 +10,6 @@ class DatestampHandler extends AbstractDateHandler {
   /**
    * {@inheritdoc}
    */
-  protected function getDateFormat() {
-    return 'U';
-  }
+  protected $dateFormat = 'U';
 
 }

--- a/src/Drupal/Driver/Fields/Drupal7/DatetimeHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/DatetimeHandler.php
@@ -5,27 +5,13 @@ namespace Drupal\Driver\Fields\Drupal7;
 /**
  * Datetime field handler for Drupal 7.
  */
-class DatetimeHandler extends AbstractHandler {
+class DatetimeHandler extends AbstractDateHandler {
 
   /**
    * {@inheritdoc}
    */
-  public function expand($values) {
-    $return = array();
-    if (isset($this->fieldInfo['columns']['value2'])) {
-      foreach ($values as $value) {
-        $return[$this->language][] = array(
-          'value' => $value[0],
-          'value2' => $value[1],
-        );
-      }
-    }
-    else {
-      foreach ($values as $value) {
-        $return[$this->language][] = array('value' => $value);
-      }
-    }
-    return $return;
+  protected function getDateFormat() {
+    return 'Y-m-d h:m:s';
   }
 
 }

--- a/src/Drupal/Driver/Fields/Drupal7/DatetimeHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/DatetimeHandler.php
@@ -11,7 +11,7 @@ class DatetimeHandler extends AbstractDateHandler {
    * {@inheritdoc}
    */
   protected function getDateFormat() {
-    return 'Y-m-d h:m:s';
+    return 'Y-m-d H:i:s';
   }
 
 }

--- a/src/Drupal/Driver/Fields/Drupal7/DatetimeHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/DatetimeHandler.php
@@ -10,8 +10,6 @@ class DatetimeHandler extends AbstractDateHandler {
   /**
    * {@inheritdoc}
    */
-  protected function getDateFormat() {
-    return 'Y-m-d H:i:s';
-  }
+  protected $dateFormat = 'Y-m-d H:i:s';
 
 }

--- a/tests/Drupal/Tests/Driver/Drupal7FieldHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Drupal7FieldHandlerTest.php
@@ -28,6 +28,9 @@ class Drupal7FieldHandlerTest extends FieldHandlerAbstractTest {
    * @dataProvider dataProvider
    */
   public function testFieldHandlers($class_name, $entity, $entity_type, array $field, array $expected_values) {
+    // Set the timezone so that timestamp dates can be predictable.
+    date_default_timezone_set('UTC');
+
     $handler = $this->getMockHandler($class_name, $entity, $entity_type, $field);
 
     $field_name = $field['field_name'];
@@ -129,6 +132,98 @@ class Drupal7FieldHandlerTest extends FieldHandlerAbstractTest {
             array(
               'value' => '2015-01-01 00:00:00',
               'value2' => '2015-01-02 00:00:00',
+            ),
+          ),
+        ),
+      ),
+
+      // Test single-value date (ISO) field provided as simple text.
+      array(
+        'DateHandler',
+        (object) array('field_date' => '2015-01-01 00:00:00'),
+        'node',
+        array('field_name' => 'field_date'),
+        array('en' => array(array('value' => '2015-01-01T00:00:00'))),
+      ),
+
+      // Test single-value date (ISO) field provided as an array.
+      array(
+        'DateHandler',
+        (object) array('field_date' => array('2015-01-01 00:00:00')),
+        'node',
+        array('field_name' => 'field_date'),
+        array('en' => array(array('value' => '2015-01-01T00:00:00'))),
+      ),
+
+      // Test double-value date (ISO) field. Can only be provided as an array
+      // due to array type casting we perform in
+      // \Drupal\Driver\Fields\Drupal7\AbstractFieldHandler::__call()
+      array(
+        'DateHandler',
+        (object) array(
+          'field_date' => array(
+            array(
+              '2015-01-01 00:00:00',
+              '2015-01-02 00:00:00',
+            ),
+          ),
+        ),
+        'node',
+        array(
+          'field_name' => 'field_date',
+          'columns' => array('value' => '', 'value2' => ''),
+        ),
+        array(
+          'en' => array(
+            array(
+              'value' => '2015-01-01T00:00:00',
+              'value2' => '2015-01-02T00:00:00',
+            ),
+          ),
+        ),
+      ),
+
+      // Test single-value datestamp field provided as simple text.
+      array(
+        'DatestampHandler',
+        (object) array('field_date' => '2015-01-01 00:00:00'),
+        'node',
+        array('field_name' => 'field_date'),
+        array('en' => array(array('value' => '1420070400'))),
+      ),
+
+      // Test single-value datestamp field provided as an array.
+      array(
+        'DatestampHandler',
+        (object) array('field_date' => array('2015-01-01 00:00:00')),
+        'node',
+        array('field_name' => 'field_date'),
+        array('en' => array(array('value' => '1420070400'))),
+      ),
+
+      // Test double-value datestamp field. Can only be provided as an array
+      // due to array type casting we perform in
+      // \Drupal\Driver\Fields\Drupal7\AbstractFieldHandler::__call()
+      array(
+        'DatestampHandler',
+        (object) array(
+          'field_date' => array(
+            array(
+              '2015-01-01 00:00:00',
+              '2015-01-02 00:00:00',
+            ),
+          ),
+        ),
+        'node',
+        array(
+          'field_name' => 'field_date',
+          'columns' => array('value' => '', 'value2' => ''),
+        ),
+        array(
+          'en' => array(
+            array(
+              'value' => '1420070400',
+              'value2' => '1420156800',
             ),
           ),
         ),


### PR DESCRIPTION
I've run into D7 sites that use other "types" of date fields, and so these are 2 additional classes to simply inherit, without changing, the existing DatetimeHandler class.
