### PR TITLE
Do not process empty batches.

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -196,9 +196,10 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
    */
   public function processBatch() {
     $this->validateDrupalSite();
-    $batch =& batch_get();
-    $batch['progressive'] = FALSE;
-    batch_process();
+    if ($batch =& batch_get()) {
+      $batch['progressive'] = FALSE;
+      batch_process();
+    }
   }
 
   /**


### PR DESCRIPTION
Hi @jhedstrom 
I have had a weird issue with one of my behat test so before anything, this can be fixed by filtering users anew at https://github.com/jhedstrom/drupalextension/blob/main/src/Drupal/DrupalExtension/Context/RawDrupalContext.php#L266 before we call for the process batch.

I managed to reproduce it in behat by simply creating a basic test 
```
@api
Feature: Ensure user cancellation is not breaking behat.

  Scenario: User cancels the account
    Given users:
      | name | pass |
      | test | test |
    Given I delete the user "test"
```

What happens, is that the `cleanUsers` tries to clean users by calling `user_cancel`. In `/core/modules/user/user.module:614` of Drupal, a check occurs for whether the user actually exists and just throws an error that we are trying to delete a user that does not exist.

However, in `RawDrupalContext`, the `::processCallback` is called and the `Drupal8` driver just does
```
public function processBatch() {
    $this->validateDrupalSite();
    $batch =& batch_get();
    $batch['progressive'] = FALSE;
    batch_process();
  }
```

Because the batch from `batch_get` is returned empty, the progressive key is added to an empty array and the process is called. Then the batch fails with an error `Warning: Undefined array key "sets" in /var/www/html/web/core/includes/form.inc line 925` and the behat test partially succeeds. 

As said above, this can be fixed here with this PR, or in `RawDrupalContext` from drupalextension or in both. 