### PR TITLE
Allow reference field properties to be preserved after expanding the values.

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -33,14 +33,13 @@ class EntityReferenceHandler extends AbstractHandler {
       $target_bundle_key = $entity_definition->getKey('bundle');
     }
 
-
     // The values can either be a direct label reference or a complex array
     // containing multiple properties of the field. For example, the file field
     // contains a target_id, a description and a display property. If the
     // target_id exists as a property, we assume that the other properties are
     // also present. Retrieve all labels and load the entities.
     $main_property = $this->fieldInfo->getMainPropertyName();
-    $labels = array_map(function ($value) use ($main_property){
+    $labels = array_map(function ($value) use ($main_property) {
       return is_array($value) && isset($value[$main_property]) ? $value[$main_property] : $value;
     }, $values);
 

--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -33,13 +33,15 @@ class EntityReferenceHandler extends AbstractHandler {
       $target_bundle_key = $entity_definition->getKey('bundle');
     }
 
+
     // The values can either be a direct label reference or a complex array
     // containing multiple properties of the field. For example, the file field
     // contains a target_id, a description and a display property. If the
     // target_id exists as a property, we assume that the other properties are
     // also present. Retrieve all labels and load the entities.
-    $labels = array_map(function ($value) {
-      return is_array($value) && isset($value['target_id']) ? $value['target_id'] : $value;
+    $main_property = $this->fieldInfo->getMainPropertyName();
+    $labels = array_map(function ($value) use ($main_property){
+      return is_array($value) && isset($value[$main_property]) ? $value[$main_property] : $value;
     }, $values);
 
     foreach ((array) $labels as $index => $label) {
@@ -52,8 +54,8 @@ class EntityReferenceHandler extends AbstractHandler {
         $entity_id = array_shift($entities);
         // Replace the entity IDs in the original array so that other properties
         // are not lost.
-        if (is_array($values[$index]) && isset($values[$index]['target_id'])) {
-          $values[$index]['target_id'] = $entity_id;
+        if (is_array($values[$index]) && isset($values[$index][$main_property])) {
+          $values[$index][$main_property] = $entity_id;
         }
         else {
           $values[$index] = $entity_id;


### PR DESCRIPTION
### Problem description
I am having a file field which has the display field enabled. That means that when we create a new entity, we want to also be able to set the 'display' property of the field.
Now, we are using behat but we have arranged our code to reach the proper structure of the field in the `\Drupal\DrupalExtension\Context\RawDrupalContext::nodeCreate` where the values reach as
```
print_r($node->field_attachment);
Array
(
    [0] => Array
        (
            [target_id] => empty.rdf
            [display] => 1
        )

    [1] => empty_pdf.pdf
    [2] => invalid_adms.rdf
    [3] => test.zip
    [4] => text.pdf
)
```
One of the values is a multi column value and the rest are simple label references. Of course we take care of creating the files before hand.
However, when reaching `\Drupal\Driver\Fields\Drupal8\EntityReferenceHandler::expand` the entity query fails with the following error:
```
SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens: SELECT "base_table"."fid" AS "fid", "base_table"."fid" AS "base_table_fid"
FROM
"file_managed" "base_table"
INNER JOIN "file_managed" "file_managed" ON "file_managed"."fid" = "base_table"."fid"
WHERE "file_managed"."filename" = :db_condition_placeholder_0:db_condition_placeholder_1; Array
(
    [:db_condition_placeholder_0] => text.pdf
    [:db_condition_placeholder_1] => 1
)
```
because it simply passes the value in the query.

### Proposal
From what I see from the PHPDocBlocks, the `$values` array is supposed to be a field value array and the return is supposed to be a field value array as supposed to be retrieved by the field storage.
My assumption as such, is that we need to preserve the columns when querying the values and returning them. Thus, I propose to identify the `target_id` property - or any property used for the reference, and if present, extract the label for the entity instead of blindly passing the `$value` in the query.

Please, note that this means that we maintain the philosophy of the current functionality, that since the user passes a label as a value to get the entity, if they would like to use a more complex value, then the label would be passed in the reference property key. For example, if we have a reference to a node, the complex array would be
```
Array
(
    'target_id' => 'My node title'
)
```
and not
```
Array
(
   'title' => 'My node title'
)
```
At least that is how I see it.

### Remaining tasks
Tests?

