### PR TITLE
Don't force status for new created nodes

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -62,10 +62,6 @@ class Drupal8 extends AbstractCore {
     if (!in_array($node->type, array_keys($bundles))) {
       throw new \Exception("Cannot create content because provided content type '$node->type' does not exist.");
     }
-    // Default status to 1 if not set.
-    if (!isset($node->status)) {
-      $node->status = 1;
-    }
     // If 'author' is set, remap it to 'uid'.
     if (isset($node->author)) {
       $user = user_load_by_name($node->author);
@@ -74,7 +70,7 @@ class Drupal8 extends AbstractCore {
       }
     }
     $this->expandEntityFields('node', $node);
-    $entity = entity_create('node', (array) $node);
+    $entity = Node::create((array) $node);
     $entity->save();
 
     $node->nid = $entity->id();


### PR DESCRIPTION
When Node::create($values) is called without status being set in the values,
the node will be created with defaults set in the publishing options on the bundle.

The current implementation forces the node to published, although this might not be intended.
It looks like the code responsible for this is D7 legacy.