### PR TITLE
Resolved project-level Drush binary in DrushDriver.

### DIFF
--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -92,12 +92,43 @@ class DrushDriver extends BaseDriver {
       throw new BootstrapException('A drush alias or root path is required.');
     }
 
+    // When the default 'drush' binary is used, try to resolve the
+    // project-level Drush binary first.
+    if ($binary === 'drush') {
+      $binary = $this->resolveProjectDrush($binary);
+    }
+
     $this->binary = $binary;
 
     if (!isset($random)) {
       $random = new Random();
     }
     $this->random = $random;
+  }
+
+  /**
+   * Resolves the project-level Drush binary path.
+   *
+   * @param string $fallback
+   *   The fallback binary path if project-level Drush is not found.
+   *
+   * @return string
+   *   The resolved binary path.
+   */
+  protected function resolveProjectDrush($fallback) {
+    // Try Composer's runtime bin directory.
+    $composer_bin = getenv('COMPOSER_BIN_DIR');
+    if ($composer_bin && file_exists($composer_bin . '/drush')) {
+      return $composer_bin . '/drush';
+    }
+
+    // Try common vendor/bin location relative to working directory.
+    $cwd = getcwd();
+    if ($cwd && file_exists($cwd . '/vendor/bin/drush')) {
+      return $cwd . '/vendor/bin/drush';
+    }
+
+    return $fallback;
   }
 
   /**


### PR DESCRIPTION
Iterates on #273 by @mxr576. Thank you for the contribution!

## Summary

- When the default `drush` binary is used, `DrushDriver` now attempts to resolve a project-level Drush binary before falling back to the global `drush` command.
- Resolution order: `COMPOSER_BIN_DIR` environment variable, then `vendor/bin/drush` relative to the current working directory, then the original `drush` fallback.
- The logic is extracted into a protected `resolveProjectDrush()` method, making it easy to override in subclasses.

## Changes

- `src/Drupal/Driver/DrushDriver.php` - Added `resolveProjectDrush()` method and wired it into the constructor when the default binary is detected.
