### PR TITLE
Typo in ImageHandler.php

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/ImageHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/ImageHandler.php
@@ -3,7 +3,7 @@
 namespace Drupal\Driver\Fields\Drupal8;
 
 /**
- * Image field handler for Drupal 7.
+ * Image field handler for Drupal 8.
  */
 class ImageHandler extends AbstractHandler {
 


### PR DESCRIPTION
Hello, thanks for maintaining this project!

Just noticed what seems to be a good ol copy paste typo in the ImageHandler.php field. I am pretty sure it's not the Drupal 7 field handler that has been placed in the folder "Drupal8" :)

Thanks again!