### PR TITLE
Implemented proper file handling in 'FileHandler'.

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/FileHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/FileHandler.php
@@ -5,5 +5,39 @@ namespace Drupal\Driver\Fields\Drupal8;
 /**
  * File field handler for Drupal 8.
  */
-class FileHandler extends EntityReferenceHandler {
+class FileHandler extends AbstractHandler {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function expand($values) {
+    $return = [];
+    foreach ((array) $values as $value) {
+      $file_path = is_array($value) ? $value['target_id'] ?? $value[0] : $value;
+      $file_extension = pathinfo($file_path, PATHINFO_EXTENSION);
+      $data = file_get_contents($file_path);
+
+      if ($data === FALSE) {
+        throw new \Exception(sprintf('Error reading file %s.', $file_path));
+      }
+
+      /** @var \Drupal\file\FileInterface $file */
+      $file = \Drupal::service('file.repository')
+        ->writeData($data, 'public://' . uniqid() . '.' . $file_extension);
+
+      if ($file === FALSE) {
+        throw new \Exception('Error saving file.');
+      }
+
+      $file->save();
+
+      $return[] = [
+        'target_id' => $file->id(),
+        'display' => is_array($value) ? ($value['display'] ?? 1) : 1,
+        'description' => is_array($value) ? ($value['description'] ?? '') : '',
+      ];
+    }
+    return $return;
+  }
+
 }


### PR DESCRIPTION
> Iterates on #123 by @azurams. Thank you for the contribution!

## Summary

- `FileHandler` previously extended `EntityReferenceHandler`, which attempted a name-based entity lookup on raw file paths - incorrect behaviour for file fields.
- `FileHandler` now extends `AbstractHandler` and implements its own `expand()` method that reads the file from disk and creates a managed file entity using the modern `file.repository` service.
- The handler supports both plain string values and array values (with optional `display` and `description` keys), writing file data to the `public://` stream wrapper with a unique filename derived from the original extension.

## Changes

- `src/Drupal/Driver/Fields/Drupal8/FileHandler.php` - Changed base class from `EntityReferenceHandler` to `AbstractHandler` and added `expand()` implementation that:
  - Reads file contents from the provided path using `file_get_contents()`.
  - Writes the data to the public files directory via `\Drupal::service('file.repository')->writeData()`.
  - Returns the expected `target_id`, `display`, and `description` keys for the field value array.

## Test plan

- [ ] Run the existing test suite to confirm no regressions.
- [ ] Verify that a file field can be populated by passing a local file path in a Behat step.
- [ ] Confirm that passing an unreadable path throws a descriptive exception.
- [ ] Confirm that the created file entity is saved and the `target_id` returned matches the saved file.
