### PR TITLE
Fix 'id' not found

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -333,7 +333,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   public function termCreate(\stdClass $term) {
     $term->vid = $term->vocabulary_machine_name;
 
-    if (isset($term->parent)) {
+    if (!empty($term->parent)) {
       $query = \Drupal::entityQuery('taxonomy_term')
         ->accessCheck(FALSE)
         ->condition('id', $term->parent)


### PR DESCRIPTION
The following scenario results in an error `'id' not found (Drupal\Core\Entity\Query\QueryException)` on php 8.1:

```
    Given I am logged in as an "administrator"
    And "my_taxonomy" terms:
      | name | parent | description |
      | 123  |        | Description |
```

Instead of checking isset we should check if not empty
Or there should be a way to pass `NULL` in the NodeTable.