### PR TITLE
Node reference handler for Drupal7

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal7/NodereferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/NodereferenceHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\EntityReferenceGenerator\Driver\Field;
+namespace Drupal\Driver\Fields\Drupal7;
 
 use Drupal\Driver\Fields\FieldHandlerInterface;
 

--- a/src/Drupal/Driver/Fields/Drupal7/NodereferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/NodereferenceHandler.php
@@ -2,12 +2,11 @@
 
 namespace Drupal\Driver\Fields\Drupal7;
 
-use Drupal\Driver\Fields\FieldHandlerInterface;
-
 /**
  * Node reference field handler for Drupal 7.
  */
-class NodereferenceHandler implements FieldHandlerInterface {
+class NodereferenceHandler extends AbstractHandler {
+
   /**
    * {@inheritdoc}
    */

--- a/src/Drupal/Driver/Fields/Drupal7/NodereferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/NodereferenceHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\EntityReferenceGenerator\Driver\Field;
+
+use Drupal\Driver\Fields\FieldHandlerInterface;
+
+/**
+ * Node reference field handler for Drupal 7.
+ */
+class NodereferenceHandler implements FieldHandlerInterface {
+  /**
+   * {@inheritdoc}
+   */
+  public function expand($values) {
+    $entity_type = 'node';
+    $entity_info = entity_get_info($entity_type);
+    $return = array();
+    foreach ($values as $value) {
+      $nid = db_select($entity_info['base table'], 't')
+        ->fields('t', array($entity_info['entity keys']['id']))
+        ->condition('t.' . $entity_info['entity keys']['label'], $value)
+        ->execute()->fetchField();
+      if ($nid) {
+        $return[$this->language][] = array('nid' => $nid);
+      }
+    }
+
+    return $return;
+  }
+}


### PR DESCRIPTION
I have a situation where more than 20 sites use _references_ module.
I can't figure out how to make the Drupal driver use this code unless it is in the specific folder.
Would it be a bad idea to have this in the drupal driver codebase?