### PR TITLE
Infer timezone in DateTime field handler

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/DatetimeHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/DatetimeHandler.php
@@ -2,6 +2,9 @@
 
 namespace Drupal\Driver\Fields\Drupal8;
 
+use DateTime;
+use DateTimeZone;
+
 /**
  * Datetime field handler for Drupal 8.
  */
@@ -11,6 +14,8 @@ class DatetimeHandler extends AbstractHandler {
    * {@inheritdoc}
    */
   public function expand($values) {
+    $siteTimezone = new DateTimeZone(\Drupal::config('system.date')->get('timezone.default'));
+    $storageTimezone = new DateTimeZone(DATETIME_STORAGE_TIMEZONE);
     foreach ($values as $key => $value) {
       if (strpos($value, "relative:") !== FALSE) {
         $relative = trim(str_replace('relative:', '', $value));
@@ -18,7 +23,13 @@ class DatetimeHandler extends AbstractHandler {
         $values[$key] = substr(gmdate('c', strtotime($relative)), 0, 19);
       }
       else {
-        $values[$key] = str_replace(' ', 'T', $value);
+        // A Drupal install has a default site timezone, but nonetheless
+        // uses UTC for internal storage. If no timezone is specified in a date
+        // field value by the step author, assume it is in the default timezone of
+        // the Drupal install, and therefore transform it into UTC for storage.
+        $date = new DateTime($value, $siteTimezone);
+        $date->setTimezone($storageTimezone);
+        $values[$key] = $date->format('Y-m-d\TH:i:s');
       }
     }
     return $values;

--- a/src/Drupal/Driver/Fields/Drupal8/DatetimeHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/DatetimeHandler.php
@@ -25,7 +25,7 @@ class DatetimeHandler extends AbstractHandler {
       else {
         // A Drupal install has a default site timezone, but nonetheless
         // uses UTC for internal storage. If no timezone is specified in a date
-        // field value by the step author, assume it is in the default timezone of
+        // field value by the step author, assume the default timezone of
         // the Drupal install, and therefore transform it into UTC for storage.
         $date = new DateTime($value, $siteTimezone);
         $date->setTimezone($storageTimezone);


### PR DESCRIPTION
I thought I had already made PR for this but I can't find it, forgive me if I'm being foolish.

Currently the following scenario will fail most of the time:
```
Given I am viewing an article:
  | title                  | test                            |
  | field_datetime | 2005-06-30 14:00:00 |
Then I should see "2005-06-30 14:00:00"
```

It will typically fail because values are by default created and stored using UTC, but rendered using the current user's timezone. The workaround is for step authors to do mental time math, writing their "Given" times in UTC and their "Then" times in the Drupal timzeone (which is the default for any user).

I think we should assume that step authors intend time values to be in the Drupal default timezone when they write them in Given statements, unless they explicitly specify a timezone.

This will break BC for anyone writing tortured scenarios expecting the current behavior.

I can write some tests for it in the extension, if you like the idea of this.