### PR TITLE
Fix for address fields when value is an associative array of address field keys

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/AddressHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/AddressHandler.php
@@ -49,6 +49,12 @@ class AddressHandler extends AbstractHandler {
           $return[$k] = $value;
           break;
         }
+        // If the value array contains keys for the address fields array, use
+        // the keyed value.
+        elseif (isset($value[$k])) {
+          $return[$k] = $value[$k];
+          continue;
+        }
         if ($idx < count($value)) {
           // Gracefully handle users providing too few field component values.
           $return[$k] = $value[$idx];


### PR DESCRIPTION
Having the same issue as #206 (Undefined offset 0) when trying to create nodes with address fields. The AddressHandler did expect keyed values matched the keys for the address field definition.

I tried the various [formats for address fields listed here](https://github.com/jhedstrom/drupalextension/blob/master/features/field_handlers.feature#L124), but none of them worked.

This change allows for the following formats:

```
Given location content:
  | title | field_address:address_line1 | :locality | :postal_code |
  | SC 1  | 1111 Main St                | My City1  |  11111       |
  | SC 2  | 1112 Main St                | My City2  |  11112       |

And location content:
  | title | field_address                                                         |
  | SC 3  | address_line1: 1113 Main St - locality: My City3 - postal_code: 11113 |
  | SC 4  | address_line1: 1114 Main St - locality: My City4 - postal_code: 11114 |
```