### PR TITLE
Target a specific bundle if defined.

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -18,7 +18,7 @@ class EntityReferenceHandler extends AbstractHandler {
 
     // Determine target bundle restrictions.
     $target_bundle_key = NULL;
-    if (!$target_bundles = $this->getTargetBundles()) {
+    if ($target_bundles = $this->getTargetBundles()) {
       $target_bundle_key = $entity_definition->getKey('bundle');
     }
 


### PR DESCRIPTION
The current implementation looks bugged. At the moment, you never run line 28 if we are testing line 21 for an empty target bundle.
If the field is filtering a specific bundle of taxonomy terms for instance, you want to set the value of $target_bundle_key when you have multiple bundles too.
Steps to reproduce the issue, create two taxonomy terms with the same name in two different vocabularies, let's say voc1 > item & voc2 > item. Tid are respectively 1 and 2.
Now, try to create a node through the Drupal 8 behat driver that has an entity reference field with a configuration of entity type taxonomy terms and vocabulary "voc2" as target bundle. Your node should be created but with the wrong term ID because there will be a match to the "item" term that has the tid 1 instead of the tid 2 expected.