### PR TITLE
Rely on ids + support autocreate.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "artusamak/drupal-driver",
   "type": "library",
   "description": "A collection of reusable Drupal drivers",
+  "minimum-stability": "dev",
   "keywords": ["drupal", "web", "test"],
   "homepage": "http://github.com/jhedstrom/DrupalDriver",
   "license": "GPL-2.0+",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "drupal/drupal-driver",
+  "name": "artusamak/drupal-driver",
   "type": "library",
   "description": "A collection of reusable Drupal drivers",
   "keywords": ["drupal", "web", "test"],

--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,5 @@
       "Drupal\\Driver": "src/",
       "Drupal\\Tests\\Driver" : "tests/"
     }
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-master": "1.2.x-dev"
-    }
   }
 }

--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -14,7 +14,7 @@ class EntityReferenceHandler extends AbstractHandler {
     $return = array();
     $entity_type_id = $this->fieldInfo->getSetting('target_type');
     $entity_definition = \Drupal::entityManager()->getDefinition($entity_type_id);
-    $label_key = $entity_definition->getKey('label');
+    $label_key = $entity_definition->getKey('id');
 
     // Determine target bundle restrictions.
     $target_bundle_key = NULL;
@@ -31,7 +31,10 @@ class EntityReferenceHandler extends AbstractHandler {
         $return[] = array_shift($entities);
       }
       else {
-        throw new \Exception(sprintf("No entity '%s' of type '%s' exists.", $value, $entity_type_id));
+        // Do not throw an exception if the field has auto created items.
+        if (!$this->fieldConfig->getSetting('handler_settings')['auto_create']) {
+          throw new \Exception(sprintf("No entity '%s' of type '%s' exists.", $value, $entity_type_id));
+        }
       }
     }
     return $return;


### PR DESCRIPTION
The current implementation looks bugged. At the moment, you never run line 28 if we are testing line 21 for an empty target bundle.
If the field is filtering a specific bundle of taxonomy terms for instance, you want to set the value of $target_bundle_key when you have multiple bundles too.
Steps to reproduce the issue, create two taxonomy terms with the same name in two different vocabularies, let's say voc1 > item & voc2 > item. Tid are respectively 1 and 2.
Now, try to create a node through the Drupal 8 behat driver that has an entity reference field with a configuration of entity type taxonomy terms and vocabulary "voc2" as target bundle. Your node should be created but with the wrong term ID because there will be a match to the "item" term that has the tid 1 instead of the tid 2 expected.
If we reference entities like medias, names are useless. Relying on entity ids is more logical and helps deduplicate the issue mentionned above.
We also need to support auto created entities like taxonomy terms. If the term is not known, do not throw the exception.