### PR TITLE
Drush entity support

### DIFF
--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -261,6 +261,25 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
+  public function createEntity($entity_type, $entity) {
+    $options = array(
+      'entity_type' => $entity_type,
+      'entity' => $entity,
+    )
+    $result = $this->drush('behat', array('create-entity', escapeshellarg(json_encode($options))), array());
+    return $this->decodeJsonObject($result);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function entityDelete($entity) {
+    $this->drush('behat', array('delete-entity', escapeshellarg(json_encode($entity))), array());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function createNode($node) {
     // Look up author by name.
     if (isset($node->author)) {

--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -261,11 +261,11 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function createEntity($entity_type, $entity) {
+  public function createEntity($entity_type, \StdClass $entity) {
     $options = array(
       'entity_type' => $entity_type,
       'entity' => $entity,
-    )
+    );
     $result = $this->drush('behat', array('create-entity', escapeshellarg(json_encode($options))), array());
     return $this->decodeJsonObject($result);
   }
@@ -273,8 +273,12 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function entityDelete($entity) {
-    $this->drush('behat', array('delete-entity', escapeshellarg(json_encode($entity))), array());
+  public function entityDelete($entity_type, \StdClass $entity) {
+    $options = array(
+      'entity_type' => $entity_type,
+      'entity' => $entity,
+    );
+    $this->drush('behat', array('delete-entity', escapeshellarg(json_encode($options))), array());
   }
 
   /**


### PR DESCRIPTION
This feature extends the Drush driver to support 'entity-create' and 'entity-delete' with the [drush behat endpoint](https://github.com/drush-ops/behat-drush-endpoint/pull/12).

It requires [PR #300](https://github.com/jhedstrom/drupalextension/pull/300/) to be applied to drupal/drupal-extension 