### PR TITLE
Allow Entity Reference Field Handler to Refernce by ID

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -15,6 +15,8 @@ class EntityReferenceHandler extends AbstractHandler {
     $entity_type_id = $this->fieldInfo->getSetting('target_type');
     $entity_definition = \Drupal::entityTypeManager()->getDefinition($entity_type_id);
 
+    $id_key = $entity_definition->getKey('id');
+
     // Determine label field key.
     if ($entity_type_id !== 'user') {
       $label_key = $entity_definition->getKey('label');
@@ -35,7 +37,11 @@ class EntityReferenceHandler extends AbstractHandler {
     }
 
     foreach ((array) $values as $value) {
-      $query = \Drupal::entityQuery($entity_type_id)->condition($label_key, $value);
+      $query = \Drupal::entityQuery($entity_type_id);
+      $or = $query->orConditionGroup();
+      $or->condition($id_key, $value)
+        ->condition($label_key, $value);
+      $query->condition($or);
       $query->accessCheck(FALSE);
       if ($target_bundles && $target_bundle_key) {
         $query->condition($target_bundle_key, $target_bundles, 'IN');


### PR DESCRIPTION
I'm using a fair amount of custom steps to handle complicated data setup within the tests, which I track and reference via https://packagist.org/packages/kerasai/behat-tokenizer.

This PR changes the D8+ entity reference field handler to find the referenced entity by label (existing functionality) or ID.