### PR TITLE
Added .gitattributes for lean distribution archives.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Ignore files for distribution archives.
+/.artifacts      export-ignore
+/.editorconfig   export-ignore
+/.gitattributes  export-ignore
+/.github         export-ignore
+/.gitignore      export-ignore
+/CONTRIBUTING.md export-ignore
+/doc             export-ignore
+/docker-compose.yml export-ignore
+/drupal          export-ignore
+/drush           export-ignore
+/phpcs-ruleset.xml export-ignore
+/phpunit.xml.dist export-ignore
+/recipes         export-ignore
+/spec            export-ignore
+/tests           export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.phar
 *.tgz
-/.gitattributes
 /.phpunit.result.cache
 /composer.lock
 /drupal

--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,9 @@
             "dev-master": "2.3.x-dev"
         },
         "drupal-scaffold": {
+            "file-mapping": {
+                "[project-root]/.gitattributes": false
+            },
             "locations": {
                 "web-root": "drupal/"
             }


### PR DESCRIPTION
## Summary

Added a project-specific `.gitattributes` with `export-ignore` rules so that distribution archives only contain source code, `composer.json`, `LICENSE`, `README.md`, and `CHANGELOG.md`. Suppressed Drupal's scaffold from overwriting `.gitattributes` and removed the file from `.gitignore` since it is now a tracked project file.

## Changes

**`.gitattributes`** - New file with `export-ignore` rules excluding CI config, tests, docs tooling, Docker, specs, and dev-only files from distribution archives.

**`composer.json`** - Added `file-mapping` to `drupal-scaffold` config to prevent Drupal from overwriting `.gitattributes` with its own line-ending rules.

**`.gitignore`** - Removed `/.gitattributes` entry since the file is now tracked.

## Verified

Tested with `git archive` - distribution contains only:
- `composer.json`
- `CHANGELOG.md`
- `LICENSE`
- `README.md`
- `src/` (all source files)
