### PR TITLE
Added 'OgStandardReferenceHandler' for Organic Groups.

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/OgStandardReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/OgStandardReferenceHandler.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Drupal\Driver\Fields\Drupal8;
+
+/**
+ * Field handler for 'og_standard_reference' (Organic Groups) in Drupal 8.
+ */
+class OgStandardReferenceHandler extends EntityReferenceHandler {
+}


### PR DESCRIPTION
Iterates on #237 by @cheppers. Thank you for the contribution!

## Summary

- Adds `OgStandardReferenceHandler` for the Organic Groups contrib module's `og_standard_reference` field type.
- The handler extends `EntityReferenceHandler` since the entity lookup logic is identical - no additional implementation is required.

## Changes

- `src/Drupal/Driver/Fields/Drupal8/OgStandardReferenceHandler.php` - new field handler class that extends `EntityReferenceHandler`.
