### PR TITLE
Refreshed REQUEST_TIME before cron run to prevent stale timestamps.

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -120,6 +120,8 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
    * {@inheritdoc}
    */
   public function runCron() {
+    $_SERVER['REQUEST_TIME'] = time();
+    \Drupal::request()->server->set('REQUEST_TIME', $_SERVER['REQUEST_TIME']);
     return \Drupal::service('cron')->run();
   }
 

--- a/tests/Drupal/Tests/Driver/Drupal8Test.php
+++ b/tests/Drupal/Tests/Driver/Drupal8Test.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\Tests\Driver;
+
+use Drupal;
+use Drupal\Core\CronInterface;
+use Drupal\Driver\Cores\Drupal8;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Tests for the Drupal 8+ core driver.
+ */
+class Drupal8Test extends TestCase {
+
+  /**
+   * The original REQUEST_TIME value.
+   *
+   * @var int
+   */
+  protected $originalRequestTime;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->originalRequestTime = $_SERVER['REQUEST_TIME'] ?? NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    if ($this->originalRequestTime !== NULL) {
+      $_SERVER['REQUEST_TIME'] = $this->originalRequestTime;
+    }
+    parent::tearDown();
+  }
+
+  /**
+   * Tests that `runCron()` refreshes `REQUEST_TIME` before running cron.
+   */
+  public function testRunCronRefreshesRequestTime() {
+    $before = time();
+    $stale_time = $before - 60;
+
+    // Create a real Symfony Request with a stale REQUEST_TIME.
+    $request = new Request();
+    $request->server->set('REQUEST_TIME', $stale_time);
+    $_SERVER['REQUEST_TIME'] = $stale_time;
+
+    // Mock the cron service.
+    $cron = $this->createMock(CronInterface::class);
+    $cron->method('run')->willReturn(TRUE);
+
+    // Wire a container with request_stack and cron service.
+    $request_stack = new RequestStack();
+    $request_stack->push($request);
+    $container = new ContainerBuilder();
+    $container->set('request_stack', $request_stack);
+    $container->set('cron', $cron);
+    Drupal::setContainer($container);
+
+    // Use __DIR__ as a dummy drupal root (runCron does not use it).
+    $core = new Drupal8(__DIR__, 'default');
+    $result = $core->runCron();
+
+    $this->assertTrue($result);
+    $this->assertGreaterThanOrEqual($before, $_SERVER['REQUEST_TIME'], '$_SERVER[REQUEST_TIME] was not refreshed.');
+    $this->assertGreaterThanOrEqual($before, $request->server->get('REQUEST_TIME'), 'Request server bag REQUEST_TIME was not refreshed.');
+  }
+
+}


### PR DESCRIPTION
Related to https://github.com/jhedstrom/drupalextension/issues/179

## Summary

When Behat scenarios run multiple cron invocations in a single test suite, `REQUEST_TIME` retains the value captured at PHP boot, causing Drupal's cron system to see a stale timestamp. This fix refreshes both `$_SERVER['REQUEST_TIME']` and the Symfony `Request` server bag immediately before `cron->run()` is called, ensuring each cron run sees the actual current time.

## Changes

**`src/Drupal/Driver/Cores/Drupal8.php`**
- In `runCron()`, set `$_SERVER['REQUEST_TIME']` to `time()` and sync it into `\Drupal::request()->server` before delegating to the cron service.

**`tests/Drupal/Tests/Driver/Drupal8Test.php`** (new file)
- Added `Drupal8Test` unit test class covering the `runCron()` refresh behaviour.
- Seeds a stale `REQUEST_TIME` (60 seconds in the past) on both `$_SERVER` and a real Symfony `Request`, then asserts both are updated to `>= $before` after `runCron()` returns.
- Uses `setUp`/`tearDown` to restore the original `REQUEST_TIME` so it does not leak between tests.

## Before / After

```
Before
──────────────────────────────────────────────────────
  Behat boot
  │
  ├─ $_SERVER['REQUEST_TIME'] = T0  (set once at boot)
  │
  ├─ runCron() call #1  (T0 + 30s elapsed)
  │   └─ cron->run()   ← sees REQUEST_TIME = T0  ✓
  │
  └─ runCron() call #2  (T0 + 90s elapsed)
      └─ cron->run()   ← still sees REQUEST_TIME = T0  ✗ stale!

After
──────────────────────────────────────────────────────
  Behat boot
  │
  ├─ $_SERVER['REQUEST_TIME'] = T0  (set once at boot)
  │
  ├─ runCron() call #1  (T0 + 30s elapsed)
  │   ├─ $_SERVER['REQUEST_TIME']      = time()  → T0+30
  │   ├─ Request->server['REQUEST_TIME'] = time()  → T0+30
  │   └─ cron->run()   ← sees REQUEST_TIME = T0+30  ✓
  │
  └─ runCron() call #2  (T0 + 90s elapsed)
      ├─ $_SERVER['REQUEST_TIME']      = time()  → T0+90
      ├─ Request->server['REQUEST_TIME'] = time()  → T0+90
      └─ cron->run()   ← sees REQUEST_TIME = T0+90  ✓ fresh!
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved REQUEST_TIME handling during cron execution to ensure consistent timing initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->