### PR TITLE
Allow newer phpspec version and allow failures on hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ php:
   - 7.2
   - hhvm
 
+matrix:
+  allow_failures:
+    # This is broken at this time due to a phpspec issue.
+    # @see https://github.com/jhedstrom/DrupalDriver/issues/172
+    - php: hhvm
+
 install:
   - composer install
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require-dev": {
     "drupal/coder": "~8.2.0",
-    "phpspec/phpspec": "~2.0",
+    "phpspec/phpspec": "~2.0 || ~4.0",
     "phpunit/phpunit": "~4.0",
     "mockery/mockery": "0.9.4",
     "drush-ops/behat-drush-endpoint": "*",


### PR DESCRIPTION
- Workaround for #172
