### PR TITLE
Adding expandEntityBaseFields() method.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 *.tgz
 *.phar
 composer.lock

--- a/src/Drupal/Driver/Cores/AbstractCore.php
+++ b/src/Drupal/Driver/Cores/AbstractCore.php
@@ -56,7 +56,7 @@ abstract class AbstractCore implements CoreInterface {
   public function getFieldHandler($entity, $entity_type, $field_name) {
     $reflection = new \ReflectionClass($this);
     $core_namespace = $reflection->getShortName();
-    $field_types = $this->getEntityFieldTypes($entity_type);
+    $field_types = $this->getEntityFieldTypes($entity_type, array($field_name));
     $camelized_type = Container::camelize($field_types[$field_name]);
     $default_class = sprintf('\Drupal\Driver\Fields\%s\DefaultHandler', $core_namespace);
     $class_name = sprintf('\Drupal\Driver\Fields\%s\%sHandler', $core_namespace, $camelized_type);
@@ -73,9 +73,12 @@ abstract class AbstractCore implements CoreInterface {
    *   The entity type ID.
    * @param \stdClass $entity
    *   Entity object.
+   * @param array $base_fields
+   *   Optional. Define base fields that will be expanded in addition to user
+   *   defined fields.
    */
-  protected function expandEntityFields($entity_type, \stdClass $entity) {
-    $field_types = $this->getEntityFieldTypes($entity_type);
+  protected function expandEntityFields($entity_type, \stdClass $entity, $base_fields = array()) {
+    $field_types = $this->getEntityFieldTypes($entity_type, $base_fields);
     foreach ($field_types as $field_name => $type) {
       if (isset($entity->$field_name)) {
         $entity->$field_name = $this->getFieldHandler($entity, $entity_type, $field_name)

--- a/src/Drupal/Driver/Cores/AbstractCore.php
+++ b/src/Drupal/Driver/Cores/AbstractCore.php
@@ -77,7 +77,7 @@ abstract class AbstractCore implements CoreInterface {
    *   Optional. Define base fields that will be expanded in addition to user
    *   defined fields.
    */
-  protected function expandEntityFields($entity_type, \stdClass $entity, $base_fields = array()) {
+  protected function expandEntityFields($entity_type, \stdClass $entity, array $base_fields = array()) {
     $field_types = $this->getEntityFieldTypes($entity_type, $base_fields);
     foreach ($field_types as $field_name => $type) {
       if (isset($entity->$field_name)) {

--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -171,7 +171,7 @@ interface CoreInterface {
    * @return array
    *   An associative array of field types, keyed by field name.
    */
-  public function getEntityFieldTypes($entity_type, $base_fields = array());
+  public function getEntityFieldTypes($entity_type, array $base_fields = array());
 
   /**
    * Creates a language.

--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -164,11 +164,14 @@ interface CoreInterface {
    *
    * @param string $entity_type
    *   The entity type for which to return the field types.
+   * @param array $base_fields
+   *   Optional. Define base fields that will be returned in addition to user-
+   *   defined fields.
    *
    * @return array
    *   An associative array of field types, keyed by field name.
    */
-  public function getEntityFieldTypes($entity_type);
+  public function getEntityFieldTypes($entity_type, $base_fields = array());
 
   /**
    * Creates a language.

--- a/src/Drupal/Driver/Cores/Drupal6.php
+++ b/src/Drupal/Driver/Cores/Drupal6.php
@@ -432,7 +432,14 @@ class Drupal6 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
-  public function getEntityFieldTypes($entity_type) {
+  protected function expandEntityFields($entity_type, \stdClass $entity, $base_fields = array()) {
+    return parent::expandEntityFields($entity_type, $entity);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityFieldTypes($entity_type, $base_fields = array()) {
     $taxonomy_fields = array('taxonomy' => 'taxonomy');
     if (!module_exists('content')) {
       return $taxonomy_fields;

--- a/src/Drupal/Driver/Cores/Drupal6.php
+++ b/src/Drupal/Driver/Cores/Drupal6.php
@@ -432,14 +432,14 @@ class Drupal6 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
-  protected function expandEntityFields($entity_type, \stdClass $entity, $base_fields = array()) {
+  protected function expandEntityFields($entity_type, \stdClass $entity, array $base_fields = array()) {
     return parent::expandEntityFields($entity_type, $entity);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getEntityFieldTypes($entity_type, $base_fields = array()) {
+  public function getEntityFieldTypes($entity_type, array $base_fields = array()) {
     $taxonomy_fields = array('taxonomy' => 'taxonomy');
     if (!module_exists('content')) {
       return $taxonomy_fields;

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -456,7 +456,7 @@ class Drupal7 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
-  public function getEntityFieldTypes($entity_type, $base_fields = array()) {
+  public function getEntityFieldTypes($entity_type, array $base_fields = array()) {
     $return = array();
     $fields = field_info_field_map();
     foreach ($fields as $field_name => $field) {

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -456,7 +456,7 @@ class Drupal7 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
-  public function getEntityFieldTypes($entity_type) {
+  public function getEntityFieldTypes($entity_type, $base_fields = array()) {
     $return = array();
     $fields = field_info_field_map();
     foreach ($fields as $field_name => $field) {

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -375,7 +375,7 @@ class Drupal8 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
-  public function getEntityFieldTypes($entity_type, $base_fields = array()) {
+  public function getEntityFieldTypes($entity_type, array $base_fields = array()) {
     $return = array();
     $fields = \Drupal::entityManager()->getFieldStorageDefinitions($entity_type);
     foreach ($fields as $field_name => $field) {

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -368,7 +368,7 @@ class Drupal8 extends AbstractCore {
    * @param array $base_fields
    *   Base fields to be expanded in addition to user defined fields.
    */
-  public function expandEntityBaseFields($entity_type, \stdClass $entity, $base_fields) {
+  public function expandEntityBaseFields($entity_type, \stdClass $entity, array $base_fields) {
     $this->expandEntityFields($entity_type, $entity, $base_fields);
   }
 

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -3,6 +3,7 @@
 namespace Drupal\Driver\Cores;
 
 use Drupal\Core\DrupalKernel;
+use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Driver\Exception\BootstrapException;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\language\Entity\ConfigurableLanguage;
@@ -358,13 +359,28 @@ class Drupal8 extends AbstractCore {
   }
 
   /**
+   * Expands specified base fields on the entity object.
+   *
+   * @param string $entity_type
+   *   The entity type for which to return the field types.
+   * @param \stdClass $entity
+   *   Entity object.
+   * @param array $base_fields
+   *   Base fields to be expanded in addition to user defined fields.
+   */
+  public function expandEntityBaseFields($entity_type, \stdClass $entity, $base_fields) {
+    $this->expandEntityFields($entity_type, $entity, $base_fields);
+  }
+
+  /**
    * {@inheritdoc}
    */
-  public function getEntityFieldTypes($entity_type) {
+  public function getEntityFieldTypes($entity_type, $base_fields = array()) {
     $return = array();
     $fields = \Drupal::entityManager()->getFieldStorageDefinitions($entity_type);
     foreach ($fields as $field_name => $field) {
-      if ($this->isField($entity_type, $field_name)) {
+      if ($this->isField($entity_type, $field_name)
+        || (in_array($field_name, $base_fields) && $this->isBaseField($entity_type, $field_name))) {
         $return[$field_name] = $field->getType();
       }
     }
@@ -377,6 +393,14 @@ class Drupal8 extends AbstractCore {
   public function isField($entity_type, $field_name) {
     $fields = \Drupal::entityManager()->getFieldStorageDefinitions($entity_type);
     return (isset($fields[$field_name]) && $fields[$field_name] instanceof FieldStorageConfig);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isBaseField($entity_type, $field_name) {
+    $fields = \Drupal::entityManager()->getFieldStorageDefinitions($entity_type);
+    return (isset($fields[$field_name]) && $fields[$field_name] instanceof BaseFieldDefinition);
   }
 
   /**

--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -24,13 +24,17 @@ class EntityReferenceHandler extends AbstractHandler {
       $label_key = 'name';
     }
 
+    if (!$label_key && $entity_type_id == 'user') {
+      $label_key = 'name';
+    }
+
     // Determine target bundle restrictions.
     $target_bundle_key = NULL;
     if ($target_bundles = $this->getTargetBundles()) {
       $target_bundle_key = $entity_definition->getKey('bundle');
     }
 
-    foreach ($values as $value) {
+    foreach ((array) $values as $value) {
       $query = \Drupal::entityQuery($entity_type_id)->condition($label_key, $value);
       if ($target_bundles && $target_bundle_key) {
         $query->condition($target_bundle_key, $target_bundles, 'IN');


### PR DESCRIPTION
This pull request allows expansion of base fields on entities. In Drupal 8, base fields use the same field types as user-defined fields. E.g., a custom entity may define an entity reference field as a base field. Without this PR, there is no mechanism for expanding such fields.

Example usage:
```
      /** @var Drupal8 $d8_core */
      $d8_core = $this->getDriver()->getCore();
      $entity = (object) $row;
      $base_fields = [
        'licensed_entity',
        'user_id',
      ];
      $d8_core->expandEntityBaseFields('license', $entity, $base_fields);
      $d8_core->entityCreate('license', $entity);
```

This would expand the licensed_entity and user_id base fields using the EntityReferenceHandler class.

This pull request also documents a couple of undocumented parameters and fixes a bug that prevented user entity values from being expanded on entity reference fields.