### PR TITLE
Updated README and CONTRIBUTING to match DrupalExtension structure.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,39 +1,127 @@
 # Contributing
 
-Features and bug fixes are welcome! First-time contributors can jump in with the issues tagged [good first issue](https://github.com/jhedstrom/DrupalDriver/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+Features and bug fixes are welcome! First-time contributors can
+jump in with the issues tagged [good first issue](https://github.com/jhedstrom/DrupalDriver/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
-## Testing
+> **Note:** We are actively working on version 3.x which will
+> overhaul the test infrastructure, drop Drupal 6/7 support, and
+> introduce SQLite-based kernel tests. See the
+> [3.x epic](https://github.com/jhedstrom/DrupalDriver/issues/312)
+> for details.
 
-Testing is performed automatically in Github Actions when a PR is submitted. To execute tests locally before submitting a PR, you'll need [Docker and Docker Compose](https://docs.docker.com/engine/install/).
+## How this project works
 
-Configure your test environment:
+Drupal Driver is a PHP library that provides a common interface
+for interacting with Drupal programmatically. It abstracts
+version-specific details so that consumers (such as
+[Drupal Extension](https://github.com/jhedstrom/drupalextension))
+can create and manipulate entities, manage users and roles, run
+cron, and clear caches without knowing which Drupal version is
+running.
 
+### Drivers
+
+The library provides three drivers, each offering a different
+level of access to Drupal:
+
+- **Blackbox** - No Drupal bootstrap. Limited to operations
+  that do not require access to Drupal internals.
+
+- **Drupal API** - Bootstraps Drupal directly in PHP. Delegates
+  to a version-specific Core class (`Drupal8.php` covers
+  Drupal 8 through 11) for entity CRUD, field handling, user
+  and role management, cron, caching, and mail.
+
+- **Drush** - Uses the Drush command line tool to interact
+  with Drupal over a subprocess.
+
+### Field handlers
+
+Field handlers translate human-readable values into the format
+expected by Drupal's field storage system. Each handler implements
+`FieldHandlerInterface::expand($values)` and is resolved by
+convention from the Drupal field type name (e.g., `entity_reference`
+resolves to `EntityReferenceHandler`).
+
+Handlers that perform real transformation include:
+
+| Handler | What it does |
+| --- | --- |
+| `EntityReferenceHandler` | Looks up entities by name and returns target IDs |
+| `DatetimeHandler` | Converts dates with timezone handling |
+| `DaterangeHandler` | Converts date ranges with timezone handling |
+| `TimeHandler` | Converts time strings to seconds past midnight |
+| `ListStringHandler` and siblings | Resolves human labels to stored keys |
+| `ImageHandler` | Creates file entities from file paths |
+| `FileHandler` | Creates file entities from file paths |
+
+### What are we testing?
+
+This repository tests the drivers and field handlers. The current
+test suite includes:
+
+- **PHPUnit tests** for field handlers that can be tested without
+  a Drupal bootstrap (TimeHandler, LinkHandler, NameHandler) and
+  for driver logic (DrushDriver version detection, user ID
+  parsing).
+
+- **PhpSpec specs** (legacy) for core driver and exception classes.
+
+The test suite does **not** currently test handlers against a real
+Drupal installation. Integration testing with SQLite-based kernel
+tests is planned for v3.x.
+
+## Setting up the local environment
+
+Testing is performed automatically in GitHub Actions when a PR is
+submitted. To execute tests locally, you can use either Docker or
+a local PHP installation.
+
+### Local PHP (recommended)
+
+If you have PHP 8.2+ installed locally:
+
+```shell
+composer install
+composer test
 ```
+
+Run a specific test:
+
+```shell
+XDEBUG_MODE=off vendor/bin/phpunit --filter TimeHandlerTest
+```
+
+### Docker
+
+To test with a specific PHP version using Docker:
+
+```shell
 export PHP_VERSION=8.3
 export DRUPAL_VERSION=11
 export DOCKER_USER_ID=${UID}
 ```
 
-Prepare environment for testing:
-
-```
+```shell
 docker compose up -d
-docker compose exec -T php composer self-update
-docker compose exec -u ${DOCKER_USER_ID} -T php composer require --no-interaction --dev --no-update drupal/core:^${DRUPAL_VERSION}
 docker compose exec -T php composer install
-```
-
-Execute all tests:
-
-```
 docker compose exec -T php composer test
 ```
 
-Execute specific tests, eg just PHPUnit's Drupal7FieldHandlerTest:
+### Test commands
 
-```
-docker compose exec -T php phpunit --filter Drupal7FieldHandlerTest
-```
+| Command | Description |
+| --- | --- |
+| `composer test` | Run all tests (lint, PHPUnit, PhpSpec, PHPCS, Rector) |
+| `composer lint` | PHP syntax check |
+| `composer phpunit` | PHPUnit tests only |
+| `composer phpspec` | PhpSpec tests only |
+| `composer phpcs` | Drupal coding standards check |
 
-- Check the changes from `composer require` are not included in your submitted PR.
-- Before testing another PHP or Drupal version, remove `composer.lock` and `vendor/`
+## Before submitting a change
+
+- Run `composer test` locally to verify all checks pass.
+- Check that changes from `composer require` are not included
+  in your submitted PR.
+- Before testing another PHP or Drupal version with Docker,
+  remove `composer.lock` and `vendor/`.

--- a/README.md
+++ b/README.md
@@ -1,54 +1,49 @@
-<?php
+<h1 align="center">Drupal Driver</h1>
 
-/**
- * @file
- */
-?>
-[![Build Status](https://github.com/jhedstrom/DrupalDriver/actions/workflows/ci.yml/badge.svg)](https://github.com/jhedstrom/DrupalDriver/actions/workflows/ci.yml)
+<div align="center">
 
-Provides a collection of light-weight drivers with a common interface for interacting with [Drupal](http://drupal.org). These are generally intended for testing, and are not meant to be API-complete.
+[![Latest Stable Version](https://poser.pugx.org/drupal/drupal-driver/v/stable.svg)](https://packagist.org/packages/drupal/drupal-driver)
+[![Total Downloads](https://poser.pugx.org/drupal/drupal-driver/downloads.svg)](https://packagist.org/packages/drupal/drupal-driver)
+[![License](https://poser.pugx.org/drupal/drupal-driver/license.svg)](https://packagist.org/packages/drupal/drupal-driver)
 
-[Read the full documentation](http://drupal-drivers.readthedocs.org)
+[![ci](https://github.com/jhedstrom/DrupalDriver/actions/workflows/ci.yml/badge.svg)](https://github.com/jhedstrom/DrupalDriver/actions/workflows/ci.yml)
+[![GitHub Issues](https://img.shields.io/github/issues/jhedstrom/DrupalDriver.svg)](https://github.com/jhedstrom/DrupalDriver/issues)
+[![GitHub Pull Requests](https://img.shields.io/github/issues-pr/jhedstrom/DrupalDriver.svg)](https://github.com/jhedstrom/DrupalDriver/pulls)
+</div>
 
-[![Latest Stable Version](https://poser.pugx.org/drupal/drupal-driver/v/stable.svg)](https://packagist.org/packages/drupal/drupal-driver) [![Total Downloads](https://poser.pugx.org/drupal/drupal-driver/downloads.svg)](https://packagist.org/packages/drupal/drupal-driver) [![License](https://poser.pugx.org/drupal/drupal-driver/license.svg)](https://packagist.org/packages/drupal/drupal-driver) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/jhedstrom/DrupalDriver/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/jhedstrom/DrupalDriver/?branch=master)
+A collection of lightweight drivers with a common interface for
+interacting with [Drupal](https://www.drupal.org). These are generally
+intended for testing and are not meant to be API-complete.
 
-### Drivers
+> **Note:** We are actively working on version 3.x which will drop
+> Drupal 6/7 support, modernise the codebase, and introduce integration
+> testing. See the
+> [3.x epic](https://github.com/jhedstrom/DrupalDriver/issues/312)
+> for details and progress.
 
-These drivers support Drupal versions 7 and 8.
+## Drivers
 
-* Blackbox
-* Direct Drupal API bootstrap
-* Drush
+| Driver | Description |
+| --- | --- |
+| **Blackbox** | No Drupal bootstrap. Interacts only through HTTP. |
+| **Drupal API** | Bootstraps Drupal directly in PHP for programmatic access to entities, fields, users, and configuration. |
+| **Drush** | Interacts with Drupal through the [Drush](https://www.drush.org) command line tool. |
 
-### Installation
+## Installation
 
-``` json
-{
-  "require": {
-    "drupal/drupal-driver": "~2.0"
-  }
-}
+```shell
+composer require drupal/drupal-driver
 ```
 
-``` bash
-$> curl -sS http://getcomposer.org/installer | php
-$> php composer.phar install
-```
+## Usage
 
-### Usage
-
-``` php
-<?php
-
+```php
 use Drupal\Driver\DrupalDriver;
 
 require 'vendor/autoload.php';
 
-// Path to Drupal.
-$path = './drupal-8';
-
-// Host.
-$uri = 'http://d8.devl';
+$path = './web';           // Path to Drupal root.
+$uri  = 'http://my-site';  // Site URI.
 
 $driver = new DrupalDriver($path, $uri);
 $driver->setCoreFromVersion();
@@ -57,21 +52,31 @@ $driver->setCoreFromVersion();
 $driver->bootstrap();
 
 // Create a node.
-$node = (object) array(
+$node = (object) [
   'type' => 'article',
   'uid' => 1,
   'title' => $driver->getRandom()->name(),
-);
+];
 $driver->createNode($node);
 ```
 
-### Contributing
+## Credits
 
-Features and bug fixes are welcome! First-time contributors can jump in with the
-issues tagged [good first issue](https://github.com/jhedstrom/DrupalDriver/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+ * Originally developed by [Jonathan Hedstrom](https://github.com/jhedstrom)
+ * Maintainers
+   * [Alex Skrypnyk](https://github.com/AlexSkrypnyk)
+   * [All contributors](https://github.com/jhedstrom/DrupalDriver/graphs/contributors)
 
-See [CONTRIBUTING.md](https://github.com/jhedstrom/DrupalDriver/blob/master/CONTRIBUTING.md) for more information.
+## Additional resources
 
-### Release notes
+ * [Drupal Driver documentation](https://drupal-drivers.readthedocs.org)
+
+## Release notes
 
 See [CHANGELOG](CHANGELOG.MD).
+
+## Contributing
+
+Features and bug fixes are welcome!
+
+See [CONTRIBUTING.md](https://github.com/jhedstrom/DrupalDriver/blob/master/CONTRIBUTING.md) for more information.


### PR DESCRIPTION
## Summary

- `README.md`: replaced the stale PHP-comment preamble and inline badge row with a centered `<h1>` + grouped badge block (Packagist stable/downloads/license, CI status, issues, PRs); replaced the flat driver bullet list with a three-row table; replaced the `composer.json` snippet installation block with a single `composer require` shell command; modernised the Usage example (array short syntax, cleaner comments); added a Credits section and an Additional resources section; moved the Contributing blurb to the bottom with a link to `CONTRIBUTING.md`; added a 3.x admonition linking to the epic (#312).
- `CONTRIBUTING.md`: added a "How this project works" section explaining the purpose of the library; added a Drivers sub-section summarising Blackbox / Drupal API / Drush; added a Field handlers sub-section with a handler reference table; added a "What are we testing?" sub-section documenting the current test coverage and the v3.x integration-testing plan; restructured the local setup section into "Local PHP (recommended)" and "Docker" sub-sections with separate code blocks; added a test-commands reference table; simplified the "Before submitting a change" checklist; added a 3.x admonition linking to the epic (#312).

## Test plan

- This PR contains documentation changes only - no PHP source files were modified.
- Verify rendered Markdown on the GitHub PR preview for both files.
- Confirm all badge URLs and internal links resolve correctly.
- Confirm the 3.x epic link (`https://github.com/jhedstrom/DrupalDriver/issues/312`) is reachable.
