### PR TITLE
Fixed `isLegacyDrush()` misdetecting Drush 12+ as legacy on PHP 8.4.

### DIFF
--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -135,7 +135,16 @@ class DrushDriver extends BaseDriver {
   protected function isLegacyDrush() {
     try {
       // Try for a drush 9 version.
-      $version = trim($this->drush('version', [], ['format' => 'string']));
+      $output = trim($this->drush('version', [], ['format' => 'string']));
+      // On PHP 8.4, deprecation warnings from Drush dependencies may be
+      // written to stdout before the version string. Extract the actual
+      // version number from the output to avoid misdetection.
+      if (preg_match('/(\d+\.\d+\.\d+(\.\d+)?)\s*$/', $output, $matches)) {
+        $version = $matches[1];
+      }
+      else {
+        $version = $output;
+      }
       return version_compare($version, '9', '<=');
     }
     catch (\RuntimeException $e) {

--- a/tests/Drupal/Tests/Driver/DrushDriverTest.php
+++ b/tests/Drupal/Tests/Driver/DrushDriverTest.php
@@ -45,4 +45,76 @@ class DrushDriverTest extends TestCase {
     new DrushDriver('', '');
   }
 
+  /**
+   * Tests `isLegacyDrush()` correctly detects version from noisy output.
+   *
+   * @dataProvider dataProviderIsLegacyDrush
+   */
+  public function testIsLegacyDrush($drush_output, $expected) {
+    $driver = new TestDrushDriver('alias');
+    $driver->drushOutput = $drush_output;
+    $result = $driver->callIsLegacyDrush();
+    $this->assertSame($expected, $result);
+  }
+
+  /**
+   * Data provider for testIsLegacyDrush().
+   */
+  public function dataProviderIsLegacyDrush() {
+    return [
+      'clean modern version' => [
+        "12.5.2.0\n",
+        FALSE,
+      ],
+      'deprecation warnings before version' => [
+        "Deprecated: Drush\\Drush::shell(): Implicitly marking parameter \$env as nullable\nDeprecated: Consolidation\\Config\\Config::__construct(): ...\n12.5.2.0\n",
+        FALSE,
+      ],
+      'drush 9 version' => [
+        "9.7.2\n",
+        FALSE,
+      ],
+      'legacy drush version' => [
+        "8.4.12\n",
+        TRUE,
+      ],
+      'legacy version with noise' => [
+        "Some warning output\n8.1.0\n",
+        TRUE,
+      ],
+      'three-part modern version' => [
+        "13.0.0\n",
+        FALSE,
+      ],
+    ];
+  }
+
+}
+
+/**
+ * Testable subclass that stubs the `drush()` method.
+ */
+class TestDrushDriver extends DrushDriver {
+
+  /**
+   * The output to return from `drush()`.
+   *
+   * @var string
+   */
+  public $drushOutput = '';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function drush($command, array $arguments = [], array $options = []) {
+    return $this->drushOutput;
+  }
+
+  /**
+   * Exposes `isLegacyDrush()` for testing.
+   */
+  public function callIsLegacyDrush() {
+    return $this->isLegacyDrush();
+  }
+
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Drush version detection to handle PHP 8.4 deprecation warnings by extracting semantic versions from noisy output.

* **Tests**
  * Added comprehensive test coverage for version detection with various output formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->