### PR TITLE
[#281] Fixed 'parseUserId()' to handle Drush 12+ table output format.

### DIFF
--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -216,14 +216,32 @@ class DrushDriver extends BaseDriver {
 
   /**
    * Parse user id from drush user-information output.
+   *
+   * Supports both the legacy key-value format ("User ID : 123") and the
+   * Drush 12+ table format where the ID is the first numeric value in the
+   * data row.
    */
   protected function parseUserId($info) {
-    // Find the row containing "User ID : xxx".
-    preg_match('/User ID\s+:\s+\d+/', $info, $matches);
-    if (!empty($matches)) {
-      // Extract the ID from the row.
-      list(, $uid) = explode(':', $matches[0]);
-      return (int) $uid;
+    // Legacy format: "User ID : 123".
+    if (preg_match('/User ID\s+:\s+(\d+)/', $info, $matches)) {
+      return (int) $matches[1];
+    }
+
+    // Drush 12+ table format: extract the first numeric value from the first
+    // data row (the row after the header separator).
+    if (preg_match('/User ID/', $info)) {
+      $lines = explode("\n", trim($info));
+      foreach ($lines as $line) {
+        // Skip header, separator, and empty lines.
+        $trimmed = trim($line, " \t\n\r\0\x0B-");
+        if ($trimmed === '' || str_contains($trimmed, 'User ID')) {
+          continue;
+        }
+        // The first column in the data row is the User ID.
+        if (preg_match('/^\s*(\d+)\s/', $line, $matches)) {
+          return (int) $matches[1];
+        }
+      }
     }
   }
 

--- a/tests/Drupal/Tests/Driver/DrushDriverTest.php
+++ b/tests/Drupal/Tests/Driver/DrushDriverTest.php
@@ -58,6 +58,41 @@ class DrushDriverTest extends TestCase {
   }
 
   /**
+   * Tests 'parseUserId()' correctly extracts UID from drush output.
+   *
+   * @dataProvider dataProviderParseUserId
+   */
+  public function testParseUserId($drush_output, $expected) {
+    $driver = new TestDrushDriver('alias');
+    $result = $driver->callParseUserId($drush_output);
+    $this->assertSame($expected, $result);
+  }
+
+  /**
+   * Data provider for testParseUserId().
+   */
+  public function dataProviderParseUserId() {
+    return [
+      'legacy key-value format' => [
+        "User ID   :   550895\nUser name :   test\n",
+        550895,
+      ],
+      'drush 12 table format' => [
+        " --------- ----------- ----------- --------------- ------------- \n  User ID   User name   User mail   User roles      User status  \n --------- ----------- ----------- --------------- ------------- \n  550895    test        test@ex.co  authenticated   1            \n --------- ----------- ----------- --------------- ------------- \n",
+        550895,
+      ],
+      'no user id present' => [
+        "Some random output\n",
+        NULL,
+      ],
+      'drush 12 table uid 1' => [
+        " --------- ----------- ----------- --------------- ------------- \n  User ID   User name   User mail   User roles      User status  \n --------- ----------- ----------- --------------- ------------- \n  1         admin       a@ex.co     administrator   1            \n --------- ----------- ----------- --------------- ------------- \n",
+        1,
+      ],
+    ];
+  }
+
+  /**
    * Data provider for testIsLegacyDrush().
    */
   public function dataProviderIsLegacyDrush() {
@@ -115,6 +150,13 @@ class TestDrushDriver extends DrushDriver {
    */
   public function callIsLegacyDrush() {
     return $this->isLegacyDrush();
+  }
+
+  /**
+   * Exposes `parseUserId()` for testing.
+   */
+  public function callParseUserId($info) {
+    return $this->parseUserId($info);
   }
 
 }


### PR DESCRIPTION
Closes #281

## Summary

- Fixed `parseUserId()` in `DrushDriver` to handle the table output format introduced in Drush 12+, where user info is returned as a formatted table rather than key-value pairs.
- Preserved full backward compatibility with the legacy `"User ID : 123"` key-value format used by older Drush versions.
- Added 4 unit tests via a data provider covering: legacy format, Drush 12+ table format, UID 1 edge case, and output with no user ID present.

## Problem

`DrushDriver::parseUserId()` used a regex that only matched the legacy `"User ID : 123"` key-value format. Drush 12+ changed the output of `user:information` to a bordered table:

```
 --------- ----------- ----------- --------------- ------------- 
  User ID   User name   User mail   User roles      User status  
 --------- ----------- ----------- --------------- ------------- 
  550895    test        test@ex.co  authenticated   1            
 --------- ----------- ----------- --------------- ------------- 
```

This caused `parseUserId()` to return `null` for all users when running Drush 12+, breaking user-related operations.

## Solution

The updated method tries the legacy regex first (no behaviour change for older Drush). If that does not match but the output contains a `User ID` header, it walks the lines and extracts the first numeric value from the first data row (the UID column).

## Test plan

- [ ] Legacy format (`"User ID : 123"`) still parses correctly.
- [ ] Drush 12+ table format parses correctly.
- [ ] UID `1` (single digit) parses correctly from table format.
- [ ] Output with no user ID present returns `null` without error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced user ID extraction to support both legacy and Drush 12+ output formats while maintaining backward compatibility.

* **Tests**
  * Added comprehensive test coverage for user ID parsing across different Drush output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->