### PR TITLE
Broaden compatibility with symfony/process

### DIFF
--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -414,7 +414,8 @@ class DrushDriver extends BaseDriver {
     // Add any global arguments.
     $global = $this->getArguments();
 
-    $process = Process::fromShellCommandline("{$this->binary} {$alias} {$string_options} {$global} {$command} {$arguments}");
+    $cmd = "{$this->binary} {$alias} {$string_options} {$global} {$command} {$arguments}";
+    $process = method_exists(Process::class, 'fromShellCommandline') ? Process::fromShellCommandline($cmd) : new Process($cmd);
     $process->setTimeout(3600);
     $process->run();
 


### PR DESCRIPTION
Updates "Fixed compatibility with Symfony\Process v4+ for Drush driver. #251".

I don't know why, I can't explain it. A project has symfony/process 4.4.4, but still, does NOT have the method "fromShellCommandline".

I noticed that another part of symfony/console actually checks for this method to remain compatible, I guess?

Can do this so that the driver works everywhere?

```php
    $process = method_exists(Process::class, 'fromShellCommandline') ? Process::fromShellCommandline($cmd) : new Process($cmd);

```

https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Console/Helper/ProcessHelper.php#L57

