### PR TITLE
Load drushrc.php for D8.

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -298,6 +298,10 @@ class Drupal8 extends AbstractCore {
     if (!file_exists($conf_file)) {
       throw new BootstrapException(sprintf('Could not find a Drupal settings.php file at "%s"', $conf_file));
     }
+    $drushrc_file = $this->drupalRoot . "/$conf_path/drushrc.php";
+    if (file_exists($drushrc_file)) {
+      require_once $drushrc_file;
+    }
   }
 
   /**


### PR DESCRIPTION
Both D6 and D7 cores load the drushrc file if they find it, but the D8 core didn't. Without this we could not easily run tests on multisites created by Aegir.