### PR TITLE
Added URI-only string support to 'LinkHandler'.

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/LinkHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/LinkHandler.php
@@ -13,12 +13,16 @@ class LinkHandler extends AbstractHandler {
   public function expand($values) {
     $return = [];
     foreach ($values as $value) {
+      // Support URI-only string values.
+      if (is_string($value)) {
+        $value = ['uri' => $value];
+      }
       // Support both named keys (title, uri, options) and numeric indices.
-      $return_value = [
+      $return_value = array_filter([
         'title' => $value['title'] ?? $value[0] ?? NULL,
         'uri' => $value['uri'] ?? $value[1] ?? NULL,
         'options' => [],
-      ];
+      ], fn ($v) => $v !== NULL);
       // 'options' is required to be an array, otherwise the utility class
       // Drupal\Core\Utility\UnroutedUrlAssembler::assemble() will complain.
       $options = $value['options'] ?? $value[2] ?? NULL;

--- a/tests/Drupal/Tests/Driver/LinkHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/LinkHandlerTest.php
@@ -61,6 +61,20 @@ class LinkHandlerTest extends TestCase {
         [['title' => 'Link', 'uri' => 'https://example.com']],
         [['title' => 'Link', 'uri' => 'https://example.com', 'options' => []]],
       ],
+      'uri-only string' => [
+        ['https://example.com'],
+        [['uri' => 'https://example.com', 'options' => []]],
+      ],
+      'mixed uri-only and full' => [
+        [
+          'https://first.com',
+          ['title' => 'Second', 'uri' => 'https://second.com'],
+        ],
+        [
+          ['uri' => 'https://first.com', 'options' => []],
+          ['title' => 'Second', 'uri' => 'https://second.com', 'options' => []],
+        ],
+      ],
     ];
   }
 


### PR DESCRIPTION
> Iterates on #267 by @zolhorvath and #137 by @ohthehugemanatee. Thank you both for the contributions!

## Summary

- Added URI-only string support to `LinkHandler::expand()` - when a plain string is passed as a link field value, it is treated as a URI with no title.
- Used `array_filter()` to omit `null` values (e.g., `title`) from the returned array when no title is provided, keeping the output clean.
- Added test cases for the new URI-only string input, including a mixed scenario combining URI-only strings with full array values.

## Changes

**`src/Drupal/Driver/Fields/Drupal8/LinkHandler.php`**

When iterating over link field values in `expand()`, a string value is now normalised to `['uri' => $value]` before further processing. The existing named-key and numeric-index handling is preserved unchanged.

**`tests/Drupal/Tests/Driver/LinkHandlerTest.php`**

Two new data provider cases cover the added behaviour:

- `uri-only string` - a single plain string value produces `['uri' => '...', 'options' => []]`.
- `mixed uri-only and full` - a mix of plain strings and full arrays is handled correctly in one call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced link handling to accept simpler URI-only string inputs, automatically converting them to proper link structures with normalized fields.

* **Tests**
  * Added test coverage for URI-only string inputs and mixed input combinations in link handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->