### PR TITLE
Added project-level rector configuration and applied fixes.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,14 +93,10 @@
         "lint": [
             "XDEBUG_MODE=off parallel-lint src spec tests",
             "XDEBUG_MODE=off phpcs",
-            "cp ./vendor/palantirnet/drupal-rector/rector.php drupal/.",
-            "XDEBUG_MODE=off cd drupal && ../vendor/bin/rector process ../src/Drupal/Driver/Cores/Drupal8.php --dry-run",
-            "XDEBUG_MODE=off cd drupal && ../vendor/bin/rector process ../src/Drupal/Driver/Fields/Drupal8 --dry-run"
+            "XDEBUG_MODE=off rector process --dry-run"
         ],
         "lint-fix": [
-            "cp ./vendor/palantirnet/drupal-rector/rector.php drupal/.",
-            "XDEBUG_MODE=off cd drupal && ../vendor/bin/rector process ../src/Drupal/Driver/Cores/Drupal8.php",
-            "XDEBUG_MODE=off cd drupal && ../vendor/bin/rector process ../src/Drupal/Driver/Fields/Drupal8",
+            "XDEBUG_MODE=off rector process",
             "XDEBUG_MODE=off phpcbf"
         ],
         "test": [

--- a/rector.php
+++ b/rector.php
@@ -10,6 +10,7 @@
 
 declare(strict_types=1);
 
+use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
 use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
 use Rector\Config\RectorConfig;
 use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
@@ -31,8 +32,12 @@ return RectorConfig::configure()
     ->withSkip([
         // Conflicts with Drupal coding style.
         NewlineAfterStatementRector::class,
+        // Conflicts with PHPCS snake_case variable naming.
+        CatchExceptionNameMatchingTypeRector::class,
         // Too aggressive for mixed-type codebase.
         DisallowedEmptyRuleFixerRector::class,
+        // Legacy test with PHPUnit compatibility issue.
+        __DIR__ . '/tests/Drupal/Tests/Driver/Drupal7FieldHandlerTest.php',
         // Dependencies.
         '*/vendor/*',
     ]);

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @file
+ * Rector configuration.
+ *
+ * Usage:
+ * ./vendor/bin/rector process .
+ */
+
+declare(strict_types=1);
+
+use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
+use Rector\Config\RectorConfig;
+use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src/**',
+        __DIR__ . '/tests/**',
+    ])
+    // PHP 7.4 only - strict types and PHP 8.0+ features deferred to v3.x.
+    ->withPhpSets(php74: TRUE)
+    ->withPreparedSets(
+        deadCode: TRUE,
+        codeQuality: TRUE,
+        codingStyle: TRUE,
+        instanceOf: TRUE,
+        earlyReturn: TRUE,
+    )
+    ->withSkip([
+        // Conflicts with Drupal coding style.
+        NewlineAfterStatementRector::class,
+        // Too aggressive for mixed-type codebase.
+        DisallowedEmptyRuleFixerRector::class,
+        // Dependencies.
+        '*/vendor/*',
+    ]);

--- a/src/Drupal/Driver/Cores/Drupal6.php
+++ b/src/Drupal/Driver/Cores/Drupal6.php
@@ -358,7 +358,7 @@ class Drupal6 extends AbstractCore {
     }
 
     if (empty($term->vid)) {
-      throw new \Exception('No "%s" vocabulary found.');
+      throw new \Exception(sprintf('No "%s" vocabulary found.', $term->vocabulary_machine_name));
     }
 
     // Attempt to decipher any fields that may be specified.

--- a/src/Drupal/Driver/Cores/Drupal6.php
+++ b/src/Drupal/Driver/Cores/Drupal6.php
@@ -183,7 +183,7 @@ class Drupal6 extends AbstractCore {
    */
   protected function checkPermissions(array $permissions, $reset = FALSE) {
 
-    if (!isset($this->availablePermissons) || $reset) {
+    if ($this->availablePermissons === NULL || $reset) {
       $this->availablePermissons = array_keys(module_invoke_all('permission'));
     }
 
@@ -203,7 +203,7 @@ class Drupal6 extends AbstractCore {
     // Verify permissions exist.
     $all_permissions = module_invoke_all('perm');
     foreach ($permissions as $name) {
-      $search = array_search($name, $all_permissions);
+      $search = array_search($name, $all_permissions, TRUE);
       if (!$search) {
         throw new \RuntimeException(sprintf("No permission '%s' exists.", $name));
       }
@@ -274,11 +274,11 @@ class Drupal6 extends AbstractCore {
     $_SERVER['HTTP_USER_AGENT'] = NULL;
 
     $conf_path = conf_path(TRUE, TRUE);
-    $conf_file = $this->drupalRoot . "/$conf_path/settings.php";
+    $conf_file = $this->drupalRoot . sprintf('/%s/settings.php', $conf_path);
     if (!file_exists($conf_file)) {
       throw new BootstrapException(sprintf('Could not find a Drupal settings.php file at "%s"', $conf_file));
     }
-    $drushrc_file = $this->drupalRoot . "/$conf_path/drushrc.php";
+    $drushrc_file = $this->drupalRoot . sprintf('/%s/drushrc.php', $conf_path);
     if (file_exists($drushrc_file)) {
       require_once $drushrc_file;
     }
@@ -318,7 +318,7 @@ class Drupal6 extends AbstractCore {
    */
   protected function taxonomyVocabularyLoadMultiple(array $vids = []) {
     $vocabularies = taxonomy_get_vocabularies();
-    if ($vids) {
+    if ($vids !== []) {
       return array_intersect_key($vocabularies, array_flip($vids));
     }
     return $vocabularies;
@@ -331,7 +331,7 @@ class Drupal6 extends AbstractCore {
     // Map vocabulary names to vid, these take precedence over machine names.
     if (!isset($term->vid)) {
       $vocabularies = \taxonomy_get_vocabularies();
-      foreach ($vocabularies as $vid => $vocabulary) {
+      foreach ($vocabularies as $vocabulary) {
         if ($vocabulary->name == $term->vocabulary_machine_name) {
           $term->vid = $vocabulary->vid;
         }
@@ -358,7 +358,7 @@ class Drupal6 extends AbstractCore {
     }
 
     if (empty($term->vid)) {
-      throw new \Exception(sprintf('No "%s" vocabulary found.'));
+      throw new \Exception('No "%s" vocabulary found.');
     }
 
     // Attempt to decipher any fields that may be specified.
@@ -375,21 +375,19 @@ class Drupal6 extends AbstractCore {
     // only be one matching term in a testing context, so take the first match
     // by reset()'ing $matches.
     $matches = \taxonomy_get_term_by_name($term->name);
-    $saved_term = reset($matches);
 
-    return $saved_term;
+    return reset($matches);
   }
 
   /**
    * {@inheritdoc}
    */
   public function termDelete(\stdClass $term) {
-    $status = 0;
     if (isset($term->tid)) {
-      $status = \taxonomy_del_term($term->tid);
+      return \taxonomy_del_term($term->tid);
     }
     // Will be SAVED_DELETED (3) on success.
-    return $status;
+    return 0;
   }
 
   /**
@@ -452,9 +450,7 @@ class Drupal6 extends AbstractCore {
       }
     }
 
-    $return += $taxonomy_fields;
-
-    return $return;
+    return $return + $taxonomy_fields;
   }
 
   /**

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -165,7 +165,7 @@ class Drupal7 extends AbstractCore {
 
     foreach ($permissions as $key => $name) {
       if (!isset($all_permissions[$name])) {
-        $search = array_search($name, $all_permissions);
+        $search = array_search($name, $all_permissions, TRUE);
         if (!$search) {
           throw new \RuntimeException(sprintf("No permission '%s' exists.", $name));
         }
@@ -179,7 +179,7 @@ class Drupal7 extends AbstractCore {
     user_role_save($role);
     user_role_grant_permissions($role->rid, $permissions);
 
-    if ($role && !empty($role->rid)) {
+    if (!empty($role->rid)) {
       return $role->name;
     }
 
@@ -239,11 +239,11 @@ class Drupal7 extends AbstractCore {
     $_SERVER['HTTP_USER_AGENT'] = NULL;
 
     $conf_path = conf_path(TRUE, TRUE);
-    $conf_file = $this->drupalRoot . "/$conf_path/settings.php";
+    $conf_file = $this->drupalRoot . sprintf('/%s/settings.php', $conf_path);
     if (!file_exists($conf_file)) {
       throw new BootstrapException(sprintf('Could not find a Drupal settings.php file at "%s"', $conf_file));
     }
-    $drushrc_file = $this->drupalRoot . "/$conf_path/drushrc.php";
+    $drushrc_file = $this->drupalRoot . sprintf('/%s/drushrc.php', $conf_path);
     if (file_exists($drushrc_file)) {
       require_once $drushrc_file;
     }
@@ -279,7 +279,7 @@ class Drupal7 extends AbstractCore {
     // Map vocabulary names to vid, these take precedence over machine names.
     if (!isset($term->vid)) {
       $vocabularies = \taxonomy_get_vocabularies();
-      foreach ($vocabularies as $vid => $vocabulary) {
+      foreach ($vocabularies as $vocabulary) {
         if ($vocabulary->name == $term->vocabulary_machine_name) {
           $term->vid = $vocabulary->vid;
         }
@@ -323,12 +323,11 @@ class Drupal7 extends AbstractCore {
    * {@inheritdoc}
    */
   public function termDelete(\stdClass $term) {
-    $status = 0;
     if (isset($term->tid)) {
-      $status = \taxonomy_term_delete($term->tid);
+      return \taxonomy_term_delete($term->tid);
     }
     // Will be SAVED_DELETED (3) on success.
-    return $status;
+    return 0;
   }
 
   /**
@@ -346,7 +345,7 @@ class Drupal7 extends AbstractCore {
 
     // If the language code is not valid then throw an InvalidArgumentException.
     if (!isset($predefined_languages[$language->langcode])) {
-      throw new \InvalidArgumentException("There is no predefined language with langcode '{$language->langcode}'.");
+      throw new \InvalidArgumentException(sprintf("There is no predefined language with langcode '%s'.", $language->langcode));
     }
 
     // Enable a language only if it has not been enabled already.
@@ -507,7 +506,7 @@ class Drupal7 extends AbstractCore {
     if (isset($entity->$bundle_key) && ($entity->$bundle_key !== NULL)) {
       $bundles = $info['bundles'];
       if (!in_array($entity->$bundle_key, array_keys($bundles))) {
-        throw new \Exception("Cannot create entity because provided bundle {$entity->$bundle_key} does not exist.");
+        throw new \Exception(sprintf('Cannot create entity because provided bundle %s does not exist.', $entity->$bundle_key));
       }
     }
     if (empty($entity_type)) {

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -520,7 +520,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
       $bundle_info = \Drupal::service('entity_type.bundle.info');
       $bundles = $bundle_info->getBundleInfo($entity_type);
       if (!in_array($entity->$bundle_key, array_keys($bundles))) {
-        throw new \Exception(sprintf("Cannot create entity because provided bundle '%s->%s' does not exist.", $entity, $bundle_key));
+        throw new \Exception(sprintf("Cannot create entity because provided bundle '%s' does not exist.", $entity->$bundle_key));
       }
     }
     if (empty($entity_type)) {

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -57,6 +57,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
     // @see https://www.drupal.org/node/3151009
     $request->attributes->set('_route_object', new Route('<none>'));
     $request->attributes->set('_route', '<none>');
+
     $kernel->preHandle($request);
 
     // Initialise an anonymous session. required for the bootstrap.
@@ -210,7 +211,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
     $permissions = &drupal_static(__FUNCTION__);
 
     if (!isset($permissions)) {
-      $permissions = \Drupal::service('user.permissions')->getPermissions();
+      return \Drupal::service('user.permissions')->getPermissions();
     }
 
     return $permissions;
@@ -226,7 +227,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
     $all_permissions = $this->getAllPermissions();
 
     foreach ($all_permissions as $name => $definition) {
-      $key = array_search($definition['title'], $permissions);
+      $key = array_search($definition['title'], $permissions, TRUE);
       if (FALSE !== $key) {
         $permissions[$key] = $name;
       }
@@ -317,11 +318,11 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
     $_SERVER['REQUEST_URI'] = $_SERVER['SCRIPT_NAME'] = $_SERVER['PHP_SELF'];
 
     $conf_path = DrupalKernel::findSitePath(Request::createFromGlobals());
-    $conf_file = $this->drupalRoot . "/$conf_path/settings.php";
+    $conf_file = $this->drupalRoot . sprintf('/%s/settings.php', $conf_path);
     if (!file_exists($conf_file)) {
       throw new BootstrapException(sprintf('Could not find a Drupal settings.php file at "%s"', $conf_file));
     }
-    $drushrc_file = $this->drupalRoot . "/$conf_path/drushrc.php";
+    $drushrc_file = $this->drupalRoot . sprintf('/%s/drushrc.php', $conf_path);
     if (file_exists($drushrc_file)) {
       require_once $drushrc_file;
     }
@@ -404,7 +405,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
     $return = [];
     $entity_field_manager = $this->getEntityFieldManager();
     $fields = $entity_field_manager->getFieldStorageDefinitions($entity_type);
-    if (!empty($base_fields)) {
+    if ($base_fields !== []) {
       $fields += $entity_field_manager->getBaseFieldDefinitions($entity_type);
     }
     foreach ($fields as $field_name => $field) {
@@ -452,7 +453,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
     if (!ConfigurableLanguage::load($langcode)) {
       $created_language = ConfigurableLanguage::createFromLangcode($language->langcode);
       if (!$created_language) {
-        throw new \InvalidArgumentException("There is no predefined language with langcode '{$langcode}'.");
+        throw new \InvalidArgumentException(sprintf("There is no predefined language with langcode '%s'.", $langcode));
       }
       $created_language->save();
       return $language;
@@ -519,7 +520,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
       $bundle_info = \Drupal::service('entity_type.bundle.info');
       $bundles = $bundle_info->getBundleInfo($entity_type);
       if (!in_array($entity->$bundle_key, array_keys($bundles))) {
-        throw new \Exception("Cannot create entity because provided bundle '$entity->$bundle_key' does not exist.");
+        throw new \Exception(sprintf("Cannot create entity because provided bundle '%s->%s' does not exist.", $entity, $bundle_key));
       }
     }
     if (empty($entity_type)) {
@@ -593,9 +594,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
     \Drupal::state()->resetCache();
     $mail = \Drupal::state()->get('system.test_mail_collector') ?: [];
     // Discard cancelled mail.
-    $mail = array_values(array_filter($mail, function ($mail_item) {
-      return ($mail_item['send'] == TRUE);
-    }));
+    $mail = array_values(array_filter($mail, fn($mail_item) => $mail_item['send'] == TRUE));
     return $mail;
   }
 
@@ -614,8 +613,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
     $params['context']['message'] = $body;
     $params['context']['subject'] = $subject;
     $mail_manager = \Drupal::service('plugin.manager.mail');
-    $result = $mail_manager->mail('system', '', $to, $langcode, $params, NULL, TRUE);
-    return $result;
+    return $mail_manager->mail('system', '', $to, $langcode, $params, NULL, TRUE);
   }
 
   /**
@@ -682,7 +680,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
         \Drupal::service('account_switcher')->switchBack();
       }
     }
-    catch (\RuntimeException $e) {
+    catch (\RuntimeException $runtime_exception) {
       // No more users are logged in.
     }
   }

--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -156,7 +156,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
    * @see drush_drupal_version()
    */
   public function getDrupalVersion() {
-    if (!isset($this->version)) {
+    if ($this->version === NULL) {
       // Support 6, 7 and 8.
       $version_constant_paths = [
         // Drupal 6.
@@ -180,7 +180,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
       if (defined('VERSION')) {
         $version = VERSION;
       }
-      elseif (defined('\Drupal::VERSION')) {
+      elseif (defined(\Drupal::class . '::VERSION')) {
         $version = \Drupal::VERSION;
       }
       else {

--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -145,7 +145,7 @@ class DrushDriver extends BaseDriver {
     // Check that the given alias works.
     // @todo check that this is a functioning alias.
     // See http://drupal.org/node/1615450
-    if (!isset($this->alias) && !isset($this->root)) {
+    if ($this->alias === NULL && $this->root === NULL) {
       throw new BootstrapException('A drush alias or root path is required.');
     }
 
@@ -170,15 +170,10 @@ class DrushDriver extends BaseDriver {
       // On PHP 8.4, deprecation warnings from Drush dependencies may be
       // written to stdout before the version string. Extract the actual
       // version number from the output to avoid misdetection.
-      if (preg_match('/(\d+\.\d+\.\d+(\.\d+)?)\s*$/', $output, $matches)) {
-        $version = $matches[1];
-      }
-      else {
-        $version = $output;
-      }
+      $version = preg_match('/(\d+\.\d+\.\d+(\.\d+)?)\s*$/', $output, $matches) ? $matches[1] : $output;
       return version_compare($version, '9', '<=');
     }
-    catch (\RuntimeException $e) {
+    catch (\RuntimeException $runtime_exception) {
       // The version of drush is old enough that only `--version` was available,
       // so this is a legacy version.
       return TRUE;
@@ -234,7 +229,10 @@ class DrushDriver extends BaseDriver {
       foreach ($lines as $line) {
         // Skip header, separator, and empty lines.
         $trimmed = trim($line, " \t\n\r\0\x0B-");
-        if ($trimmed === '' || str_contains($trimmed, 'User ID')) {
+        if ($trimmed === '') {
+          continue;
+        }
+        if (str_contains($trimmed, 'User ID')) {
           continue;
         }
         // The first column in the data row is the User ID.
@@ -243,6 +241,7 @@ class DrushDriver extends BaseDriver {
         }
       }
     }
+    return NULL;
   }
 
   /**
@@ -290,8 +289,8 @@ class DrushDriver extends BaseDriver {
     }
     if (($type == 'all') || ($type == 'drush')) {
       $this->drush('cache-clear', ['drush'], []);
-      if ($type == 'drush') {
-        return;
+      if ($type === 'drush') {
+        return NULL;
       }
     }
     return $this->drush('cache:rebuild');
@@ -408,7 +407,7 @@ class DrushDriver extends BaseDriver {
       $result = $this->drush('behat', $arguments, []);
       return strpos($result, "true\n") !== FALSE;
     }
-    catch (\Exception $e) {
+    catch (\Exception $exception) {
       return FALSE;
     }
   }
@@ -465,14 +464,14 @@ class DrushDriver extends BaseDriver {
     else {
       $options['no-ansi'] = NULL;
     }
-    $string_options = $this->parseArguments($options);
+    $string_options = static::parseArguments($options);
 
-    $alias = isset($this->alias) ? "@{$this->alias}" : '--root=' . $this->root;
+    $alias = $this->alias !== NULL ? '@' . $this->alias : '--root=' . $this->root;
 
     // Add any global arguments.
     $global = $this->getArguments();
 
-    $cmd = "{$this->binary} {$alias} {$string_options} {$global} {$command} {$arguments}";
+    $cmd = sprintf('%s %s %s %s %s %s', $this->binary, $alias, $string_options, $global, $command, $arguments);
     $process = method_exists(Process::class, 'fromShellCommandline') ? Process::fromShellCommandline($cmd) : new Process($cmd);
     $process->setTimeout(3600);
     $process->run();
@@ -484,12 +483,10 @@ class DrushDriver extends BaseDriver {
     // Some drush commands write to standard error output (for example enable
     // use drush_log which default to _drush_print_log) instead of returning a
     // string (drush status use drush_print_pipe).
-    if (!$process->getOutput()) {
+    if ($process->getOutput() === '' || $process->getOutput() === '0') {
       return $process->getErrorOutput();
     }
-    else {
-      return $process->getOutput();
-    }
+    return $process->getOutput();
 
   }
 

--- a/src/Drupal/Driver/Fields/Drupal7/AbstractHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/AbstractHandler.php
@@ -14,28 +14,28 @@ abstract class AbstractHandler implements FieldHandlerInterface {
    *
    * @var string
    */
-  protected $language = NULL;
+  protected $language;
 
   /**
    * The simulated entity.
    *
    * @var object
    */
-  protected $entity = NULL;
+  protected $entity;
 
   /**
    * The entity type.
    *
    * @var string
    */
-  protected $entityType = NULL;
+  protected $entityType;
 
   /**
    * The field name.
    *
    * @var string
    */
-  protected $fieldName = NULL;
+  protected $fieldName;
 
   /**
    * The field array, as returned by field_read_fields().

--- a/src/Drupal/Driver/Fields/Drupal7/ListTextHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/ListTextHandler.php
@@ -25,9 +25,11 @@ class ListTextHandler extends AbstractHandler {
       if (array_key_exists($value, $options)) {
         $allowed_values[$value] = $value;
       }
-      elseif (in_array($value, $options)) {
+      else {
         $key = array_search($value, $options, TRUE);
-        $allowed_values[$value] = $key;
+        if ($key !== FALSE) {
+          $allowed_values[$value] = $key;
+        }
       }
     }
     foreach ($values as $value) {

--- a/src/Drupal/Driver/Fields/Drupal7/ListTextHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/ListTextHandler.php
@@ -26,7 +26,7 @@ class ListTextHandler extends AbstractHandler {
         $allowed_values[$value] = $value;
       }
       elseif (in_array($value, $options)) {
-        $key = array_search($value, $options);
+        $key = array_search($value, $options, TRUE);
         $allowed_values[$value] = $key;
       }
     }

--- a/src/Drupal/Driver/Fields/Drupal7/TaxonomyTermReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal7/TaxonomyTermReferenceHandler.php
@@ -33,6 +33,7 @@ class TaxonomyTermReferenceHandler extends AbstractHandler {
     if (!empty($this->fieldInfo['settings']['allowed_values'][0]['vocabulary'])) {
       return $this->fieldInfo['settings']['allowed_values'][0]['vocabulary'];
     }
+    return NULL;
   }
 
 }

--- a/src/Drupal/Driver/Fields/Drupal8/AbstractHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/AbstractHandler.php
@@ -13,14 +13,14 @@ abstract class AbstractHandler implements FieldHandlerInterface {
    *
    * @var \Drupal\field\Entity\FieldStorageConfig
    */
-  protected $fieldInfo = NULL;
+  protected $fieldInfo;
 
   /**
    * Field configuration definition.
    *
    * @var \Drupal\field\Entity\FieldConfig
    */
-  protected $fieldConfig = NULL;
+  protected $fieldConfig;
 
   /**
    * Constructs an AbstractHandler object.
@@ -49,7 +49,7 @@ abstract class AbstractHandler implements FieldHandlerInterface {
     // of the entity's bundle key. If both are empty, assume this is a single
     // bundle entity, and therefore make the bundle name the entity type.
     $bundle_key = \Drupal::entityTypeManager()->getDefinition($entity_type)->getKey('bundle');
-    $bundle = !empty($entity->$bundle_key) ? $entity->$bundle_key : ($entity->step_bundle ?? $entity_type);
+    $bundle = empty($entity->$bundle_key) ? $entity->step_bundle ?? $entity_type : ($entity->$bundle_key);
 
     $fields = $entity_field_manager->getFieldDefinitions($entity_type, $bundle);
     $fieldsstring = '';

--- a/src/Drupal/Driver/Fields/Drupal8/AddressHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/AddressHandler.php
@@ -29,12 +29,7 @@ class AddressHandler extends AbstractHandler {
     // Any overrides that set field inputs to hidden will be skipped.
     foreach ($overrides as $key => $value) {
       preg_match('/[A-Z]/', $key, $matches, PREG_OFFSET_CAPTURE);
-      if (count($matches) > 0) {
-        $field_name = strtolower(substr_replace($key, '_', $matches[0][1], 0));
-      }
-      else {
-        $field_name = $key;
-      }
+      $field_name = $matches !== [] ? strtolower(substr_replace($key, '_', $matches[0][1], 0)) : $key;
       if ($value['override'] === 'hidden') {
         $remove_key = array_search($field_name, $address_fields, TRUE);
         unset($address_fields[$remove_key]);

--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -18,13 +18,7 @@ class EntityReferenceHandler extends AbstractHandler {
     $id_key = $entity_definition->getKey('id');
 
     // Determine label field key.
-    if ($entity_type_id !== 'user') {
-      $label_key = $entity_definition->getKey('label');
-    }
-    else {
-      // Entity Definition->getKey('label') returns false for users.
-      $label_key = 'name';
-    }
+    $label_key = $entity_type_id !== 'user' ? $entity_definition->getKey('label') : 'name';
 
     if (!$label_key && $entity_type_id == 'user') {
       $label_key = 'name';
@@ -75,6 +69,7 @@ class EntityReferenceHandler extends AbstractHandler {
     if (!empty($settings['handler_settings']['target_bundles'])) {
       return $settings['handler_settings']['target_bundles'];
     }
+    return NULL;
   }
 
 }

--- a/src/Drupal/Driver/Fields/Drupal8/ImageHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/ImageHandler.php
@@ -24,13 +24,11 @@ class ImageHandler extends AbstractHandler {
     }
 
     $file->save();
-
-    $return = [
+    return [
       'target_id' => $file->id(),
       'alt' => 'Behat test image',
       'title' => 'Behat test image',
     ];
-    return $return;
   }
 
 }

--- a/src/Drupal/Driver/Fields/Drupal8/ListHandlerBase.php
+++ b/src/Drupal/Driver/Fields/Drupal8/ListHandlerBase.php
@@ -19,7 +19,7 @@ abstract class ListHandlerBase extends AbstractHandler {
     $allowed_values = $this->fieldInfo->getSetting('allowed_values');
     foreach ((array) $values as $value) {
       // Determine if a label matching the value is found.
-      $key = array_search($value, $allowed_values);
+      $key = array_search($value, $allowed_values, TRUE);
       if ($key !== FALSE) {
         // Set the return to use the key instead of the value.
         $return[] = $key;

--- a/src/Drupal/Driver/Fields/Drupal8/SupportedImageHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/SupportedImageHandler.php
@@ -26,7 +26,7 @@ class SupportedImageHandler extends AbstractHandler {
     foreach ($values as $value) {
       $file_path = (string) ($value['target_id'] ?? $value);
       $file_extension = pathinfo($file_path, PATHINFO_EXTENSION);
-      $data = file_get_contents((string) $file_path);
+      $data = file_get_contents($file_path);
 
       if ($data === FALSE) {
         throw new \Exception("Error reading file");

--- a/src/Drupal/Driver/Fields/Drupal8/TimeHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/TimeHandler.php
@@ -11,7 +11,7 @@ class TimeHandler extends AbstractHandler {
    * {@inheritdoc}
    */
   public function expand($values) {
-    $values = array_map(function ($value) {
+    return array_map(function ($value) {
       // Value is numeric so it is safe to assume we have the seconds passed in
       // the storage format (seconds past midnight).
       if (is_numeric($value)) {
@@ -22,8 +22,6 @@ class TimeHandler extends AbstractHandler {
       $midnight = strtotime('today midnight');
       return strtotime($value) - $midnight;
     }, $values);
-
-    return $values;
   }
 
 }

--- a/tests/Drupal/Tests/Driver/Drupal8FieldMethodsTest.php
+++ b/tests/Drupal/Tests/Driver/Drupal8FieldMethodsTest.php
@@ -5,7 +5,7 @@
 // This must be declared before any class that references it.
 // phpcs:disable
 namespace Drupal\field\Entity {
-  if (!class_exists('Drupal\field\Entity\FieldStorageConfig')) {
+  if (!class_exists(\Drupal\field\Entity\FieldStorageConfig::class)) {
     class FieldStorageConfig {
       protected $type;
       public function __construct(string $type) { $this->type = $type; }
@@ -99,10 +99,10 @@ namespace Drupal\Tests\Driver {
       $result = $core->getEntityFieldTypes('node', $base_fields_arg);
 
       foreach ($expected_fields as $field_name) {
-        $this->assertArrayHasKey($field_name, $result, "Expected '$field_name' in result.");
+        $this->assertArrayHasKey($field_name, $result, sprintf("Expected '%s' in result.", $field_name));
       }
       foreach ($unexpected_fields as $field_name) {
-        $this->assertArrayNotHasKey($field_name, $result, "Did not expect '$field_name' in result.");
+        $this->assertArrayNotHasKey($field_name, $result, sprintf("Did not expect '%s' in result.", $field_name));
       }
     }
 

--- a/tests/Drupal/Tests/Driver/Drupal8Test.php
+++ b/tests/Drupal/Tests/Driver/Drupal8Test.php
@@ -58,6 +58,7 @@ class Drupal8Test extends TestCase {
     // Wire a container with request_stack and cron service.
     $request_stack = new RequestStack();
     $request_stack->push($request);
+
     $container = new ContainerBuilder();
     $container->set('request_stack', $request_stack);
     $container->set('cron', $cron);

--- a/tests/Drupal/Tests/Driver/FieldHandlerAbstractTestBase.php
+++ b/tests/Drupal/Tests/Driver/FieldHandlerAbstractTestBase.php
@@ -12,7 +12,7 @@ abstract class FieldHandlerAbstractTestBase extends TestCase {
   /**
    * {@inheritdoc}
    */
-  public function tearDown(): void {
+  protected function tearDown(): void {
     \Mockery::close();
   }
 


### PR DESCRIPTION
## Summary

- Added a project-level `rector.php` configuration targeting PHP 7.4, replacing the previous approach of copying `palantirnet/drupal-rector`'s config into the `drupal/` directory before running Rector against a limited set of files.
- The new config enables dead code, code quality, coding style, early return, and `instanceof` rule sets, with targeted skips for rules that conflict with Drupal coding standards or the existing mixed-type codebase.
- Simplified `composer lint` and `composer lint-fix` scripts to invoke `rector process` directly using the project-level config, removing the fragile `cp` + `cd` workaround.
- Applied Rector fixes across 18 source and test files, covering: removal of useless variables, strict `array_search()` comparisons, ternary-to-null-coalescing simplifications, explicit `return` statements, encapsulated string literals converted to `sprintf()`, and dead code removal.

## Test plan

- [ ] Run `composer lint` and confirm Rector reports no remaining fixable issues.
- [ ] Run `composer test` and confirm all existing tests pass.
- [ ] Verify `rector.php` is picked up automatically without any `cp` or directory-change steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced permission and entity validation with stricter type checking
  * Improved error message clarity and consistency

* **Refactor**
  * Streamlined internal logic and simplified code across multiple modules
  * Optimized field handling and validation workflows

* **Chores**
  * Updated code quality configuration and development tooling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->