### PR TITLE
Added 'TimeHandler' for the 'time_field' contrib module.

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/TimeHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/TimeHandler.php
@@ -20,7 +20,7 @@ class TimeHandler extends AbstractHandler {
 
       // Support anything that can be passed to strtotime.
       $midnight = strtotime('today midnight');
-      return strtotime($value) - $midnight;;
+      return strtotime($value) - $midnight;
     }, $values);
 
     return $values;

--- a/src/Drupal/Driver/Fields/Drupal8/TimeHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/TimeHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\Driver\Fields\Drupal8;
+
+/**
+ * Time field handler for Drupal 8.
+ */
+class TimeHandler extends AbstractHandler {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function expand($values) {
+    $values = array_map(function ($value) {
+      // Value is numeric so it is safe to assume we have the seconds passed in
+      // the storage format (seconds past midnight).
+      if (is_numeric($value)) {
+        return $value;
+      }
+
+      // Support anything that can be passed to strtotime.
+      $midnight = strtotime('today midnight');
+      return strtotime($value) - $midnight;;
+    }, $values);
+
+    return $values;
+  }
+}

--- a/tests/Drupal/Tests/Driver/TimeHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/TimeHandlerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Drupal\Tests\Driver;
+
+use Drupal\Driver\Fields\Drupal8\TimeHandler;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the TimeHandler field handler.
+ */
+class TimeHandlerTest extends TestCase {
+
+  /**
+   * Tests time field expansion.
+   *
+   * @param array $input
+   *   The input values to expand.
+   * @param array $expected
+   *   The expected expanded values.
+   *
+   * @dataProvider dataProviderExpand
+   */
+  public function testExpand(array $input, array $expected) {
+    $handler = $this->createHandler();
+    $result = $handler->expand($input);
+    $this->assertSame($expected, $result);
+  }
+
+  /**
+   * Data provider for testExpand().
+   */
+  public function dataProviderExpand() {
+    // Seconds past midnight for known times.
+    // 9:30 AM = 9*3600 + 30*60 = 34200.
+    // 2:15:30 PM = 14*3600 + 15*60 + 30 = 51330.
+    // Midnight = 0.
+    $midnight = strtotime('today midnight');
+
+    return [
+      'numeric integer passthrough' => [
+        [34200],
+        [34200],
+      ],
+      'numeric string passthrough' => [
+        ['34200'],
+        ['34200'],
+      ],
+      'time string 9:30 AM' => [
+        ['9:30 AM'],
+        [strtotime('9:30 AM') - $midnight],
+      ],
+      'time string 14:15:30' => [
+        ['14:15:30'],
+        [strtotime('14:15:30') - $midnight],
+      ],
+      'time string midnight' => [
+        ['midnight'],
+        [0],
+      ],
+      'multiple mixed values' => [
+        [3600, '9:30 AM', '0'],
+        [3600, strtotime('9:30 AM') - $midnight, '0'],
+      ],
+    ];
+  }
+
+  /**
+   * Creates a TimeHandler instance that bypasses the parent constructor.
+   *
+   * @return \Drupal\Driver\Fields\Drupal8\TimeHandler
+   *   The handler instance.
+   */
+  protected function createHandler() {
+    // Use reflection to bypass AbstractHandler constructor which requires
+    // a full Drupal bootstrap.
+    $reflection = new \ReflectionClass(TimeHandler::class);
+    return $reflection->newInstanceWithoutConstructor();
+  }
+
+}


### PR DESCRIPTION
> Iterates on #296 by @ericgsmith. Thank you for the contribution!

## Summary

- Added `TimeHandler` for the `time_field` Drupal contrib module, supporting both numeric (seconds past midnight) and string time values (anything accepted by `strtotime`)
- Fixed a double semicolon typo in the handler's `expand()` method
- Added comprehensive PHPUnit tests with 6 data-provider cases covering numeric passthrough, string time parsing, midnight, and mixed input

## Changes

**`src/Drupal/Driver/Fields/Drupal8/TimeHandler.php`** (new)

A Drupal 8 field handler for `time_field` module values. The `expand()` method accepts either a numeric value (treated as seconds past midnight, passed through as-is) or any string parseable by `strtotime` (converted to seconds past midnight).

**`tests/Drupal/Tests/Driver/TimeHandlerTest.php`** (new)

Unit tests for `TimeHandler::expand()` covering:
- Numeric integer passthrough
- Numeric string passthrough
- Time string `9:30 AM`
- Time string `14:15:30`
- Time string `midnight`
- Multiple mixed values in a single call

## Test plan

- [ ] All 36 PHPUnit tests pass (`composer test` - phpspec failures are pre-existing PHP 8.4 incompatibilities unrelated to this change)
- [ ] `TimeHandler` correctly handles numeric values without conversion
- [ ] `TimeHandler` correctly converts `strtotime`-compatible strings to seconds past midnight
