### PR TITLE
Entity Reference field handler: restrict reference by ID only to integer field types and integer values

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -26,10 +26,6 @@ class EntityReferenceHandler extends AbstractHandler {
       $label_key = 'name';
     }
 
-    if (!$label_key && $entity_type_id == 'user') {
-      $label_key = 'name';
-    }
-
     // Determine target bundle restrictions.
     $target_bundle_key = NULL;
     if ($target_bundles = $this->getTargetBundles()) {

--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -36,12 +36,18 @@ class EntityReferenceHandler extends AbstractHandler {
       $target_bundle_key = $entity_definition->getKey('bundle');
     }
 
+    // Determine the id key type (can be an integer or string).
+    $id_definition = \Drupal::service('entity_field.manager')->getBaseFieldDefinitions($entity_type_id)[$id_key];
+    $id_type = $id_definition->getType();
+
     foreach ((array) $values as $value) {
       $query = \Drupal::entityQuery($entity_type_id);
-      $or = $query->orConditionGroup();
-      $or->condition($id_key, $value)
-        ->condition($label_key, $value);
-      $query->condition($or);
+      // Provide for the use of numeric entity ids.
+      if ($id_type === 'integer' && is_numeric($value)) {
+        $query->condition($id_key, $value);
+      } else {
+        $query->condition($label_key, $value);
+      }
       $query->accessCheck(FALSE);
       if ($target_bundles && $target_bundle_key) {
         $query->condition($target_bundle_key, $target_bundles, 'IN');

--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -43,9 +43,14 @@ class EntityReferenceHandler extends AbstractHandler {
     foreach ((array) $values as $value) {
       $query = \Drupal::entityQuery($entity_type_id);
       // Provide for the use of numeric entity ids.
-      if ($id_type === 'integer' && is_numeric($value)) {
-        $query->condition($id_key, $value);
-      } else {
+      if ($id_type === 'integer' && ctype_digit($value)) {
+        $or = $query->orConditionGroup();
+        $or
+          ->condition($id_key, $value)
+          ->condition($label_key, $value);
+        $query->condition($or);
+      }
+      else {
         $query->condition($label_key, $value);
       }
       $query->accessCheck(FALSE);


### PR DESCRIPTION
This resolves regression introduced by PR #241. It builds on the PR #280 but introduces some improvements:
1. It ensures value must be positive integer (decimal numbers are not accepted). 
2. It partially restores logic that was introduced in #241 but removed in #280:  It supports finding the referenced entity by label or by ID but only when that makes sense.

In addition I also removed redundant `if` code block. Condition in that block is already covered by `else` section of the previous `if` block.

Resolves #278 
