### PR TITLE
Fixing the ListTextHandler to allow a key to also be 0

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal7/ListTextHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/ListTextHandler.php
@@ -25,7 +25,8 @@ class ListTextHandler extends AbstractHandler {
       if (array_key_exists($value, $options)) {
         $allowed_values[$value] = $value;
       }
-      elseif ($key = array_search($value, $options)) {
+      elseif (in_array($value, $options)) {
+        $key = array_search($value, $options);
         $allowed_values[$value] = $key;
       }
     }


### PR DESCRIPTION
Hey there @jhedstrom,

With the current implementation, if the key of the option is 0, the `elseif` will evaluate to FALSE. 

This fix corrects the issue.