### PR TITLE
Add support for `og_standard_reference` field type of 'Organic Groups' contrib module

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/OgStandardReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/OgStandardReferenceHandler.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Driver\Fields\Drupal8;
+
+/**
+ * 'og_standard_reference' field handler for Drupal 8.
+ */
+class OgStandardReferenceHandler extends EntityReferenceHandler {
+}


### PR DESCRIPTION
We needed it in a client project to be able to build a hierarchical content structure in runtime. With this extra class in the namespace now Behat/Mink finds the correct handler to populate Organic Groups' entity reference field too. For example:

```gherkin
Given organization content:
  | title                 | status | og_audience           | author |
  | Top-level published   | 1      |                       | owner  |
  | Mid-level published   | 1      | Top-level published   | owner  |
  | Low-level published   | 1      | Mid-level published   | owner  |
  | Top-level unpublished | 0      |                       | owner  |
  | Mid-level unpublished | 0      | Top-level unpublished | owner  |
  | Low-level unpublished | 0      | Mid-level unpublished | owner  |
```