### PR TITLE
Skipped processing empty batches in 'processBatch()'.

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -198,9 +198,10 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
    */
   public function processBatch() {
     $this->validateDrupalSite();
-    $batch =& batch_get();
-    $batch['progressive'] = FALSE;
-    batch_process();
+    if ($batch =& batch_get()) {
+      $batch['progressive'] = FALSE;
+      batch_process();
+    }
   }
 
   /**


### PR DESCRIPTION
> Iterates on #284 by @idimopoulos. Thank you for the contribution!

## Summary

- Fixed a crash in `processBatch()` when no batch has been registered - `batch_get()` returns an empty value in that case, and the previous code unconditionally called `batch_process()`, causing an error.
- Added a guard so that `batch_process()` is only called when a batch is actually present.

## Changes

In `src/Drupal/Driver/Cores/Drupal8.php`, `processBatch()` now checks the return value of `batch_get()` before setting `$batch['progressive']` and calling `batch_process()`. This matches standard Drupal practice and prevents a fatal error when tests trigger `processBatch()` without having queued any batch operations.

## Test plan

- [ ] Confirm existing test suite passes.
- [ ] Confirm that calling `processBatch()` with no active batch no longer crashes.
