### PR TITLE
Allow Symfony 4 as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
   ],
   "require": {
     "php": ">=5.6",
-    "symfony/process": "~2.5|~3.0",
-    "symfony/dependency-injection": "~2.6|~3.0",
+    "symfony/process": "~2.5|~3.0|~4.4",
+    "symfony/dependency-injection": "~2.6|~3.0|~4.4",
     "drupal/core-utility": "^8.4"
   },
   "require-dev": {


### PR DESCRIPTION
Requiring ~4.4 as that's what Drupal 9 requires anyway.