### PR TITLE
Allow link fields to have only URL

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/LinkHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/LinkHandler.php
@@ -16,13 +16,19 @@ class LinkHandler extends AbstractHandler {
       // 'options' is required to be an array, otherwise the utility class
       // Drupal\Core\Utility\UnroutedUrlAssembler::assemble() will complain.
       $options = array();
-      if (!empty($value[2])) {
-        parse_str($value[2], $options);
+      $title = NULL;
+      $uri = $value;
+      if (is_array($value)) {
+        $title = $value[0];
+        $uri = $value[1];
+        if (!empty($value[2])) {
+          parse_str($value[2], $options);
+        }
       }
       $return[] = array(
         'options' => $options,
-        'title' => $value[0],
-        'uri' => $value[1],
+        'title' => $title,
+        'uri' => $uri,
       );
     }
     return $return;


### PR DESCRIPTION
The current D8 LinkHandler assumes an array input, which makes testing with an empty link "title" field impossible. This PR tests the value first to see if it's an array. If not, it assumes the value is just the URL and to leave the other values out.