### PR TITLE
Cleared EntityAccessControlHandler static cache in 'clearStaticCaches()'.

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -479,6 +479,9 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   public function clearStaticCaches() {
     drupal_static_reset();
     \Drupal::service('cache_tags.invalidator')->resetChecksums();
+    foreach (\Drupal::entityTypeManager()->getDefinitions() as $definition) {
+      \Drupal::entityTypeManager()->getAccessControlHandler($definition->id())->resetCache();
+    }
   }
 
   /**


### PR DESCRIPTION
> Iterates on #227 by @pfrenssen. Thank you for the contribution!

## Summary

- Adds `EntityAccessControlHandler::resetCache()` calls inside `clearStaticCaches()` for all defined entity types.
- Ensures entity access checks are properly invalidated when static caches are cleared, preventing stale access decisions from persisting across test steps.

## Changes

- `src/Drupal/Driver/Cores/Drupal8.php`: Iterates over all entity type definitions and resets the access control handler cache for each, complementing the existing `drupal_static_reset()` and cache tag checksum reset.
