### PR TITLE
Fixed permission label conversion broken by Rector strict comparison.

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
 use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
 use Rector\Config\RectorConfig;
+use Rector\EarlyReturn\Rector\StmtsAwareInterface\ReturnEarlyIfVariableRector;
 use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 
 return RectorConfig::configure()
@@ -36,6 +37,11 @@ return RectorConfig::configure()
         CatchExceptionNameMatchingTypeRector::class,
         // Too aggressive for mixed-type codebase.
         DisallowedEmptyRuleFixerRector::class,
+        // Breaks 'drupal_static()' caching in 'Drupal8::getAllPermissions()':
+        // assigning into the static reference is required for subsequent
+        // calls to hit the cache, so the intermediate variable is not dead
+        // code even though Rector thinks it is.
+        ReturnEarlyIfVariableRector::class,
         // Legacy test with PHPUnit compatibility issue.
         __DIR__ . '/tests/Drupal/Tests/Driver/Drupal7FieldHandlerTest.php',
         // Dependencies.

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -209,7 +209,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
     $permissions = &drupal_static(__FUNCTION__);
 
     if (!isset($permissions)) {
-      return \Drupal::service('user.permissions')->getPermissions();
+      $permissions = \Drupal::service('user.permissions')->getPermissions();
     }
 
     return $permissions;
