### PR TITLE
[#291] Fixed 'EntityReferenceHandler' crash when entity label key is FALSE.

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -38,13 +38,18 @@ class EntityReferenceHandler extends AbstractHandler {
 
     foreach ((array) $values as $value) {
       $query = \Drupal::entityQuery($entity_type_id);
-      $or = $query->orConditionGroup();
       $is_numeric_id = is_int($value) || (is_string($value) && ctype_digit($value));
-      if ($is_numeric_id) {
-        $or->condition($id_key, (int) $value);
+      if ($label_key) {
+        $or = $query->orConditionGroup();
+        if ($is_numeric_id) {
+          $or->condition($id_key, (int) $value);
+        }
+        $or->condition($label_key, $value);
+        $query->condition($or);
       }
-      $or->condition($label_key, $value);
-      $query->condition($or);
+      else {
+        $query->condition($id_key, $value);
+      }
       $query->accessCheck(FALSE);
       if ($target_bundles && $target_bundle_key) {
         $query->condition($target_bundle_key, $target_bundles, 'IN');


### PR DESCRIPTION
> Iterates on #292 by @khiminrm. Thank you for the contribution!

## Summary

- Fixed a fatal crash in `EntityReferenceHandler::expand()` when the referenced entity type has no label key (i.e., `getKey('label')` returns `FALSE`).
- Entity types such as `commerce_license` do not define a label key, which previously caused an invalid `orConditionGroup` with an `OR FALSE` condition appended, crashing the entity query.
- When `$label_key` is `FALSE`, the handler now falls back to a simple ID-only condition instead of building an `orConditionGroup`.

## Problem

Entity types that return `FALSE` for `getKey('label')` triggered this code path:

```php
$or = $query->orConditionGroup();
if ($is_numeric_id) {
  $or->condition($id_key, (int) $value);
}
$or->condition($label_key, $value);  // $label_key is FALSE - crashes
$query->condition($or);
```

Passing `FALSE` as a field name to `$or->condition()` caused a fatal error or an invalid query.

## Fix

The query-building block is now guarded by a `$label_key` check:

```php
if ($label_key) {
  $or = $query->orConditionGroup();
  if ($is_numeric_id) {
    $or->condition($id_key, (int) $value);
  }
  $or->condition($label_key, $value);
  $query->condition($or);
}
else {
  $query->condition($id_key, $value);
}
```

When `$label_key` is falsy, the handler matches by ID only, which is the only sensible fallback for entities with no label field.

## Related

- Fixes #291
- Iterates on #292
