### PR TITLE
Corrects handling of callback-based lists.

### DIFF
--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -42,7 +42,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface {
   /**
    * Drupal core version.
    *
-   * @var integer
+   * @var int
    */
   public $version;
 

--- a/src/Drupal/Driver/Fields/Drupal7/ListTextHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/ListTextHandler.php
@@ -12,21 +12,22 @@ class ListTextHandler extends AbstractHandler {
    */
   public function expand($values) {
     $return = array();
+    $allowed_values = array();
     if (!empty($this->fieldInfo['settings']['allowed_values_function'])) {
       $cacheable = TRUE;
       $callback = $this->fieldInfo['settings']['allowed_values_function'];
-      $allowed_values = call_user_func($callback, $this->fieldInfo, $this, $this->entityType, $this->entity, $cacheable);
+      $fn_allowed_values = call_user_func($callback, $this->fieldInfo, $this, $this->entityType, $this->entity, $cacheable);
+      $options = array_flip($fn_allowed_values);
     }
     else {
-      $allowed_values = array();
       $options = array_flip($this->fieldInfo['settings']['allowed_values']);
-      foreach ($values as $value) {
-        if (array_key_exists($value, $options)) {
-          $allowed_values[$value] = $options[$value];
-        }
-        else {
-          $allowed_values[$value] = $value;
-        }
+    }
+    foreach ($values as $value) {
+      if (array_key_exists($value, $options)) {
+        $allowed_values[$value] = $options[$value];
+      }
+      else {
+        $allowed_values[$value] = $value;
       }
     }
     foreach ($values as $value) {


### PR DESCRIPTION
We looked over this for awhile before we decided it was a bug.  In the case of allowed values in field info, the function had inverted the key/value pairings, and set the *key* as the return value, but in the case of callback functions, it sets the *value* of allowed_values as the return value.  This is despite the fact that the callback function is supposed to return a mapping of raw=>display values, which would mean that the display value was what was stored in the db (which was what was happening for us during api calls).

This corrects the handling so that, in each case, the options array is generated from a flip of the allowed values, and then handling of that options array is identical from that point forward.