### PR TITLE
[#192] Allowed 'LinkHandler' to accept named field properties.

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/LinkHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/LinkHandler.php
@@ -13,17 +13,19 @@ class LinkHandler extends AbstractHandler {
   public function expand($values) {
     $return = [];
     foreach ($values as $value) {
+      // Support both named keys (title, uri, options) and numeric indices.
+      $return_value = [
+        'title' => $value['title'] ?? $value[0] ?? NULL,
+        'uri' => $value['uri'] ?? $value[1] ?? NULL,
+        'options' => [],
+      ];
       // 'options' is required to be an array, otherwise the utility class
       // Drupal\Core\Utility\UnroutedUrlAssembler::assemble() will complain.
-      $options = [];
-      if (!empty($value[2])) {
-        parse_str($value[2], $options);
+      $options = $value['options'] ?? $value[2] ?? NULL;
+      if ($options) {
+        parse_str($options, $return_value['options']);
       }
-      $return[] = [
-        'options' => $options,
-        'title' => $value[0],
-        'uri' => $value[1],
-      ];
+      $return[] = $return_value;
     }
     return $return;
   }

--- a/tests/Drupal/Tests/Driver/LinkHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/LinkHandlerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\Tests\Driver;
+
+use Drupal\Driver\Fields\Drupal8\LinkHandler;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the LinkHandler field handler.
+ */
+class LinkHandlerTest extends TestCase {
+
+  /**
+   * Tests link field expansion.
+   *
+   * @param array $input
+   *   The input values to expand.
+   * @param array $expected
+   *   The expected expanded values.
+   *
+   * @dataProvider dataProviderExpand
+   */
+  public function testExpand(array $input, array $expected) {
+    $handler = $this->createHandler();
+    $result = $handler->expand($input);
+    $this->assertSame($expected, $result);
+  }
+
+  /**
+   * Data provider for testExpand().
+   */
+  public function dataProviderExpand() {
+    return [
+      'numeric indices' => [
+        [['My link', 'https://example.com']],
+        [['title' => 'My link', 'uri' => 'https://example.com', 'options' => []]],
+      ],
+      'named keys' => [
+        [['title' => 'My link', 'uri' => 'https://example.com']],
+        [['title' => 'My link', 'uri' => 'https://example.com', 'options' => []]],
+      ],
+      'numeric indices with options' => [
+        [['My link', 'https://example.com', 'target=_blank&rel=nofollow']],
+        [['title' => 'My link', 'uri' => 'https://example.com', 'options' => ['target' => '_blank', 'rel' => 'nofollow']]],
+      ],
+      'named keys with options' => [
+        [['title' => 'My link', 'uri' => 'https://example.com', 'options' => 'target=_blank']],
+        [['title' => 'My link', 'uri' => 'https://example.com', 'options' => ['target' => '_blank']]],
+      ],
+      'multiple values' => [
+        [
+          ['First', 'https://first.com'],
+          ['title' => 'Second', 'uri' => 'https://second.com'],
+        ],
+        [
+          ['title' => 'First', 'uri' => 'https://first.com', 'options' => []],
+          ['title' => 'Second', 'uri' => 'https://second.com', 'options' => []],
+        ],
+      ],
+      'no options returns empty array' => [
+        [['title' => 'Link', 'uri' => 'https://example.com']],
+        [['title' => 'Link', 'uri' => 'https://example.com', 'options' => []]],
+      ],
+    ];
+  }
+
+  /**
+   * Creates a LinkHandler instance that bypasses the parent constructor.
+   *
+   * @return \Drupal\Driver\Fields\Drupal8\LinkHandler
+   *   The handler instance.
+   */
+  protected function createHandler() {
+    $reflection = new \ReflectionClass(LinkHandler::class);
+    return $reflection->newInstanceWithoutConstructor();
+  }
+
+}


### PR DESCRIPTION
> Iterates on #277 by @chrisolof. Thank you for the contribution!

## Summary

- Updated `LinkHandler::expand()` to accept named field properties (`title`, `uri`, `options`) in addition to the existing numeric index format (`[0]`, `[1]`, `[2]`).
- Named keys take precedence over numeric indices via PHP null-coalescing (`??`), so both formats remain fully supported without breaking existing behaviour.
- The `options` key (named or positional) is passed through `parse_str()` only when present, and defaults to an empty array to satisfy `UnroutedUrlAssembler::assemble()`.

## Changes

- `src/Drupal/Driver/Fields/Drupal8/LinkHandler.php` - refactored `expand()` to support named keys alongside numeric indices.

## Test plan

- [ ] Verify existing tests pass with numeric-index link values (no regression).
- [ ] Verify a link field populated with named keys (`title`, `uri`, `options`) is correctly expanded.
- [ ] Verify a link field populated with only `title` and `uri` (no `options`) expands without errors.

Closes #192.
