### PR TITLE
[#787] Fixed `isBaseField()` to include computed base fields.

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -405,9 +405,11 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
    */
   public function getEntityFieldTypes($entity_type, array $base_fields = []) {
     $return = [];
-    /** @var \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager */
-    $entity_field_manager = \Drupal::service('entity_field.manager');
+    $entity_field_manager = $this->getEntityFieldManager();
     $fields = $entity_field_manager->getFieldStorageDefinitions($entity_type);
+    if (!empty($base_fields)) {
+      $fields += $entity_field_manager->getBaseFieldDefinitions($entity_type);
+    }
     foreach ($fields as $field_name => $field) {
       if ($this->isField($entity_type, $field_name)
         || (in_array($field_name, $base_fields) && $this->isBaseField($entity_type, $field_name))) {
@@ -421,9 +423,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
    * {@inheritdoc}
    */
   public function isField($entity_type, $field_name) {
-    /** @var \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager */
-    $entity_field_manager = \Drupal::service('entity_field.manager');
-    $fields = $entity_field_manager->getFieldStorageDefinitions($entity_type);
+    $fields = $this->getEntityFieldManager()->getFieldStorageDefinitions($entity_type);
     return (isset($fields[$field_name]) && $fields[$field_name] instanceof FieldStorageConfig);
   }
 
@@ -431,10 +431,18 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
    * {@inheritdoc}
    */
   public function isBaseField($entity_type, $field_name) {
-    /** @var \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager */
-    $entity_field_manager = \Drupal::service('entity_field.manager');
-    $fields = $entity_field_manager->getFieldStorageDefinitions($entity_type);
-    return (isset($fields[$field_name]) && $fields[$field_name] instanceof BaseFieldDefinition);
+    $base_fields = $this->getEntityFieldManager()->getBaseFieldDefinitions($entity_type);
+    return isset($base_fields[$field_name]);
+  }
+
+  /**
+   * Returns the entity field manager service.
+   *
+   * @return \Drupal\Core\Entity\EntityFieldManagerInterface
+   *   The entity field manager.
+   */
+  protected function getEntityFieldManager() {
+    return \Drupal::service('entity_field.manager');
   }
 
   /**

--- a/tests/Drupal/Tests/Driver/Drupal8FieldMethodsTest.php
+++ b/tests/Drupal/Tests/Driver/Drupal8FieldMethodsTest.php
@@ -1,0 +1,211 @@
+<?php
+
+// Define a stub FieldStorageConfig in the correct namespace so that
+// instanceof checks in Drupal8::isField() work without a full Drupal bootstrap.
+// This must be declared before any class that references it.
+// phpcs:disable
+namespace Drupal\field\Entity {
+  if (!class_exists('Drupal\field\Entity\FieldStorageConfig')) {
+    class FieldStorageConfig {
+      protected $type;
+      public function __construct(string $type) { $this->type = $type; }
+      public function getType() { return $this->type; }
+    }
+  }
+}
+// phpcs:enable
+
+namespace Drupal\Tests\Driver {
+
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Driver\Cores\Drupal8;
+use Drupal\field\Entity\FieldStorageConfig;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for Drupal8 field methods: isBaseField(), isField(), getEntityFieldTypes().
+ */
+class Drupal8FieldMethodsTest extends TestCase {
+
+  /**
+   * Tests that 'isBaseField()' correctly identifies base fields.
+   *
+   * @param string $field_name
+   *   The field name to check.
+   * @param bool $expected
+   *   The expected result.
+   *
+   * @dataProvider dataProviderIsBaseField
+   */
+  public function testIsBaseField($field_name, $expected) {
+    $core = $this->createTestCore();
+    $this->assertSame($expected, $core->isBaseField('node', $field_name));
+  }
+
+  /**
+   * Data provider for testIsBaseField().
+   */
+  public function dataProviderIsBaseField() {
+    return [
+      'non-computed base field' => ['title', TRUE],
+      'computed base field' => ['moderation_state', TRUE],
+      'configurable field' => ['field_tags', FALSE],
+      'unknown field' => ['nonexistent', FALSE],
+    ];
+  }
+
+  /**
+   * Tests that 'isField()' correctly identifies configurable fields.
+   *
+   * @param string $field_name
+   *   The field name to check.
+   * @param bool $expected
+   *   The expected result.
+   *
+   * @dataProvider dataProviderIsField
+   */
+  public function testIsField($field_name, $expected) {
+    $core = $this->createTestCore();
+    $this->assertSame($expected, $core->isField('node', $field_name));
+  }
+
+  /**
+   * Data provider for testIsField().
+   */
+  public function dataProviderIsField() {
+    return [
+      'configurable field' => ['field_tags', TRUE],
+      'non-computed base field' => ['title', FALSE],
+      'computed base field' => ['moderation_state', FALSE],
+      'unknown field' => ['nonexistent', FALSE],
+    ];
+  }
+
+  /**
+   * Tests that 'getEntityFieldTypes()' includes computed base fields.
+   *
+   * @param array $base_fields_arg
+   *   The $base_fields argument to pass.
+   * @param array $expected_fields
+   *   The expected field names in the result.
+   * @param array $unexpected_fields
+   *   Field names that should NOT be in the result.
+   *
+   * @dataProvider dataProviderGetEntityFieldTypes
+   */
+  public function testGetEntityFieldTypes(array $base_fields_arg, array $expected_fields, array $unexpected_fields) {
+    $core = $this->createTestCore();
+    $result = $core->getEntityFieldTypes('node', $base_fields_arg);
+
+    foreach ($expected_fields as $field_name) {
+      $this->assertArrayHasKey($field_name, $result, "Expected '$field_name' in result.");
+    }
+    foreach ($unexpected_fields as $field_name) {
+      $this->assertArrayNotHasKey($field_name, $result, "Did not expect '$field_name' in result.");
+    }
+  }
+
+  /**
+   * Data provider for testGetEntityFieldTypes().
+   */
+  public function dataProviderGetEntityFieldTypes() {
+    return [
+      'no base fields requested' => [
+        [],
+        ['field_tags'],
+        ['title', 'moderation_state'],
+      ],
+      'non-computed base field requested' => [
+        ['title'],
+        ['field_tags', 'title'],
+        ['moderation_state'],
+      ],
+      'computed base field requested' => [
+        ['moderation_state'],
+        ['field_tags', 'moderation_state'],
+        ['title'],
+      ],
+      'multiple base fields requested' => [
+        ['title', 'moderation_state'],
+        ['field_tags', 'title', 'moderation_state'],
+        [],
+      ],
+    ];
+  }
+
+  /**
+   * Creates a TestDrupal8Core with mocked entity field manager.
+   *
+   * @return \Drupal\Tests\Driver\TestDrupal8Core
+   *   The test core instance.
+   */
+  protected function createTestCore() {
+    // Non-computed base field.
+    $title_field = $this->createMock(BaseFieldDefinition::class);
+    $title_field->method('getType')->willReturn('string');
+
+    // Computed base field (not in getFieldStorageDefinitions).
+    $moderation_state_field = $this->createMock(BaseFieldDefinition::class);
+    $moderation_state_field->method('getType')->willReturn('string');
+
+    // Configurable field — use stub that passes instanceof FieldStorageConfig.
+    $field_tags = new FieldStorageConfig('entity_reference');
+
+    $entity_field_manager = $this->createMock(EntityFieldManagerInterface::class);
+
+    // getFieldStorageDefinitions: returns non-computed base fields + configurable fields.
+    $entity_field_manager->method('getFieldStorageDefinitions')
+      ->with('node')
+      ->willReturn([
+        'title' => $title_field,
+        'field_tags' => $field_tags,
+      ]);
+
+    // getBaseFieldDefinitions: returns ALL base fields (computed + non-computed).
+    $entity_field_manager->method('getBaseFieldDefinitions')
+      ->with('node')
+      ->willReturn([
+        'title' => $title_field,
+        'moderation_state' => $moderation_state_field,
+      ]);
+
+    $core = new TestDrupal8Core(__DIR__, 'default');
+    $core->setEntityFieldManager($entity_field_manager);
+    return $core;
+  }
+
+}
+
+/**
+ * Testable subclass that overrides 'getEntityFieldManager()'.
+ */
+class TestDrupal8Core extends Drupal8 {
+
+  /**
+   * The mock entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
+   * Sets the mock entity field manager.
+   *
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
+   *   The mock entity field manager.
+   */
+  public function setEntityFieldManager(EntityFieldManagerInterface $entity_field_manager) {
+    $this->entityFieldManager = $entity_field_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEntityFieldManager() {
+    return $this->entityFieldManager;
+  }
+
+}
+
+}


### PR DESCRIPTION
Relates to https://github.com/jhedstrom/drupalextension/issues/787

## Summary

`isBaseField()` previously used `getFieldStorageDefinitions()` to look up base fields, which only returns base fields that have field storage (i.e. non-computed ones). Computed base fields — such as `moderation_state` provided by the Content Moderation module — are returned only by `getBaseFieldDefinitions()` and were therefore silently excluded, causing them to be ignored when creating entities.

The fix switches `isBaseField()` to use `getBaseFieldDefinitions()` directly. `getEntityFieldTypes()` is also updated to merge base field definitions into the field list when `$base_fields` is non-empty, ensuring computed base fields can be resolved to their type. Both `isField()` and `getEntityFieldTypes()` are refactored to use a new protected `getEntityFieldManager()` helper, which removes duplicated `\Drupal::service()` calls and makes the class more testable.

## Changes

**`src/Drupal/Driver/Cores/Drupal8.php`**
- `isBaseField()`: switched from `getFieldStorageDefinitions()` to `getBaseFieldDefinitions()` so computed base fields are recognised.
- `getEntityFieldTypes()`: merges `getBaseFieldDefinitions()` into the field list when `$base_fields` is non-empty, allowing computed base fields to be included in the result.
- Extracted `getEntityFieldManager()` protected helper — replaces three inline `\Drupal::service('entity_field.manager')` calls and enables unit testing without a full Drupal bootstrap.

**`tests/Drupal/Tests/Driver/Drupal8FieldMethodsTest.php`** (new)
- Unit tests covering `isBaseField()`, `isField()`, and `getEntityFieldTypes()` with data providers.
- Uses a `TestDrupal8Core` subclass that injects a mock `EntityFieldManagerInterface`, avoiding a full Drupal bootstrap.
- Includes a namespace-isolated `FieldStorageConfig` stub to satisfy `instanceof` checks.

## Before / After

```
Before — isBaseField() lookup:
  getFieldStorageDefinitions()
    ├── title             (BaseFieldDefinition) ✓ found
    ├── field_tags        (FieldStorageConfig)  — skipped
    └── [moderation_state MISSING — computed, no storage]  ✗ not found

After — isBaseField() lookup:
  getBaseFieldDefinitions()
    ├── title             ✓ found
    └── moderation_state  ✓ found  ← previously missed
```

```
Before — getEntityFieldTypes() with $base_fields = ['moderation_state']:
  fields = getFieldStorageDefinitions()  → {title, field_tags}
  isBaseField('moderation_state') → FALSE (not in storage defs)
  result → {field_tags}  ← moderation_state absent

After — getEntityFieldTypes() with $base_fields = ['moderation_state']:
  fields = getFieldStorageDefinitions() + getBaseFieldDefinitions()
         → {title, field_tags, moderation_state}
  isBaseField('moderation_state') → TRUE
  result → {field_tags, moderation_state}  ← now included
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for field methods, validating field detection, field type retrieval, and proper handling of base fields, configurable fields, and computed field scenarios.

* **Refactor**
  * Improved field management access patterns and enhanced field definition consolidation logic to better recognize the full set of available fields and improve overall code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->