### PR TITLE
Added 'NameHandler' for the Name module with tests.

### DIFF
--- a/src/Drupal/Driver/Fields/Drupal8/NameHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/NameHandler.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\Driver\Fields\Drupal8;
+
+/**
+ * Name field handler for Drupal 8.
+ *
+ * Supports the Name module (https://www.drupal.org/project/name).
+ */
+class NameHandler extends AbstractHandler {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function expand($values) {
+    $return = [];
+    $components = ['title', 'given', 'middle', 'family', 'generational', 'credentials'];
+
+    foreach ($values as $value) {
+      if (is_string($value)) {
+        // Support "Family, Given" shorthand.
+        $parts = array_map('trim', explode(',', $value));
+        $return[] = [
+          'family' => $parts[0] ?? NULL,
+          'given' => $parts[1] ?? NULL,
+        ];
+        continue;
+      }
+
+      if (is_array($value)) {
+        $return_value = [];
+        $idx = 0;
+        foreach ($value as $k => $v) {
+          if (in_array($k, $components, TRUE)) {
+            $return_value[$k] = $v;
+          }
+          elseif (is_numeric($k) && isset($components[$idx])) {
+            $return_value[$components[$idx]] = $v;
+            $idx++;
+          }
+        }
+        $return[] = $return_value;
+      }
+    }
+
+    return $return;
+  }
+
+}

--- a/tests/Drupal/Tests/Driver/NameHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/NameHandlerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\Tests\Driver;
+
+use Drupal\Driver\Fields\Drupal8\NameHandler;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the NameHandler field handler.
+ */
+class NameHandlerTest extends TestCase {
+
+  /**
+   * Tests name field expansion.
+   *
+   * @param array $input
+   *   The input values to expand.
+   * @param array $expected
+   *   The expected expanded values.
+   *
+   * @dataProvider dataProviderExpand
+   */
+  public function testExpand(array $input, array $expected) {
+    $handler = $this->createHandler();
+    $result = $handler->expand($input);
+    $this->assertSame($expected, $result);
+  }
+
+  /**
+   * Data provider for testExpand().
+   */
+  public function dataProviderExpand() {
+    return [
+      'string shorthand family, given' => [
+        ['Doe, John'],
+        [['family' => 'Doe', 'given' => 'John']],
+      ],
+      'string shorthand family only' => [
+        ['Doe'],
+        [['family' => 'Doe', 'given' => NULL]],
+      ],
+      'named keys' => [
+        [['given' => 'John', 'family' => 'Doe', 'middle' => 'Q']],
+        [['given' => 'John', 'family' => 'Doe', 'middle' => 'Q']],
+      ],
+      'numeric indices' => [
+        [['Dr', 'John', 'Quincy', 'Doe']],
+        [['title' => 'Dr', 'given' => 'John', 'middle' => 'Quincy', 'family' => 'Doe']],
+      ],
+      'multiple values' => [
+        [
+          'Doe, John',
+          ['given' => 'Jane', 'family' => 'Smith'],
+        ],
+        [
+          ['family' => 'Doe', 'given' => 'John'],
+          ['given' => 'Jane', 'family' => 'Smith'],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Creates a NameHandler instance that bypasses the parent constructor.
+   *
+   * @return \Drupal\Driver\Fields\Drupal8\NameHandler
+   *   The handler instance.
+   */
+  protected function createHandler() {
+    $reflection = new \ReflectionClass(NameHandler::class);
+    return $reflection->newInstanceWithoutConstructor();
+  }
+
+}


### PR DESCRIPTION
Iterates on #269 by @sensespidey. Thank you for the contribution!

## Summary

- Added `NameHandler` for the [Name module](https://www.drupal.org/project/name), properly extending `AbstractHandler` rather than implementing `FieldHandlerInterface` directly.
- Supports all six name components: `title`, `given`, `middle`, `family`, `generational`, and `credentials`.
- Handles string shorthand (`"Family, Given"`), named array keys, and positional (numeric index) array keys.
- Added `NameHandlerTest` with a data provider covering all input formats and multi-value scenarios.

## Changes

- `src/Drupal/Driver/Fields/Drupal8/NameHandler.php` - new handler.
- `tests/Drupal/Tests/Driver/NameHandlerTest.php` - unit tests.

## Test plan

- [ ] String shorthand `"Doe, John"` maps `family` and `given` correctly.
- [ ] String with no comma maps family only (`given` is `null`).
- [ ] Named keys (`given`, `family`, `middle`, etc.) pass through as-is.
- [ ] Numeric indices map positionally to `title`, `given`, `middle`, `family`, `generational`, `credentials`.
- [ ] Multiple values in a single call are each expanded independently.
- [ ] Existing unit tests pass: `composer test`.
