### PR TITLE
Fixed compatibility with Symfony\Process v4+ for Drush driver.

### DIFF
--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -414,7 +414,7 @@ class DrushDriver extends BaseDriver {
     // Add any global arguments.
     $global = $this->getArguments();
 
-    $process = new Process("{$this->binary} {$alias} {$string_options} {$global} {$command} {$arguments}");
+    $process = Process::fromShellCommandline("{$this->binary} {$alias} {$string_options} {$global} {$command} {$arguments}");
     $process->setTimeout(3600);
     $process->run();
 


### PR DESCRIPTION
DrushDriver uses `Symfony\Process` to issue CLI commands. 

`Process` expects the first element to be an array. Since we are passing the Drush command with arguments as a string, it would be better to use `Process::fromShellCommandline()` instead of `new Process()` to make sure compatibility with different versions of `Symfony\Process`.

Without this change, drush steps are failing with Symfony v6