@@ -225,8 +225,11 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
     $all_permissions = $this->getAllPermissions();
 
     foreach ($all_permissions as $name => $definition) {
-      $key = array_search($definition['title'], $permissions, TRUE);
-      if (FALSE !== $key) {
+      // Cast the title to string: Drupal returns TranslatableMarkup objects
+      // for permission titles, which would never strictly equal the plain
+      // string labels supplied by callers.
+      $key = array_search((string) $definition['title'], $permissions, TRUE);
+      if ($key !== FALSE) {
         $permissions[$key] = $name;
       }
     }

--- a/tests/Drupal/Tests/Driver/Drupal8PermissionsTest.php
+++ b/tests/Drupal/Tests/Driver/Drupal8PermissionsTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Drupal\Tests\Driver;
+
+use Drupal\Driver\Cores\Drupal8;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests permission label and machine name conversion in the Drupal 8+ driver.
+ */
+class Drupal8PermissionsTest extends TestCase {
+
+  /**
+   * Tests that human-readable titles are converted to machine names.
+   *
+   * Drupal returns permission titles as TranslatableMarkup objects. Strict
+   * comparison against plain string labels would never match, so the driver
+   * must cast the title to string before lookup. This guards against
+   * regressions where automated refactoring flips the comparison to strict
+   * mode without adding the cast.
+   */
+  public function testConvertPermissionsMapsStringableTitlesToMachineNames() {
+    $core = new TestDrupal8PermissionsCore(__DIR__, 'default');
+    $core->setPermissions([
+      'administer content types' => [
+        'title' => $this->stringable('Administer content types'),
+      ],
+      'administer users' => [
+        'title' => $this->stringable('Administer users'),
+      ],
+    ]);
+
+    $permissions = ['Administer content types', 'Administer users'];
+    $this->callConvertPermissions($core, $permissions);
+
+    $this->assertSame(['administer content types', 'administer users'], $permissions);
+  }
+
+  /**
+   * Tests that titles already in machine name form are left unchanged.
+   */
+  public function testConvertPermissionsLeavesMachineNamesAlone() {
+    $core = new TestDrupal8PermissionsCore(__DIR__, 'default');
+    $core->setPermissions([
+      'administer users' => [
+        'title' => $this->stringable('Administer users'),
+      ],
+    ]);
+
+    $permissions = ['administer users'];
+    $this->callConvertPermissions($core, $permissions);
+
+    $this->assertSame(['administer users'], $permissions);
+  }
+
+  /**
+   * Tests that 'checkPermissions()' passes for valid machine names.
+   */
+  public function testCheckPermissionsAcceptsValidMachineNames() {
+    $core = new TestDrupal8PermissionsCore(__DIR__, 'default');
+    $core->setPermissions([
+      'administer users' => ['title' => 'Administer users'],
+      'access content' => ['title' => 'Access content'],
+    ]);
+
+    $permissions = ['administer users', 'access content'];
+    $this->callCheckPermissions($core, $permissions);
+
+    $this->assertSame(['administer users', 'access content'], $permissions);
+  }
+
+  /**
+   * Tests that 'checkPermissions()' throws for unknown machine names.
+   */
+  public function testCheckPermissionsThrowsForUnknownPermission() {
+    $core = new TestDrupal8PermissionsCore(__DIR__, 'default');
+    $core->setPermissions([
+      'administer users' => ['title' => 'Administer users'],
+    ]);
+
+    $permissions = ['administer users', 'unknown permission'];
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Invalid permission "unknown permission".');
+
+    $this->callCheckPermissions($core, $permissions);
+  }
+
+  /**
+   * Invokes the protected 'convertPermissions()' method by reference.
+   */
+  protected function callConvertPermissions(Drupal8 $core, array &$permissions) {
+    $method = new \ReflectionMethod($core, 'convertPermissions');
+    $method->setAccessible(TRUE);
+    $method->invokeArgs($core, [&$permissions]);
+  }
+
+  /**
+   * Invokes the protected 'checkPermissions()' method by reference.
+   */
+  protected function callCheckPermissions(Drupal8 $core, array &$permissions) {
+    $method = new \ReflectionMethod($core, 'checkPermissions');
+    $method->setAccessible(TRUE);
+    $method->invokeArgs($core, [&$permissions]);
+  }
+
+  /**
+   * Returns an anonymous Stringable that mimics a Drupal TranslatableMarkup.
+   */
+  protected function stringable($label) {
+    return new class($label) {
+
+      public function __construct(private $label) {}
+
+      /**
+       * Renders the stringable into its label.
+       */
+      public function __toString(): string {
+        return $this->label;
+      }
+
+    };
+  }
+
+}
+
+/**
+ * Testable subclass that overrides 'getAllPermissions()'.
+ */
+class TestDrupal8PermissionsCore extends Drupal8 {
+
+  /**
+   * Stored permissions keyed by machine name.
+   *
+   * @var array
+   */
+  protected $permissions = [];
+
+  /**
+   * Sets the permissions returned by 'getAllPermissions()'.
+   */
+  public function setPermissions(array $permissions) {
+    $this->permissions = $permissions;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getAllPermissions() {
+    return $this->permissions;
+  }
+
+}


### PR DESCRIPTION
## Summary

Restored the permission label lookup broken by an automated Rector fix in #328, which added strict comparison to `array_search()` and turned the `drupal_static()` cache assignment into an early return. DrupalExtension users were seeing `Invalid permission "Administer content types"` for every permission passed by its human-readable label; permission titles are Drupal `TranslatableMarkup` objects, so strict equality against plain strings always failed and the mapping step silently did nothing. Added a Rector skip entry and a PHPUnit regression suite so the pattern cannot be reintroduced silently.

## Changes

### `src/Drupal/Driver/Cores/Drupal8.php`
- `convertPermissions()`: cast `$definition['title']` to string before the strict `array_search()`, so `TranslatableMarkup` titles match the plain-string labels callers supply. Also normalised the `FALSE !== $key` Yoda condition.
- `getAllPermissions()`: restored the static-cache assignment so `drupal_static(__FUNCTION__)` populates on the first call (Rector had replaced it with an early `return`, which bypassed the cached reference).

### `rector.php`
- Added `ReturnEarlyIfVariableRector` to the `withSkip()` list with a comment explaining why the `drupal_static()` pattern is not dead code.

### `tests/Drupal/Tests/Driver/Drupal8PermissionsTest.php` (new)
- 4 regression tests covering the label-to-machine name conversion (including a Stringable title stand-in for `TranslatableMarkup`), the machine-name-idempotent path, and the `checkPermissions()` pass/throw cases.
- Introduces a `TestDrupal8PermissionsCore` subclass that overrides `getAllPermissions()` so the tests stay free of a Drupal bootstrap.

## Before / After

```
convertPermissions() title comparison:

Before (Rector strict, no cast):
  array_search( TranslatableMarkup("Administer users"),  ["Administer users"],  TRUE )
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^
                object                                    string
                                        strict === -> always FALSE
                        -> label never mapped -> checkPermissions() throws

After (string cast, strict):
  array_search( (string) TranslatableMarkup("Administer users"),  ["Administer users"],  TRUE )
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^
                "Administer users"                                  "Administer users"
                                        strict === -> TRUE
                        -> $permissions[$key] = "administer users" -> valid
```

```
getAllPermissions() static cache:

Before:                                     After:
  $p = &drupal_static(__FUNCTION__);          $p = &drupal_static(__FUNCTION__);
  if (!isset($p)) {                           if (!isset($p)) {
    return \Drupal::service(...)->...;          $p = \Drupal::service(...)->...;
  }                                           }
  return $p;                                  return $p;
  ────────────────                            ────────────────
  cache never populated,                       cache populated on first call,
  every call hits user.permissions             subsequent calls are O(1)
```
