### PR TITLE
fix(php): Fix PHP 8.4 nullable types warnings

### DIFF
--- a/src/Drupal/Driver/Cores/AbstractCore.php
+++ b/src/Drupal/Driver/Cores/AbstractCore.php
@@ -34,7 +34,7 @@ abstract class AbstractCore implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function __construct($drupal_root, $uri = 'default', Random $random = NULL) {
+  public function __construct($drupal_root, $uri = 'default', ?Random $random = NULL) {
     $this->drupalRoot = realpath($drupal_root);
     $this->uri = $uri;
     if (!isset($random)) {

--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -19,7 +19,7 @@ interface CoreInterface {
    * @param \Drupal\Component\Utility\Random $random
    *   Random string generator.
    */
-  public function __construct($drupal_root, $uri = 'default', Random $random = NULL);
+  public function __construct($drupal_root, $uri = 'default', ?Random $random = NULL);
 
   /**
    * Return random generator.

--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -78,7 +78,7 @@ class DrushDriver extends BaseDriver {
    * @throws \Drupal\Driver\Exception\BootstrapException
    *   Thrown when a required parameter is missing.
    */
-  public function __construct($alias = NULL, $root_path = NULL, $binary = 'drush', Random $random = NULL) {
+  public function __construct($alias = NULL, $root_path = NULL, $binary = 'drush', ?Random $random = NULL) {
     if (!empty($alias)) {
       // Trim off the '@' symbol if it has been added.
       $alias = ltrim($alias, '@');

--- a/src/Drupal/Driver/Exception/BootstrapException.php
+++ b/src/Drupal/Driver/Exception/BootstrapException.php
@@ -17,7 +17,7 @@ class BootstrapException extends Exception {
    * @param \Exception $previous
    *   Optional previous exception that was thrown.
    */
-  public function __construct($message, $code = 0, \Exception $previous = NULL) {
+  public function __construct($message, $code = 0, ?\Exception $previous = NULL) {
     parent::__construct($message, NULL, $code, $previous);
   }
 

--- a/src/Drupal/Driver/Exception/Exception.php
+++ b/src/Drupal/Driver/Exception/Exception.php
@@ -28,7 +28,7 @@ abstract class Exception extends \Exception {
    * @param \Exception $previous
    *   Optional previous exception that was thrown.
    */
-  public function __construct($message, DriverInterface $driver = NULL, $code = 0, \Exception $previous = NULL) {
+  public function __construct($message, ?DriverInterface $driver = NULL, $code = 0, ?\Exception $previous = NULL) {
     $this->driver = $driver;
 
     parent::__construct($message, $code, $previous);

--- a/src/Drupal/Driver/Exception/UnsupportedDriverActionException.php
+++ b/src/Drupal/Driver/Exception/UnsupportedDriverActionException.php
@@ -21,7 +21,7 @@ class UnsupportedDriverActionException extends Exception {
    * @param \Exception $previous
    *   Previous exception.
    */
-  public function __construct($template, DriverInterface $driver, $code = 0, \Exception $previous = NULL) {
+  public function __construct($template, DriverInterface $driver, $code = 0, ?\Exception $previous = NULL) {
     $message = sprintf($template, get_class($driver));
 
     parent::__construct($message, $driver, $code, $previous);


### PR DESCRIPTION
Deprecated: Drupal\Driver\DrushDriver::__construct(): Implicitly marking parameter $random as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/backend/vendor/drupal/drupal-driver/src/Drupal/Driver/DrushDriver.php on line 81

Automatically generated with:
```
~/workspace/php-cs-fixer/vendor/bin/php-cs-fixer fix . --rules=nullable_type_declaration_for_default_null_value
```