### PR TITLE
Entity reference field handler: allow force target id

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal7/EntityreferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/EntityreferenceHandler.php
@@ -11,7 +11,7 @@ class EntityreferenceHandler extends AbstractHandler {
    * {@inheritdoc}
    */
   public function expand($values) {
-    $entity_type = $this->fieldInfo['settings']['target_type'];
+    $entity_type = $this->getEntityType();
     $entity_info = entity_get_info($entity_type);
     // For users set label to username.
     if ($entity_type == 'user') {
@@ -20,15 +20,47 @@ class EntityreferenceHandler extends AbstractHandler {
 
     $return = array();
     foreach ($values as $value) {
-      $target_id = db_select($entity_info['base table'], 't')
-        ->fields('t', array($entity_info['entity keys']['id']))
-        ->condition('t.' . $entity_info['entity keys']['label'], $value)
-        ->execute()->fetchField();
+      // Extract target id by step. Otherwise, try get entity searching
+      // by entity label.
+      if (is_array($value) && !empty($value['target_id']) && $this->entityExists($value['target_id'])) {
+        $target_id = $value['target_id'];
+      }
+      else {
+        $target_id = db_select($entity_info['base table'], 't')
+          ->fields('t', array($entity_info['entity keys']['id']))
+          ->condition('t.' . $entity_info['entity keys']['label'], $value)
+          ->execute()->fetchField();
+      }
       if ($target_id) {
         $return[$this->language][] = array('target_id' => $target_id);
       }
     }
     return $return;
+  }
+
+  /**
+   * Get entity type.
+   *
+   * @return string
+   *   Entity type (node, user, taxonomy, etc).
+   */
+  public function getEntityType() {
+    return $this->fieldInfo['settings']['target_type'];
+  }
+
+  /**
+   * Check target id belongs to a real entity.
+   *
+   * @param int $target_id
+   *   Target id.
+   *
+   * @return bool
+   *   Entity exists?
+   */
+  public function entityExists($target_id) {
+    $entity_type = $this->getEntityType();
+    $entity = entity_load_single($entity_type, $target_id);
+    return !empty($entity);
   }
 
 }


### PR DESCRIPTION
Hi.

Now the step 'Given :type content' doesn't allow force target id for entity reference fields, in this way:
```
 | field_entityrereference:target_id |
 | 123                                              |
```

I need this in a project where there is a entity reference field which points to a remote entity. That entity doesn't have a single label column (it needs 2 to build the label) and it's needed force target id.

Can you review this pull request, please? Thanks!

