### PR TITLE
Added 'DaterangeHandler' with timezone-aware date formatting.

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/DaterangeHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/DaterangeHandler.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\Driver\Fields\Drupal8;
+
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItem;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+
+/**
+ * Daterange field handler for Drupal 8.
+ */
+class DaterangeHandler extends AbstractHandler {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function expand($values) {
+    $siteTimezone = new \DateTimeZone(\Drupal::config('system.date')->get('timezone.default'));
+    $storageTimezone = new \DateTimeZone(DateTimeItemInterface::STORAGE_TIMEZONE);
+    $return = [];
+
+    foreach ($values as $value) {
+      // Support both named keys and numeric indices.
+      $start = $value['value'] ?? $value[0] ?? NULL;
+      $end = $value['end_value'] ?? $value[1] ?? NULL;
+
+      $return[] = [
+        'value' => $start ? $this->formatDate($start, $siteTimezone, $storageTimezone) : NULL,
+        'end_value' => $end ? $this->formatDate($end, $siteTimezone, $storageTimezone) : NULL,
+      ];
+    }
+
+    return $return;
+  }
+
+  /**
+   * Formats a date value for storage.
+   *
+   * @param string $value
+   *   The date value to format.
+   * @param \DateTimeZone $site_timezone
+   *   The site timezone.
+   * @param \DateTimeZone $storage_timezone
+   *   The storage timezone.
+   *
+   * @return string
+   *   The formatted date string.
+   */
+  protected function formatDate($value, \DateTimeZone $site_timezone, \DateTimeZone $storage_timezone) {
+    if (strpos($value, 'relative:') !== FALSE) {
+      $value = trim(str_replace('relative:', '', $value));
+    }
+
+    if ($this->fieldInfo->getSetting('datetime_type') === DateTimeItem::DATETIME_TYPE_DATE) {
+      $date = new DrupalDateTime($value, $site_timezone);
+      $format = DateTimeItemInterface::DATE_STORAGE_FORMAT;
+    }
+    else {
+      $date = new DrupalDateTime($value, $site_timezone);
+      $date->setTimezone($storage_timezone);
+      $format = DateTimeItemInterface::DATETIME_STORAGE_FORMAT;
+    }
+
+    return $date->format($format);
+  }
+
+}


### PR DESCRIPTION
> Iterates on #167 by @shrimala. Thank you for the contribution!

## Summary

- Added `DaterangeHandler` for Drupal 8 `daterange` field type, with full timezone-aware date formatting consistent with the existing `DatetimeHandler`.
- Supports relative dates (using the `relative:` prefix), named keys (`value`/`end_value`), and numeric indices for flexible input.
- Uses `DrupalDateTime` with `DateTimeItemInterface` storage format constants (`DATE_STORAGE_FORMAT` and `DATETIME_STORAGE_FORMAT`) for correct date-only and datetime storage.

## What changed

**New file: `src/Drupal/Driver/Fields/Drupal8/DaterangeHandler.php`**

- Implements `expand()` to process start and end date values for `daterange` fields.
- Reads the site timezone from `system.date` config and converts to `DateTimeItemInterface::STORAGE_TIMEZONE` (UTC) for datetime fields.
- Detects `datetime_type` via `$fieldInfo->getSetting('datetime_type')` to apply the correct storage format (date-only vs datetime).
- Strips the `relative:` prefix before parsing, enabling relative date expressions (e.g. `relative:+1 week`).

## Context

The original PR #167 introduced a basic `DaterangeHandler` without timezone conversion or relative date support. This iteration aligns the implementation with `DatetimeHandler` to ensure consistent, correct storage of daterange field values across all usage patterns.

## Test plan

- [ ] Verify a `daterange` field is correctly populated using named keys: `['value' => '2025-01-01', 'end_value' => '2025-01-31']`.
- [ ] Verify numeric index input works: `['2025-01-01', '2025-01-31']`.
- [ ] Verify a relative date expression is correctly resolved: `['value' => 'relative:+1 day', 'end_value' => 'relative:+7 days']`.
- [ ] Verify a date-only `daterange` field (with `datetime_type = date`) stores in `Y-m-d` format.
- [ ] Verify a datetime `daterange` field stores in `Y-m-d\TH:i:s` format converted to UTC.
