### PR TITLE
[D8] Support LinkHandler options

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/LinkHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/LinkHandler.php
@@ -13,10 +13,14 @@ class LinkHandler extends AbstractHandler {
   public function expand($values) {
     $return = array();
     foreach ($values as $value) {
+      // 'options' is required to be an array, otherwise the utility class
+      // Drupal\Core\Utility\UnroutedUrlAssembler::assemble() will complain.
+      $options = array();
+      if (!empty($value[2])) {
+        parse_str($value[2], $options);
+      }
       $return[] = array(
-        // 'options' is required to be an array, otherwise the utility class
-        // Drupal\Core\Utility\UnroutedUrlAssembler::assemble() will complain.
-        'options' => array(),
+        'options' => $options,
         'title' => $value[0],
         'uri' => $value[1],
       );


### PR DESCRIPTION
Currently the LinkHandler disregards and input for the options since it sets a empty array().
This pull request will use the $value[2], split similarly to the Title and Uri, as the options array.

To supply the link options in the behat feature, your input value should look like:
"Link title - http://urihere.com - attributes[target]=_blank"