### PR TITLE
Added 'moduleInstall()' and 'moduleUninstall()' to all drivers.

### DIFF
--- a/src/Drupal/Driver/BaseDriver.php
+++ b/src/Drupal/Driver/BaseDriver.php
@@ -216,4 +216,18 @@ abstract class BaseDriver implements DriverInterface {
     throw new UnsupportedDriverActionException($this->errorString('work with mail'), $this);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function moduleInstall($module_name) {
+    throw new UnsupportedDriverActionException($this->errorString('install modules'), $this);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function moduleUninstall($module_name) {
+    throw new UnsupportedDriverActionException($this->errorString('uninstall modules'), $this);
+  }
+
 }

--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -306,4 +306,20 @@ interface CoreInterface {
    */
   public function sendMail($body, $subject, $to, $langcode);
 
+  /**
+   * Installs a module.
+   *
+   * @param string $module_name
+   *   The machine name of the module to install.
+   */
+  public function moduleInstall($module_name);
+
+  /**
+   * Uninstalls a module.
+   *
+   * @param string $module_name
+   *   The machine name of the module to uninstall.
+   */
+  public function moduleUninstall($module_name);
+
 }

--- a/src/Drupal/Driver/Cores/Drupal6.php
+++ b/src/Drupal/Driver/Cores/Drupal6.php
@@ -575,4 +575,19 @@ class Drupal6 extends AbstractCore {
     throw new \Exception('Mail testing is not yet implemented for Drupal 6.');
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function moduleInstall($module_name) {
+    module_enable([$module_name]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function moduleUninstall($module_name) {
+    module_disable([$module_name]);
+    drupal_uninstall_module([$module_name]);
+  }
+
 }

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -577,4 +577,19 @@ class Drupal7 extends AbstractCore {
     throw new \Exception('Mail testing is not yet implemented for Drupal 7.');
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function moduleInstall($module_name) {
+    module_enable([$module_name]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function moduleUninstall($module_name) {
+    module_disable([$module_name]);
+    drupal_uninstall_modules([$module_name]);
+  }
+
 }

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -549,6 +549,20 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
+  public function moduleInstall($module_name) {
+    \Drupal::service('module_installer')->install([$module_name]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function moduleUninstall($module_name) {
+    \Drupal::service('module_installer')->uninstall([$module_name]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function startCollectingMail() {
     $config = \Drupal::configFactory()->getEditable('system.mail');
     $data = $config->getRawData();

--- a/src/Drupal/Driver/DriverInterface.php
+++ b/src/Drupal/Driver/DriverInterface.php
@@ -255,4 +255,20 @@ interface DriverInterface {
    */
   public function sendMail($body, $subject, $to, $langcode);
 
+  /**
+   * Installs a module.
+   *
+   * @param string $module_name
+   *   The machine name of the module to install.
+   */
+  public function moduleInstall($module_name);
+
+  /**
+   * Uninstalls a module.
+   *
+   * @param string $module_name
+   *   The machine name of the module to uninstall.
+   */
+  public function moduleUninstall($module_name);
+
 }

--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -379,6 +379,20 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
   /**
    * {@inheritdoc}
    */
+  public function moduleInstall($module_name) {
+    $this->getCore()->moduleInstall($module_name);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function moduleUninstall($module_name) {
+    $this->getCore()->moduleUninstall($module_name);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function login(\stdClass $user) {
     if ($this->getCore() instanceof CoreAuthenticationInterface) {
       $this->getCore()->login($user);

--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -460,6 +460,20 @@ class DrushDriver extends BaseDriver {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function moduleInstall($module_name) {
+    $this->drush('pm-enable', [$module_name], ['yes' => TRUE]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function moduleUninstall($module_name) {
+    $this->drush('pm-uninstall', [$module_name], ['yes' => TRUE]);
+  }
+
+  /**
    * Run Drush commands dynamically from a DrupalContext.
    */
   public function __call($name, $arguments) {


### PR DESCRIPTION
> Iterates on #164 by @phenaproxima. Thank you for the contribution!

## Summary

- Added `moduleInstall()` and `moduleUninstall()` methods to `DriverInterface` and `CoreInterface`.
- Implemented the methods across all drivers: `DrupalDriver`, `DrushDriver`, and `BaseDriver` (throws `UnsupportedDriverActionException`).
- Implemented the methods in all three core classes: `Drupal6`, `Drupal7`, and `Drupal8`.

## Implementation details

**`DriverInterface` / `CoreInterface`**: Defined `moduleInstall($module_name)` and `moduleUninstall($module_name)` with full PHPDoc.

**`BaseDriver`**: Both methods throw `UnsupportedDriverActionException` as the default fallback, consistent with other unimplemented actions.

**`DrupalDriver`**: Delegates to the active core via `$this->getCore()->moduleInstall()` / `moduleUninstall()`.

**`DrushDriver`**: Uses Drush commands `pm-enable` and `pm-uninstall` with `--yes` to avoid interactive prompts.

**`Drupal6`**: Uses `module_enable()` / `module_disable()` + `drupal_uninstall_module()`.

**`Drupal7`**: Uses `module_enable()` / `module_disable()` + `drupal_uninstall_modules()`.

**`Drupal8`**: Uses the `module_installer` service via `\Drupal::service('module_installer')->install()` / `uninstall()`.
