### PR TITLE
[#293] Added 'SupportedImageHandler' for supported_image module.

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/SupportedImageHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/SupportedImageHandler.php
@@ -34,7 +34,7 @@ class SupportedImageHandler extends AbstractHandler {
 
       /** @var \Drupal\file\FileInterface $file */
       $file = \Drupal::service('file.repository')
-        ->writeData($data, 'public://' . uniqid() . ".$file_extension");
+        ->writeData($data, 'public://' . uniqid() . '.' . $file_extension);
 
       if ($file === FALSE) {
         throw new \Exception("Error saving file");

--- a/src/Drupal/Driver/Fields/Drupal8/SupportedImageHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/SupportedImageHandler.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\Driver\Fields\Drupal8;
+
+/**
+ * Supported Image field handler for Drupal 8+.
+ *
+ * Adapted from ImageHandler.
+ *
+ * @see \Drupal\Driver\Fields\Drupal8\ImageHandler
+ * @see https://www.drupal.org/project/supported_image
+ */
+class SupportedImageHandler extends AbstractHandler {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function expand($values) {
+    $return_values = [];
+
+    // Standardize single/multi-value input.
+    if (is_string($values) || isset($values['target_id'])) {
+      $values = [$values];
+    }
+
+    foreach ($values as $value) {
+      $file_path = (string) ($value['target_id'] ?? $value);
+      $file_extension = pathinfo($file_path, PATHINFO_EXTENSION);
+      $data = file_get_contents((string) $file_path);
+
+      if ($data === FALSE) {
+        throw new \Exception("Error reading file");
+      }
+
+      /** @var \Drupal\file\FileInterface $file */
+      $file = \Drupal::service('file.repository')
+        ->writeData($data, 'public://' . uniqid() . ".$file_extension");
+
+      if ($file === FALSE) {
+        throw new \Exception("Error saving file");
+      }
+
+      $file->save();
+
+      $return_values[] = [
+        'target_id' => $file->id(),
+        'alt' => $value['alt'] ?? NULL,
+        'title' => $value['title'] ?? NULL,
+        'caption_value' => $value['caption_value'] ?? NULL,
+        'caption_format' => $value['caption_format'] ?? NULL,
+        'attribution_value' => $value['attribution_value'] ?? NULL,
+        'attribution_format' => $value['attribution_format'] ?? NULL,
+      ];
+    }
+
+    return $return_values;
+  }
+
+}


### PR DESCRIPTION
> Iterates on #294 by @chrisolof. Thank you for the contribution!

## Summary

- Added `SupportedImageHandler` for the `supported_image` Drupal contrib module (resolves #293).
- The handler extends `AbstractHandler` and mirrors the existing `ImageHandler` logic, adding support for the extra fields specific to the `supported_image` module: `caption_value`, `caption_format`, `attribution_value`, and `attribution_format`.
- Fixed string concatenation to use single quotes for Drupal coding standards compliance.

## Changes

- `src/Drupal/Driver/Fields/Drupal8/SupportedImageHandler.php` - new field handler class for `supported_image` field type.

## Test plan

- PHPUnit test suite: 36/36 OK (verified locally).
- Manually test by setting a `supported_image` field value via Behat/DrupalDriver on a Drupal site with the `supported_image` module enabled and confirm the field is populated correctly including `caption` and `attribution` sub-fields.
