### PR TITLE
[#200] Fixed date-only field handling and simplified relative date logic.

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/DatetimeHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/DatetimeHandler.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\Driver\Fields\Drupal8;
 
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItem;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
 
 /**
@@ -16,20 +18,24 @@ class DatetimeHandler extends AbstractHandler {
     $siteTimezone = new \DateTimeZone(\Drupal::config('system.date')->get('timezone.default'));
     $storageTimezone = new \DateTimeZone(DateTimeItemInterface::STORAGE_TIMEZONE);
     foreach ($values as $key => $value) {
-      if (strpos($value, "relative:") !== FALSE) {
-        $relative = trim(str_replace('relative:', '', $value));
-        // Get time, convert to ISO 8601 date in GMT/UTC, remove TZ offset.
-        $values[$key] = substr(gmdate('c', strtotime($relative)), 0, 19);
+      if (strpos($value, 'relative:') !== FALSE) {
+        $value = trim(str_replace('relative:', '', $value));
+      }
+
+      if ($this->fieldInfo->getSetting('datetime_type') === DateTimeItem::DATETIME_TYPE_DATE) {
+        // A date-only value should use the date storage format in the site
+        // timezone.
+        $date = new DrupalDateTime($value, $siteTimezone);
+        $format = DateTimeItemInterface::DATE_STORAGE_FORMAT;
       }
       else {
-        // A Drupal install has a default site timezone, but nonetheless
-        // uses UTC for internal storage. If no timezone is specified in a date
-        // field value by the step author, assume the default timezone of
-        // the Drupal install, and therefore transform it into UTC for storage.
-        $date = new \DateTime($value, $siteTimezone);
+        // A datetime value is assumed to be provided in the site timezone and
+        // must be transformed into the storage timezone.
+        $date = new DrupalDateTime($value, $siteTimezone);
         $date->setTimezone($storageTimezone);
-        $values[$key] = $date->format('Y-m-d\TH:i:s');
+        $format = DateTimeItemInterface::DATETIME_STORAGE_FORMAT;
       }
+      $values[$key] = $date->format($format);
     }
     return $values;
   }


### PR DESCRIPTION
> Iterates on #290 by @ericgsmith. Thank you for the contribution!

## Summary

- Fixed date-only field handling so values are stored using `DATE_STORAGE_FORMAT` in the site timezone, rather than incorrectly treating them as datetime values.
- Unified the relative/explicit date branches so relative date stripping happens first, then a single code path handles formatting based on the field's `datetime_type` setting.
- Replaced `\DateTime` with `DrupalDateTime` for both date-only and datetime values, ensuring proper timezone handling via Drupal's API.
- Added imports for `DrupalDateTime` and `DateTimeItem` to support the new logic.

## Problem

The original `expand()` method in `DatetimeHandler` had two separate branches:

1. **Relative dates** (`relative:` prefix) - used `gmdate` / `strtotime` and always produced a datetime format, ignoring whether the field was date-only.
2. **Explicit dates** - used `\DateTime` and always applied a datetime format with timezone conversion to UTC.

Neither branch was aware of the field's `datetime_type` setting, so date-only fields (configured as `DateTimeItem::DATETIME_TYPE_DATE`) received the wrong storage format.

## Before / After

**Before** - two independent branches, no date-type awareness:

```php
if (strpos($value, "relative:") !== FALSE) {
    $relative = trim(str_replace('relative:', '', $value));
    // Always produced a datetime string, even for date-only fields.
    $values[$key] = substr(gmdate('c', strtotime($relative)), 0, 19);
}
else {
    $date = new \DateTime($value, $siteTimezone);
    $date->setTimezone($storageTimezone);
    // Always formatted as datetime, ignoring date-only fields.
    $values[$key] = $date->format('Y-m-d\TH:i:s');
}
```

**After** - relative prefix stripped first, then a unified path selects format by field type:

```php
if (strpos($value, 'relative:') !== FALSE) {
    $value = trim(str_replace('relative:', '', $value));
}

if ($this->fieldInfo->getSetting('datetime_type') === DateTimeItem::DATETIME_TYPE_DATE) {
    // Date-only: store in site timezone using date storage format.
    $date = new DrupalDateTime($value, $siteTimezone);
    $format = DateTimeItemInterface::DATE_STORAGE_FORMAT;
}
else {
    // Datetime: convert from site timezone to storage timezone.
    $date = new DrupalDateTime($value, $siteTimezone);
    $date->setTimezone($storageTimezone);
    $format = DateTimeItemInterface::DATETIME_STORAGE_FORMAT;
}
$values[$key] = $date->format($format);
```

## Issue

Resolves #200.

## Test plan

- PHPUnit test suite: 36/36 tests passing.
- Covers both date-only and datetime field types, as well as relative date values for each.
