### PR TITLE
Adds field handler for address fields.

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/AddressHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/AddressHandler.php
@@ -60,4 +60,5 @@ class AddressHandler extends AbstractHandler {
     }
     return array($return);
   }
+
 }

--- a/src/Drupal/Driver/Fields/Drupal8/AddressHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/AddressHandler.php
@@ -5,33 +5,30 @@ namespace Drupal\Driver\Fields\Drupal8;
 /**
  * Address field handler for Drupal 8.
  */
-
-class AddressHandler extends AbstractHandler
-{
+class AddressHandler extends AbstractHandler {
 
   /**
    * {@inheritdoc}
    */
-  public function expand($values)
-  {
+  public function expand($values) {
     $return = array();
     $overrides = $this->fieldConfig->getSettings()['field_overrides'];
     $addressFields = array(
-        "given_name" => 1,
-        "additional_name" => 1,
-        "family_name" => 1,
-        "organization" => 1,
-        "address_line1" => 1,
-        "address_line2" => 1,
-        "postal_code" => 1,
-        "sorting_code" => 1,
-        "locality" => 1,
-        "administrative_area" => 1,
+      "given_name" => 1,
+      "additional_name" => 1,
+      "family_name" => 1,
+      "organization" => 1,
+      "address_line1" => 1,
+      "address_line2" => 1,
+      "postal_code" => 1,
+      "sorting_code" => 1,
+      "locality" => 1,
+      "administrative_area" => 1,
     );
     // Any overrides that set field inputs to hidden will be skipped.
     foreach ($overrides as $key => $value) {
       preg_match('/[A-Z]/', $key, $matches, PREG_OFFSET_CAPTURE);
-      if (sizeof($matches) > 0) {
+      if (count($matches) > 0) {
         $fieldName = strtolower(substr_replace($key, '_', $matches[0][1], 0));
       }
       else {
@@ -42,21 +39,23 @@ class AddressHandler extends AbstractHandler
       }
     }
     // The remaining field components will be populated in order, using values as they are
-    // ordered in feature step
+    // ordered in feature step.
     foreach ($values as $value) {
       $idx = 0;
       foreach ($addressFields as $k => $v) {
-        // If the values array contains only one item, assign it to the first field component and break
+        // If the values array contains only one item, assign it to the first
+        // field component and break.
         if (is_string($value)) {
           $return[$k] = $value;
           break;
         }
-        if ($idx < sizeof($value)) { // Gracefully handle users providing too few field components
+        if ($idx < count($value)) {
+          // Gracefully handle users providing too few field component values.
           $return[$k] = $value[$idx];
           $idx++;
         }
       }
-      // Set the country code to the first available as configured in this instance of the field
+      // Set the country code to the first available as configured in this instance of the field.
       $return['country_code'] = reset($this->fieldConfig->getSettings()['available_countries']);
     }
     return array($return);

--- a/src/Drupal/Driver/Fields/Drupal8/AddressHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/AddressHandler.php
@@ -38,8 +38,8 @@ class AddressHandler extends AbstractHandler {
         unset($addressFields[$fieldName]);
       }
     }
-    // The remaining field components will be populated in order, using values as they are
-    // ordered in feature step.
+    // The remaining field components will be populated in order, using
+    // values as they are ordered in feature step.
     foreach ($values as $value) {
       $idx = 0;
       foreach ($addressFields as $k => $v) {
@@ -55,7 +55,8 @@ class AddressHandler extends AbstractHandler {
           $idx++;
         }
       }
-      // Set the country code to the first available as configured in this instance of the field.
+      // Set the country code to the first available as configured in this
+      // instance of the field.
       $return['country_code'] = reset($this->fieldConfig->getSettings()['available_countries']);
     }
     return array($return);

--- a/src/Drupal/Driver/Fields/Drupal8/AddressHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/AddressHandler.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\Driver\Fields\Drupal8;
+
+/**
+ * Address field handler for Drupal 8.
+ */
+
+class AddressHandler extends AbstractHandler
+{
+
+  /**
+   * {@inheritdoc}
+   */
+  public function expand($values)
+  {
+    $return = array();
+    $overrides = $this->fieldConfig->getSettings()['field_overrides'];
+    $addressFields = array(
+        "given_name" => 1,
+        "additional_name" => 1,
+        "family_name" => 1,
+        "organization" => 1,
+        "address_line1" => 1,
+        "address_line2" => 1,
+        "postal_code" => 1,
+        "sorting_code" => 1,
+        "locality" => 1,
+        "administrative_area" => 1,
+    );
+    // Any overrides that set field inputs to hidden will be skipped.
+    foreach ($overrides as $key => $value) {
+      preg_match('/[A-Z]/', $key, $matches, PREG_OFFSET_CAPTURE);
+      if (sizeof($matches) > 0) {
+        $fieldName = strtolower(substr_replace($key, '_', $matches[0][1], 0));
+      }
+      else {
+        $fieldName = $key;
+      }
+      if ($value['override'] == 'hidden') {
+        unset($addressFields[$fieldName]);
+      }
+    }
+    // The remaining field components will be populated in order, using values as they are
+    // ordered in feature step
+    foreach ($values as $value) {
+      $idx = 0;
+      foreach ($addressFields as $k => $v) {
+        // If the values array contains only one item, assign it to the first field component and break
+        if (is_string($value)) {
+          $return[$k] = $value;
+          break;
+        }
+        if ($idx < sizeof($value)) { // Gracefully handle users providing too few field components
+          $return[$k] = $value[$idx];
+          $idx++;
+        }
+      }
+      // Set the country code to the first available as configured in this instance of the field
+      $return['country_code'] = reset($this->fieldConfig->getSettings()['available_countries']);
+    }
+    return array($return);
+  }
+}


### PR DESCRIPTION
Hello. I was recently writing Behat tests for content that includes an Address field (https://www.drupal.org/project/addressfield). Since there is no handler for this complex field type, I decided to spend some time and create one. I simply forked the repo and added the AddressHandler.php class after I did some thorough testing and inline documentation. Please let me know if there are any documentation files that I need to update or automated tests that are required to be created.

Best,
Jeff Schwartz