### PR TITLE
PostgreSQL crashes when trying to look up an entity reference field t…

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -39,8 +39,9 @@ class EntityReferenceHandler extends AbstractHandler {
     foreach ((array) $values as $value) {
       $query = \Drupal::entityQuery($entity_type_id);
       $or = $query->orConditionGroup();
-      if ((int) $value == $value && $value !== '') {
-        $or->condition($id_key, $value);
+      $is_numeric_id = is_int($value) || (is_string($value) && ctype_digit($value));
+      if ($is_numeric_id) {
+        $or->condition($id_key, (int) $value);
       }
       $or->condition($label_key, $value);
       $query->condition($or);

--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -39,8 +39,10 @@ class EntityReferenceHandler extends AbstractHandler {
     foreach ((array) $values as $value) {
       $query = \Drupal::entityQuery($entity_type_id);
       $or = $query->orConditionGroup();
-      $or->condition($id_key, $value)
-        ->condition($label_key, $value);
+      if ((int) $value == $value && $value !== '') {
+        $or->condition($id_key, $value);
+      }
+      $or->condition($label_key, $value);
       $query->condition($or);
       $query->accessCheck(FALSE);
       if ($target_bundles && $target_bundle_key) {


### PR DESCRIPTION
…hat's connected using a string/title (the query tries to select a string from an integer field)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved entity-reference field filtering: queries no longer attempt ID-based matches for non-numeric inputs, while still matching by label. This reduces incorrect matches and improves accuracy when selecting referenced items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->