### PR TITLE
Support Coder 8.3.14

### DIFF
--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -5,6 +5,11 @@
     <description>DrupalDriver coding standard</description>
 
     <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal">
+        <!-- Ignore the requirement to use the null coalescing operator. This has been introduced in PHP 7.0 but we still support 5.6. -->
+        <exclude name="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator.NullCoalesceOperatorNotUsed" />
+
+        <!-- Ignore the requirement to use the shorthand list syntax. This has been introduced in PHP 7.1 but we still support 5.6. -->
+        <exclude name="SlevomatCodingStandard.PHP.ShortList.LongListUsed" />
     </rule>
 
     <!-- Core drivers need to set a server's remote address. -->


### PR DESCRIPTION
The latest 8.3.14 release of Coder has introduced some stricter coding standards checks and now requires the use of the null coalescing operator as well as the short list syntax. These are both only compatible with PHP 7, while we still support PHP 5.6.

This PR excludes these new rules so we can still offer PHP 5.6 compatibility for the time being.