### PR TITLE
Restrict reference by ID to numeric values on integer fields

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -36,12 +36,18 @@ class EntityReferenceHandler extends AbstractHandler {
       $target_bundle_key = $entity_definition->getKey('bundle');
     }
 
+    // Determine the id key type (can be an integer or string).
+    $id_definition = \Drupal::service('entity_field.manager')->getBaseFieldDefinitions($entity_type_id)[$id_key];
+    $id_type = $id_definition->getType();
+
     foreach ((array) $values as $value) {
       $query = \Drupal::entityQuery($entity_type_id);
-      $or = $query->orConditionGroup();
-      $or->condition($id_key, $value)
-        ->condition($label_key, $value);
-      $query->condition($or);
+      // Provide for the use of numeric entity ids.
+      if ($id_type === 'integer' && is_numeric($value)) {
+        $query->condition($id_key, $value);
+      } else {
+        $query->condition($label_key, $value);
+      }
       $query->accessCheck(FALSE);
       if ($target_bundles && $target_bundle_key) {
         $query->condition($target_bundle_key, $target_bundles, 'IN');


### PR DESCRIPTION
#241 introduced regression when using entity labels with a postgres database

SQLSTATE[22P02]: Invalid text representation: 7
 ERROR: invalid input syntax for type bigint