### PR TITLE
[#210] Skipped exception when deleting non-existent role.

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -186,11 +186,9 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   public function roleDelete($role_name) {
     $role = Role::load($role_name);
 
-    if (!$role) {
-      throw new \RuntimeException(sprintf('No role "%s" exists.', $role_name));
+    if ($role) {
+      $role->delete();
     }
-
-    $role->delete();
   }
 
   /**


### PR DESCRIPTION
> Iterates on #211 by @bkosborne. Thank you for the contribution!

## Summary

Fixes `roleDelete()` in `Drupal8` to silently skip deletion when the specified role does not exist, instead of throwing a `RuntimeException`. This prevents test failures in scenarios where cleanup teardown attempts to delete a role that was never created.

Resolves #210.

## Changes

- `src/Drupal/Driver/Cores/Drupal8.php`: Inverted the `roleDelete()` guard condition to only call `$role->delete()` when the role exists, removing the exception thrown for missing roles.

## Test plan

- [ ] Verify that calling `roleDelete()` with an existing role name successfully deletes it.
- [ ] Verify that calling `roleDelete()` with a non-existent role name returns silently without throwing an exception.
