### PR TITLE
Fix d8 User Entity Reference fields

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -14,7 +14,15 @@ class EntityReferenceHandler extends AbstractHandler {
     $return = array();
     $entity_type_id = $this->fieldInfo->getSetting('target_type');
     $entity_definition = \Drupal::entityManager()->getDefinition($entity_type_id);
-    $label_key = $entity_definition->getKey('label');
+
+    // Determine label field key.
+    if ($entity_type_id !== 'user') {
+      $label_key = $entity_definition->getKey('label');
+    }
+    else {
+      // Entity Definition->getKey('label') returns false for users.
+      $label_key = 'name';
+    }
 
     // Determine target bundle restrictions.
     $target_bundle_key = NULL;


### PR DESCRIPTION
Creating a node with an user entity reference field value throws:
```
'Drupal\Core\Entity\Query\QueryException' with message ''' not found' in web/core/lib/Drupal/Core/Entity/Query/Sql/Tables.php:316
```

It would seem that the User entity does not define the label column, an issue that the d7 EntityReferenceHandler appears to work around:
```
// For users set label to username.
if ($entity_type == 'user') {
  $entity_info['entity keys']['label'] = 'name';
}
```

So i have used the same approach to fix it, manually setting the label_key for user entities.