### PR TITLE
Added a method configGetOriginal which will return the original config data.

### DIFF
--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -210,6 +210,19 @@ interface CoreInterface {
   public function configGet($name, $key = '');
 
   /**
+   * Returns the original configuration item.
+   *
+   * @param string $name
+   *   The name of the configuration object to retrieve.
+   * @param string $key
+   *   A string that maps to a key within the configuration data.
+   *
+   * @return mixed
+   *   The original data that was requested.
+   */
+  public function configGetOriginal($name, $key = '');
+
+  /**
    * Sets a value in a configuration object.
    *
    * @param string $name

--- a/src/Drupal/Driver/Cores/Drupal6.php
+++ b/src/Drupal/Driver/Cores/Drupal6.php
@@ -495,8 +495,7 @@ class Drupal6 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
-  public function configGetOriginal($name, $key = '')
-  {
+  public function configGetOriginal($name, $key = '') {
     throw new \Exception('Getting original config is not yet implemented for Drupal 6.');
   }
 

--- a/src/Drupal/Driver/Cores/Drupal6.php
+++ b/src/Drupal/Driver/Cores/Drupal6.php
@@ -495,6 +495,14 @@ class Drupal6 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
+  public function configGetOriginal($name, $key = '')
+  {
+    throw new \Exception('Getting original config is not yet implemented for Drupal 6.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function configSet($name, $key, $value) {
     throw new \Exception('Setting config is not yet implemented for Drupal 6.');
   }

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -412,8 +412,7 @@ class Drupal7 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
-  public function configGetOriginal($name, $key = '')
-  {
+  public function configGetOriginal($name, $key = '') {
     throw new \Exception('Getting original config is not yet implemented for Drupal 7.');
   }
 

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -412,6 +412,14 @@ class Drupal7 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
+  public function configGetOriginal($name, $key = '')
+  {
+    throw new \Exception('Getting original config is not yet implemented for Drupal 7.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function configSet($name, $key, $value) {
     throw new \Exception('Setting config is not yet implemented for Drupal 7.');
   }

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -460,6 +460,13 @@ class Drupal8 extends AbstractCore {
   /**
    * {@inheritdoc}
    */
+  public function configGetOriginal($name, $key = '') {
+    return \Drupal::config($name)->getOriginal($key, FALSE);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function configSet($name, $key, $value) {
     \Drupal::configFactory()->getEditable($name)
       ->set($key, $value)


### PR DESCRIPTION
**Motivation**:
- DrupalDriver configGet() method which uses the Drupal "get" method to retrieve the configuration. The problem is that the latter takes override into account which means that when the Behat extension restores the config backups, it will save the override instead of the original config value.

By providing this method, when the Behat extension restores the config it will take the original data from configuration (eg.:settings.php).