### PR TITLE
Speed up test runs by being satisfied with release packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
   - hhvm
 
 install:
-  - composer install --dev --prefer-source
+  - composer install
 
 script:
   - find ./src -name "*.php" -print0 | xargs -0 -n1 -P8 php -l


### PR DESCRIPTION
Currently we're using the `--prefer-source` option to download our dependencies. This is slow since the complete git repositories will be downloaded for every dependency. I don't think we have an actual need for the full source packages of our dependencies, so we can download the faster distribution builds instead.