### PR TITLE
Prevent PHP warning when creating a node with Drupal 7.79 and it's new field storage optimization

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -40,11 +40,6 @@ class Drupal7 extends AbstractCore {
    * {@inheritdoc}
    */
   public function nodeCreate($node) {
-    // Set original if not set.
-    if (!isset($node->original)) {
-      $node->original = clone $node;
-    }
-
     // Assign authorship if none exists and `author` is passed.
     if (!isset($node->uid) && !empty($node->author) && ($user = user_load_by_name($node->author))) {
       $node->uid = $user->uid;


### PR DESCRIPTION
Drupal 7.79 ([release notes](https://www.drupal.org/project/drupal/releases/7.79)) added a field storage optimization ([change record](https://www.drupal.org/node/3205293)) that can be enabled by setting a variable in the site's `settings.php`:

```
$conf['field_sql_storage_skip_writing_unchanged_fields'] = TRUE;
```

With this enabled, creating nodes in Behat with the Drupal extension, for example:

```
Given I am viewing my "page" with the title "A page"
```

... will lead to a PHP warning like this:

```
Warning: Invalid argument supplied for foreach() in /app/modules/field/modules/field_sql_storage/field_sql_storage.module line 462
```

This was discovered on a project which has Behat setup to treat PHP notices/warnings as test failures, so it's actually breaking the test suite in this case.

After digging into this, it seems the problem is that the new field storage optimization is comparing `$node` to `$node->original`, but `Drupal\Driver\Cores\Drupal7::nodeCreate()` is doing `$node->original = clone $node` **before** the fields are expanded by `$this->expandEntityFields()`. That means that `$node->original->body` contains a string, rather than an array is the proper format for a Drupal field, which leads to the PHP warning.

One possible solution would be to move the `$node->original = clone $node` after the `$this->expandEntityFields()` so that `$node->original->body` is expanded. However, in normal operation, Drupal doesn't set `$node->original` when creating a new node, only when updating an existing node. So, I don't this this actually needed at all, and this PR removes it.

This fixes the PHP warning in my testing.

