### PR TITLE
Support Drupal 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "php": ">=5.6",
     "symfony/process": "~2.5|~3.0|~4.4",
     "symfony/dependency-injection": "~2.6|~3.0|~4.4",
-    "drupal/core-utility": "^8.4"
+    "drupal/core-utility": "^8.4 || ^9"
   },
   "require-dev": {
     "drupal/coder": "~8.3.0",

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -15,7 +15,9 @@ use Drupal\taxonomy\Entity\Term;
 use Drupal\taxonomy\TermInterface;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
+use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Route;
 
 /**
  * Drupal 8 core.
@@ -51,7 +53,10 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
     $request = Request::createFromGlobals();
     $kernel = DrupalKernel::createFromRequest($request, $autoloader, 'prod');
     $kernel->boot();
-    $kernel->prepareLegacyRequest($request);
+    // A route is required for route matching.
+    $request->attributes->set(RouteObjectInterface::ROUTE_OBJECT, new Route('<none>'));
+    $request->attributes->set(RouteObjectInterface::ROUTE_NAME, '<none>');
+    $kernel->preHandle($request);
 
     // Initialise an anonymous session. required for the bootstrap.
     \Drupal::service('session_manager')->start();

--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -190,7 +190,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
       // Extract the major version from VERSION.
       $version_parts = explode('.', $version);
       if (is_numeric($version_parts[0])) {
-        $this->version = (integer) $version_parts[0];
+        $this->version = (integer) $version_parts[0] < 8 ? $version_parts[0] : 8;
       }
       else {
         throw new BootstrapException(sprintf('Unable to extract major Drupal core version from version string %s.', $version));


### PR DESCRIPTION
I'm not 100% sure, but considering how Drupal 9+ is expected to behave, this seems like a simple option.

Able to do some first tests against Drupal 9 with this.