### PR TITLE
Added 'declare(strict_types=1)' and PHP 8.2 type declarations via Rector.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,9 +36,11 @@
         "drupal/mailsystem": "^4.4 || 4.x-dev",
         "drush-ops/behat-drush-endpoint": "*",
         "ergebnis/composer-normalize": "^2.50",
+        "mglaman/phpstan-drupal": "^2.0",
         "mockery/mockery": "^1.5",
         "php-parallel-lint/php-parallel-lint": "^1.0",
         "phpspec/phpspec": "^7.5 || dev-main",
+        "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^9.6 || ^10 || ^11",
         "rector/rector": "^2.0",
         "symfony/phpunit-bridge": "^6.4 || ^7",
@@ -91,6 +93,7 @@
         "lint": [
             "XDEBUG_MODE=off parallel-lint src spec tests",
             "XDEBUG_MODE=off phpcs",
+            "XDEBUG_MODE=off phpstan",
             "XDEBUG_MODE=off rector process --dry-run"
         ],
         "lint-fix": [

--- a/composer.json
+++ b/composer.json
@@ -37,10 +37,10 @@
         "drush-ops/behat-drush-endpoint": "*",
         "ergebnis/composer-normalize": "^2.50",
         "mockery/mockery": "^1.5",
-        "palantirnet/drupal-rector": "^0.20",
         "php-parallel-lint/php-parallel-lint": "^1.0",
         "phpspec/phpspec": "^7.5 || dev-main",
         "phpunit/phpunit": "^9.6 || ^10 || ^11",
+        "rector/rector": "^2.0",
         "symfony/phpunit-bridge": "^6.4 || ^7",
         "webmozart/assert": "^2.3"
     },

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -42,4 +42,16 @@
         <exclude-pattern>*/spec/*</exclude-pattern>
     </rule>
 
+    <!-- Enforce native PHP type declarations on parameters, returns and
+         properties (auto-fixable when types exist in docblocks). -->
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
+        <exclude-pattern>*/spec/*</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
+        <exclude-pattern>*/spec/*</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
+        <exclude-pattern>*/spec/*</exclude-pattern>
+    </rule>
+
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,7 +10,6 @@
     <file>tests</file>
 
     <rule ref="Drupal">
-        <exclude name="Drupal.Files.LineLength.TooLong"/>
         <exclude name="Drupal.Semantics.FunctionTriggerError"/>
         <exclude name="Drupal.Commenting.Deprecated"/>
     </rule>
@@ -37,11 +36,6 @@
     </rule>
     <rule ref="Drupal.Commenting.VariableComment">
         <exclude-pattern>*/spec/*</exclude-pattern>
-    </rule>
-
-    <!-- Strict types deferred to v3.x. -->
-    <rule ref="Generic.PHP.RequireStrictTypes">
-        <severity>0</severity>
     </rule>
 
     <rule ref="DrevOps">

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,26 @@
+##
+# Configuration file for PHPStan static code checking, see https://phpstan.org .
+#
+
+includes:
+  - vendor/mglaman/phpstan-drupal/extension.neon
+  - vendor/phpstan/phpstan-deprecation-rules/rules.neon
+
+parameters:
+
+  level: 3
+
+  paths:
+    - src
+    - tests
+
+  excludePaths:
+    - vendor/*
+
+  ignoreErrors:
+    -
+      # Tests and data providers do not require parameter docblocks, so the
+      # iterable type cannot always be specified.
+      message: '#.*no value type specified in iterable type array.#'
+      path: tests/*
+      reportUnmatched: false

--- a/rector.php
+++ b/rector.php
@@ -10,33 +10,68 @@
 
 declare(strict_types=1);
 
+use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
+use Rector\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector;
+use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
 use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
+use Rector\CodingStyle\Rector\ClassLike\NewlineBetweenClassLikeStmtsRector;
+use Rector\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector;
+use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
 use Rector\EarlyReturn\Rector\StmtsAwareInterface\ReturnEarlyIfVariableRector;
+use Rector\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector;
+use Rector\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector;
+use Rector\Naming\Rector\ClassMethod\RenameVariableToMatchNewTypeRector;
+use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector;
+use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchMethodCallReturnTypeRector;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\YieldDataProviderRector;
 use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
 
 return RectorConfig::configure()
     ->withPaths([
         __DIR__ . '/src/**',
         __DIR__ . '/tests/**',
     ])
-    // PHP 7.4 only - strict types and PHP 8.0+ features deferred to v3.x.
-    ->withPhpSets(php74: TRUE)
+    ->withPhpSets(php82: TRUE)
     ->withPreparedSets(
         deadCode: TRUE,
         codeQuality: TRUE,
         codingStyle: TRUE,
+        typeDeclarations: TRUE,
+        naming: TRUE,
         instanceOf: TRUE,
         earlyReturn: TRUE,
     )
+    ->withRules([
+        DeclareStrictTypesRector::class,
+        YieldDataProviderRector::class,
+    ])
     ->withSkip([
-        // Conflicts with Drupal coding style.
-        NewlineAfterStatementRector::class,
-        // Conflicts with PHPCS snake_case variable naming.
+        // Rules added by Rector's rule sets.
         CatchExceptionNameMatchingTypeRector::class,
-        // Too aggressive for mixed-type codebase.
+        ChangeSwitchToMatchRector::class,
+        // Constructor property promotion mangles existing docblocks for the
+        // promoted parameter and trips PHPCS multi-line declaration sniffs.
+        ClassPropertyAssignToConstructorPromotionRector::class,
+        CompleteDynamicPropertiesRector::class,
+        CountArrayToEmptyArrayComparisonRector::class,
         DisallowedEmptyRuleFixerRector::class,
+        InlineArrayReturnAssignRector::class,
+        NewlineAfterStatementRector::class,
+        NewlineBeforeNewAssignSetRector::class,
+        NewlineBetweenClassLikeStmtsRector::class,
+        RemoveAlwaysTrueIfConditionRector::class,
+        RenameForeachValueVariableToMatchExprVariableRector::class,
+        RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,
+        RenameParamToMatchTypeRector::class,
+        RenameVariableToMatchMethodCallReturnTypeRector::class,
+        RenameVariableToMatchNewTypeRector::class,
+        SimplifyEmptyCheckOnEmptyArrayRector::class,
         // Breaks 'drupal_static()' caching in 'Drupal8::getAllPermissions()':
         // assigning into the static reference is required for subsequent
         // calls to hit the cache, so the intermediate variable is not dead
@@ -44,4 +79,9 @@ return RectorConfig::configure()
         ReturnEarlyIfVariableRector::class,
         // Dependencies.
         '*/vendor/*',
-    ]);
+    ])
+    ->withFileExtensions([
+        'php',
+        'inc',
+    ])
+    ->withImportNames(importNames: TRUE, importDocBlockNames: FALSE, importShortClasses: FALSE);

--- a/spec/Drupal/Driver/Cores/Drupal8Spec.php
+++ b/spec/Drupal/Driver/Cores/Drupal8Spec.php
@@ -12,7 +12,7 @@ class Drupal8Spec extends ObjectBehavior
 {
     function let(Random $random)
     {
-        $this->beConstructedWith('path', 'http://www.example.com', $random);
+        $this->beConstructedWith(__DIR__, 'http://www.example.com', $random);
     }
 
     function it_is_initializable()

--- a/src/Drupal/Driver/AuthenticationDriverInterface.php
+++ b/src/Drupal/Driver/AuthenticationDriverInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver;
 
 /**

--- a/src/Drupal/Driver/AuthenticationDriverInterface.php
+++ b/src/Drupal/Driver/AuthenticationDriverInterface.php
@@ -12,11 +12,11 @@ interface AuthenticationDriverInterface {
   /**
    * Logs the user in.
    */
-  public function login(\stdClass $user);
+  public function login(\stdClass $user): void;
 
   /**
    * Logs the user out.
    */
-  public function logout();
+  public function logout(): void;
 
 }

--- a/src/Drupal/Driver/BaseDriver.php
+++ b/src/Drupal/Driver/BaseDriver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Driver;
 
+use Drupal\Component\Utility\Random;
 use Drupal\Driver\Exception\UnsupportedDriverActionException;
 
 /**
@@ -14,145 +15,146 @@ abstract class BaseDriver implements DriverInterface {
   /**
    * {@inheritdoc}
    */
-  public function getRandom() {
+  public function getRandom(): Random {
     throw new UnsupportedDriverActionException($this->errorString('generate random'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function bootstrap() {
+  public function bootstrap(): void {
   }
 
   /**
    * {@inheritdoc}
    */
-  public function isBootstrapped() {
+  public function isBootstrapped(): bool {
+    return FALSE;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function userCreate(\stdClass $user) {
+  public function userCreate(\stdClass $user): void {
     throw new UnsupportedDriverActionException($this->errorString('create users'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function userDelete(\stdClass $user) {
+  public function userDelete(\stdClass $user): void {
     throw new UnsupportedDriverActionException($this->errorString('delete users'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function processBatch() {
+  public function processBatch(): void {
     throw new UnsupportedDriverActionException($this->errorString('process batch actions'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function userAddRole(\stdClass $user, $role) {
+  public function userAddRole(\stdClass $user, string $role): void {
     throw new UnsupportedDriverActionException($this->errorString('add roles'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function fetchWatchdog($count = 10, $type = NULL, $severity = NULL) {
+  public function fetchWatchdog(int $count = 10, ?string $type = NULL, ?string $severity = NULL): string {
     throw new UnsupportedDriverActionException($this->errorString('access watchdog entries'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function clearCache($type = NULL) {
+  public function clearCache(?string $type = NULL): void {
     throw new UnsupportedDriverActionException($this->errorString('clear Drupal caches'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function clearStaticCaches() {
+  public function clearStaticCaches(): void {
     throw new UnsupportedDriverActionException($this->errorString('clear static caches'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function createNode($node) {
+  public function createNode(object $node): object {
     throw new UnsupportedDriverActionException($this->errorString('create nodes'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function nodeDelete($node) {
+  public function nodeDelete(object $node): void {
     throw new UnsupportedDriverActionException($this->errorString('delete nodes'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function runCron() {
+  public function runCron(): bool {
     throw new UnsupportedDriverActionException($this->errorString('run cron'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function createTerm(\stdClass $term) {
+  public function createTerm(\stdClass $term): object {
     throw new UnsupportedDriverActionException($this->errorString('create terms'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function termDelete(\stdClass $term) {
+  public function termDelete(\stdClass $term): bool {
     throw new UnsupportedDriverActionException($this->errorString('delete terms'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function roleCreate(array $permissions) {
+  public function roleCreate(array $permissions): string {
     throw new UnsupportedDriverActionException($this->errorString('create roles'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function roleDelete($rid) {
+  public function roleDelete(string $rid): void {
     throw new UnsupportedDriverActionException($this->errorString('delete roles'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function isField($entity_type, $field_name) {
+  public function isField(string $entity_type, string $field_name): bool {
     return FALSE;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function isBaseField($entity_type, $field_name) {
+  public function isBaseField(string $entity_type, string $field_name): bool {
     return FALSE;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function configGet($name, $key) {
+  public function configGet(string $name, string $key): mixed {
     throw new UnsupportedDriverActionException($this->errorString('config get'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function configSet($name, $key, $value) {
+  public function configSet(string $name, string $key, mixed $value): void {
     throw new UnsupportedDriverActionException($this->errorString('config set'), $this);
   }
 
@@ -172,63 +174,63 @@ abstract class BaseDriver implements DriverInterface {
   /**
    * {@inheritdoc}
    */
-  public function createEntity($entity_type, \stdClass $entity) {
+  public function createEntity(string $entity_type, \stdClass $entity): object {
     throw new UnsupportedDriverActionException($this->errorString('create entities using the generic Entity API'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function entityDelete($entity_type, \stdClass $entity) {
+  public function entityDelete(string $entity_type, \stdClass $entity): void {
     throw new UnsupportedDriverActionException($this->errorString('delete entities using the generic Entity API'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function startCollectingMail() {
+  public function startCollectingMail(): void {
     throw new UnsupportedDriverActionException($this->errorString('work with mail'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function stopCollectingMail() {
+  public function stopCollectingMail(): void {
     throw new UnsupportedDriverActionException($this->errorString('work with mail'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getMail() {
+  public function getMail(): array {
     throw new UnsupportedDriverActionException($this->errorString('work with mail'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function clearMail() {
+  public function clearMail(): void {
     throw new UnsupportedDriverActionException($this->errorString('work with mail'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function sendMail($body, $subject, $to, $langcode) {
+  public function sendMail(string $body, string $subject, string $to, string $langcode): bool {
     throw new UnsupportedDriverActionException($this->errorString('work with mail'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function moduleInstall($module_name) {
+  public function moduleInstall(string $module_name): void {
     throw new UnsupportedDriverActionException($this->errorString('install modules'), $this);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function moduleUninstall($module_name) {
+  public function moduleUninstall(string $module_name): void {
     throw new UnsupportedDriverActionException($this->errorString('uninstall modules'), $this);
   }
 

--- a/src/Drupal/Driver/BaseDriver.php
+++ b/src/Drupal/Driver/BaseDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver;
 
 use Drupal\Driver\Exception\UnsupportedDriverActionException;
@@ -163,7 +165,7 @@ abstract class BaseDriver implements DriverInterface {
    * @return string
    *   A formatted string reminding people to use an API driver.
    */
-  private function errorString($error) {
+  private function errorString(string $error): string {
     return sprintf('No ability to %s in %%s. Put `@api` into your feature and add an API driver (ex: `api_driver: drupal`) in behat.yml.', $error);
   }
 

--- a/src/Drupal/Driver/BlackboxDriver.php
+++ b/src/Drupal/Driver/BlackboxDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver;
 
 /**
@@ -10,7 +12,7 @@ class BlackboxDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function isBootstrapped() {
+  public function isBootstrapped(): bool {
     // Assume the blackbox is always bootstrapped.
     return TRUE;
   }

--- a/src/Drupal/Driver/Cores/AbstractCore.php
+++ b/src/Drupal/Driver/Cores/AbstractCore.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Cores;
 
 use Drupal\Component\Utility\Random;
@@ -26,10 +28,8 @@ abstract class AbstractCore implements CoreInterface {
 
   /**
    * Random generator.
-   *
-   * @var \Drupal\Component\Utility\Random
    */
-  protected $random;
+  protected ?Random $random;
 
   /**
    * {@inheritdoc}

--- a/src/Drupal/Driver/Cores/AbstractCore.php
+++ b/src/Drupal/Driver/Cores/AbstractCore.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Driver\Cores;
 
+use Drupal\Driver\Fields\FieldHandlerInterface;
 use Drupal\Component\Utility\Random;
 use Symfony\Component\DependencyInjection\Container;
 
@@ -14,17 +15,13 @@ abstract class AbstractCore implements CoreInterface {
 
   /**
    * System path to the Drupal installation.
-   *
-   * @var string
    */
-  protected $drupalRoot;
+  protected string $drupalRoot;
 
   /**
    * URI for the Drupal installation.
-   *
-   * @var string
    */
-  protected $uri;
+  protected string $uri;
 
   /**
    * Random generator.
@@ -46,14 +43,14 @@ abstract class AbstractCore implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function getRandom() {
+  public function getRandom(): Random {
     return $this->random;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getFieldHandler($entity, $entity_type, $field_name) {
+  public function getFieldHandler($entity, $entity_type, $field_name): FieldHandlerInterface {
     $reflection = new \ReflectionClass($this);
     $core_namespace = $reflection->getShortName();
     $field_types = $this->getEntityFieldTypes($entity_type, [$field_name]);
@@ -71,15 +68,15 @@ abstract class AbstractCore implements CoreInterface {
    *
    * @param string $entity_type
    *   The entity type ID.
-   * @param object $entity
+   * @param \stdClass $entity
    *   Entity object.
-   * @param array $base_fields
+   * @param array<string> $base_fields
    *   Optional. Define base fields that will be expanded in addition to user
    *   defined fields.
    */
-  protected function expandEntityFields($entity_type, \stdClass $entity, array $base_fields = []) {
+  protected function expandEntityFields(string $entity_type, \stdClass $entity, array $base_fields = []): void {
     $field_types = $this->getEntityFieldTypes($entity_type, $base_fields);
-    foreach ($field_types as $field_name => $type) {
+    foreach (array_keys($field_types) as $field_name) {
       if (isset($entity->$field_name)) {
         $entity->$field_name = $this->getFieldHandler($entity, $entity_type, $field_name)
           ->expand($entity->$field_name);
@@ -90,7 +87,7 @@ abstract class AbstractCore implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function clearStaticCaches() {
+  public function clearStaticCaches(): void {
   }
 
 }

--- a/src/Drupal/Driver/Cores/AbstractCore.php
+++ b/src/Drupal/Driver/Cores/AbstractCore.php
@@ -26,7 +26,7 @@ abstract class AbstractCore implements CoreInterface {
   /**
    * Random generator.
    */
-  protected ?Random $random;
+  protected Random $random;
 
   /**
    * {@inheritdoc}

--- a/src/Drupal/Driver/Cores/CoreAuthenticationInterface.php
+++ b/src/Drupal/Driver/Cores/CoreAuthenticationInterface.php
@@ -12,11 +12,11 @@ interface CoreAuthenticationInterface {
   /**
    * Logs a user in.
    */
-  public function login(\stdClass $user);
+  public function login(\stdClass $user): void;
 
   /**
    * Logs a user out.
    */
-  public function logout();
+  public function logout(): void;
 
 }

--- a/src/Drupal/Driver/Cores/CoreAuthenticationInterface.php
+++ b/src/Drupal/Driver/Cores/CoreAuthenticationInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Cores;
 
 /**

--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Cores;
 
 use Drupal\Component\Utility\Random;

--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\Driver\Cores;
 
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Driver\Fields\FieldHandlerInterface;
 use Drupal\Component\Utility\Random;
 
 /**
@@ -21,35 +23,38 @@ interface CoreInterface {
    * @param \Drupal\Component\Utility\Random $random
    *   Random string generator.
    */
-  public function __construct($drupal_root, $uri = 'default', ?Random $random = NULL);
+  public function __construct(string $drupal_root, string $uri = 'default', ?Random $random = NULL);
 
   /**
    * Return random generator.
    */
-  public function getRandom();
+  public function getRandom(): Random;
 
   /**
    * Bootstrap Drupal.
    */
-  public function bootstrap();
+  public function bootstrap(): void;
 
   /**
    * Get module list.
+   *
+   * @return array<int, string>
+   *   List of installed module names.
    */
-  public function getModuleList();
+  public function getModuleList(): array;
 
   /**
    * Returns a list of all extension absolute paths.
    *
-   * @return array
+   * @return array<string>
    *   An array of absolute paths to enabled extensions.
    */
-  public function getExtensionPathList();
+  public function getExtensionPathList(): array;
 
   /**
    * Clear caches.
    */
-  public function clearCache();
+  public function clearCache(): void;
 
   /**
    * Run cron.
@@ -57,37 +62,46 @@ interface CoreInterface {
    * @return bool
    *   True if cron runs, otherwise false.
    */
-  public function runCron();
+  public function runCron(): bool;
 
   /**
    * Create a node.
+   *
+   * @param \stdClass $node
+   *   The node object.
+   *
+   * @return object
+   *   The created node.
    */
-  public function nodeCreate($node);
+  public function nodeCreate(\stdClass $node): object;
 
   /**
    * Delete a node.
+   *
+   * @param \stdClass $node
+   *   The node object.
    */
-  public function nodeDelete($node);
+  public function nodeDelete(\stdClass $node): void;
 
   /**
    * Create a user.
    */
-  public function userCreate(\stdClass $user);
+  public function userCreate(\stdClass $user): void;
 
   /**
    * Delete a user.
    */
-  public function userDelete(\stdClass $user);
+  public function userDelete(\stdClass $user): void;
 
   /**
    * Add a role to a user.
    *
-   * @param object $user
+   * @param \stdClass $user
    *   The Drupal user object.
    * @param string $role_name
    *   The role name.
    */
-  public function userAddRole(\stdClass $user, $role_name);
+  public function userAddRole(\stdClass $user, string $role_name): void;
 
   /**
    * Validate, and prepare environment for Drupal bootstrap.
@@ -97,33 +111,39 @@ interface CoreInterface {
    *
    * @see _drush_bootstrap_drupal_site_validate()
    */
-  public function validateDrupalSite();
+  public function validateDrupalSite(): void;
 
   /**
    * Processes a batch of actions.
    */
-  public function processBatch();
+  public function processBatch(): void;
 
   /**
    * Create a taxonomy term.
+   *
+   * @return object
+   *   The created term object.
    */
-  public function termCreate(\stdClass $term);
+  public function termCreate(\stdClass $term): object;
 
   /**
    * Deletes a taxonomy term.
+   *
+   * @return bool
+   *   Status constant indicating deletion.
    */
-  public function termDelete(\stdClass $term);
+  public function termDelete(\stdClass $term): bool;
 
   /**
    * Creates a role.
    *
-   * @param array $permissions
+   * @param array<string> $permissions
    *   An array of permissions to create the role with.
    *
    * @return int|string
    *   The created role name.
    */
-  public function roleCreate(array $permissions);
+  public function roleCreate(array $permissions): int|string;
 
   /**
    * Deletes a role.
@@ -131,7 +151,7 @@ interface CoreInterface {
    * @param string $role_name
    *   A role name to delete.
    */
-  public function roleDelete($role_name);
+  public function roleDelete(string $role_name): void;
 
   /**
    * Get FieldHandler class.
@@ -146,7 +166,7 @@ interface CoreInterface {
    * @return \Drupal\Driver\Fields\FieldHandlerInterface
    *   The field handler.
    */
-  public function getFieldHandler($entity, $entity_type, $field_name);
+  public function getFieldHandler(object $entity, string $entity_type, string $field_name): FieldHandlerInterface;
 
   /**
    * Check if the specified field is an actual Drupal field.
@@ -159,7 +179,7 @@ interface CoreInterface {
    * @return bool
    *   TRUE if the given field is a Drupal field, FALSE otherwise.
    */
-  public function isField($entity_type, $field_name);
+  public function isField(string $entity_type, string $field_name): bool;
 
   /**
    * Checks if the specified field is a Drupal base field.
@@ -172,44 +192,47 @@ interface CoreInterface {
    * @return bool
    *   TRUE if the given field is a base field, FALSE otherwise.
    */
-  public function isBaseField($entity_type, $field_name);
+  public function isBaseField(string $entity_type, string $field_name): bool;
 
   /**
    * Returns array of field types for the specified entity.
    *
    * @param string $entity_type
    *   The entity type for which to return the field types.
-   * @param array $base_fields
+   * @param array<string> $base_fields
    *   Optional. Define base fields that will be returned in addition to user-
    *   defined fields.
    *
-   * @return array
+   * @return array<string, string>
    *   An associative array of field types, keyed by field name.
    */
-  public function getEntityFieldTypes($entity_type, array $base_fields = []);
+  public function getEntityFieldTypes(string $entity_type, array $base_fields = []): array;
 
   /**
    * Creates a language.
    *
-   * @param object $language
+   * @param \stdClass $language
    *   An object with the following properties:
    *   - langcode: the langcode of the language to create.
+   *
+   * @return \stdClass|false
+   *   The language object, or false if the language already exists.
    */
-  public function languageCreate(\stdClass $language);
+  public function languageCreate(\stdClass $language): \stdClass|false;
 
   /**
    * Deletes a language.
    *
-   * @param object $language
+   * @param \stdClass $language
    *   An object with the following properties:
    *   - langcode: the langcode of the language to delete.
    */
-  public function languageDelete(\stdClass $language);
+  public function languageDelete(\stdClass $language): void;
 
   /**
    * Clears the static caches.
    */
-  public function clearStaticCaches();
+  public function clearStaticCaches(): void;
 
   /**
    * Returns a configuration item.
@@ -222,7 +245,7 @@ interface CoreInterface {
    * @return mixed
    *   The data that was requested.
    */
-  public function configGet($name, $key = '');
+  public function configGet(string $name, string $key = ''): mixed;
 
   /**
    * Returns the original configuration item.
@@ -235,7 +258,7 @@ interface CoreInterface {
    * @return mixed
    *   The original data that was requested.
    */
-  public function configGetOriginal($name, $key = '');
+  public function configGetOriginal(string $name, string $key = ''): mixed;
 
   /**
    * Sets a value in a configuration object.
@@ -247,7 +270,7 @@ interface CoreInterface {
    * @param mixed $value
    *   Value to associate with identifier.
    */
-  public function configSet($name, $key, $value);
+  public function configSet(string $name, string $key, mixed $value): void;
 
   /**
    * Create an entity.
@@ -260,22 +283,27 @@ interface CoreInterface {
    * @return \Drupal\Core\Entity\EntityInterface
    *   A new entity object.
    */
-  public function entityCreate($entity_type, $entity);
+  public function entityCreate(string $entity_type, object $entity): EntityInterface;
 
   /**
    * Delete an entity.
+   *
+   * @param string $entity_type
+   *   The entity type ID.
+   * @param object $entity
+   *   The entity to delete.
    */
-  public function entityDelete($entity_type, $entity);
+  public function entityDelete(string $entity_type, object $entity): void;
 
   /**
    * Enable the test mail collector.
    */
-  public function startCollectingMail();
+  public function startCollectingMail(): void;
 
   /**
    * Restore normal operation of outgoing mail.
    */
-  public function stopCollectingMail();
+  public function stopCollectingMail(): void;
 
   /**
    * Get any mail collected by the test mail collector.
@@ -284,12 +312,12 @@ interface CoreInterface {
    *   An array of collected emails, each formatted as a Drupal 8
    *   \Drupal\Core\Mail\MailInterface::mail $message array.
    */
-  public function getMail();
+  public function getMail(): array;
 
   /**
    * Empty the test mail collector store of any collected mail.
    */
-  public function clearMail();
+  public function clearMail(): void;
 
   /**
    * Send a mail.
@@ -306,7 +334,7 @@ interface CoreInterface {
    * @return bool
    *   Whether the email was sent successfully.
    */
-  public function sendMail($body, $subject, $to, $langcode);
+  public function sendMail(string $body, string $subject, string $to, string $langcode): bool;
 
   /**
    * Installs a module.
@@ -314,7 +342,7 @@ interface CoreInterface {
    * @param string $module_name
    *   The machine name of the module to install.
    */
-  public function moduleInstall($module_name);
+  public function moduleInstall(string $module_name): void;
 
   /**
    * Uninstalls a module.
@@ -322,6 +350,6 @@ interface CoreInterface {
    * @param string $module_name
    *   The machine name of the module to uninstall.
    */
-  public function moduleUninstall($module_name);
+  public function moduleUninstall(string $module_name): void;
 
 }

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -30,10 +30,10 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
    * This is necessary since configurations modified here are actually saved so
    * that they persist values across bootstraps.
    *
-   * @var array
+   * @var array<string, mixed>
    *   An array of data, keyed by configuration name.
    */
-  protected $originalConfiguration = [];
+  protected array $originalConfiguration = [];
 
   /**
    * {@inheritdoc}
@@ -77,9 +77,9 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function nodeCreate($node) {
+  public function nodeCreate($node): object {
     // Throw an exception if the node type is missing or does not exist.
-    /** @var \Drupal\node\Entity\Node $node */
+    /** @var \stdClass $node */
     if (!isset($node->type) || !$node->type) {
       throw new \Exception("Cannot create content because it is missing the required property 'type'.");
     }
@@ -120,7 +120,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function runCron() {
+  public function runCron(): bool {
     $_SERVER['REQUEST_TIME'] = time();
     \Drupal::request()->server->set('REQUEST_TIME', $_SERVER['REQUEST_TIME']);
     return \Drupal::service('cron')->run();
@@ -148,7 +148,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function roleCreate(array $permissions) {
+  public function roleCreate(array $permissions): int|string {
     // Generate a random, lowercase machine name.
     $rid = strtolower($this->random->name(8, TRUE));
 
@@ -204,10 +204,10 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * Retrieve all permissions.
    *
-   * @return array
+   * @return array<string, mixed>
    *   Array of all defined permissions.
    */
-  protected function getAllPermissions() {
+  protected function getAllPermissions(): array {
     $permissions = &drupal_static(__FUNCTION__);
 
     if (!isset($permissions)) {
@@ -220,10 +220,10 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * Convert any permission labels to machine name.
    *
-   * @param array &$permissions
+   * @param array<string> &$permissions
    *   Array of permission names.
    */
-  protected function convertPermissions(array &$permissions) {
+  protected function convertPermissions(array &$permissions): void {
     $all_permissions = $this->getAllPermissions();
 
     foreach ($all_permissions as $name => $definition) {
@@ -240,10 +240,10 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * Check to make sure that the array of permissions are valid.
    *
-   * @param array $permissions
+   * @param array<string> $permissions
    *   Permissions to check.
    */
-  protected function checkPermissions(array &$permissions) {
+  protected function checkPermissions(array &$permissions): void {
     $available = array_keys($this->getAllPermissions());
 
     foreach ($permissions as $permission) {
@@ -359,11 +359,13 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function termDelete(\stdClass $term): void {
+  public function termDelete(\stdClass $term): bool {
     $term = $term instanceof TermInterface ? $term : Term::load($term->tid);
     if ($term instanceof TermInterface) {
       $term->delete();
+      return TRUE;
     }
+    return FALSE;
   }
 
   /**
@@ -394,10 +396,10 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
    *   The entity type for which to return the field types.
    * @param \StdClass $entity
    *   Entity object.
-   * @param array $base_fields
+   * @param array<string> $base_fields
    *   Base fields to be expanded in addition to user defined fields.
    */
-  public function expandEntityBaseFields($entity_type, \StdClass $entity, array $base_fields): void {
+  public function expandEntityBaseFields(string $entity_type, \StdClass $entity, array $base_fields): void {
     $this->expandEntityFields($entity_type, $entity, $base_fields);
   }
 
@@ -487,14 +489,14 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function configGet($name, $key = '') {
+  public function configGet($name, $key = ''): mixed {
     return \Drupal::config($name)->get($key);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function configGetOriginal($name, $key = '') {
+  public function configGetOriginal($name, $key = ''): mixed {
     return \Drupal::config($name)->getOriginal($key, FALSE);
   }
 
@@ -510,7 +512,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function entityCreate($entity_type, $entity) {
+  public function entityCreate($entity_type, $entity): EntityInterface {
     // If the bundle field is empty, put the inferred bundle value in it.
     $bundle_key = \Drupal::entityTypeManager()->getDefinition($entity_type)->getKey('bundle');
     if (!isset($entity->$bundle_key) && isset($entity->step_bundle)) {
@@ -592,7 +594,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function getMail() {
+  public function getMail(): array {
     \Drupal::state()->resetCache();
     $mail = \Drupal::state()->get('system.test_mail_collector') ?: [];
     // Discard cancelled mail.
@@ -610,12 +612,13 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function sendMail($body = '', $subject = '', $to = '', $langcode = '') {
+  public function sendMail($body = '', $subject = '', $to = '', $langcode = ''): bool {
     // Send the mail, via the system module's hook_mail.
     $params['context']['message'] = $body;
     $params['context']['subject'] = $subject;
     $mail_manager = \Drupal::service('plugin.manager.mail');
-    return $mail_manager->mail('system', '', $to, $langcode, $params, NULL, TRUE);
+    $result = $mail_manager->mail('system', '', $to, $langcode, $params, NULL, TRUE);
+    return !empty($result['result']);
   }
 
   /**
@@ -623,7 +626,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
    *
    * @see MailsystemManager::getPluginInstance()
    */
-  protected function startCollectingMailSystemMail() {
+  protected function startCollectingMailSystemMail(): void {
     if (!\Drupal::moduleHandler()->moduleExists('mailsystem')) {
       return;
     }
@@ -639,6 +642,12 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
 
   /**
    * Recursively replaces mail sender plugins with the test collector.
+   *
+   * @param array<string, mixed> $config_tree
+   *   The configuration tree to process.
+   *
+   * @return array<string, mixed>
+   *   The modified configuration tree.
    */
   protected function replaceMailSenders(array $config_tree): array {
     foreach ($config_tree as $key => $values) {
@@ -660,7 +669,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * If the Mail System module is enabled, stop collecting those mails.
    */
-  protected function stopCollectingMailSystemMail() {
+  protected function stopCollectingMailSystemMail(): void {
     if (\Drupal::moduleHandler()->moduleExists('mailsystem')) {
       \Drupal::configFactory()->getEditable('mailsystem.settings')->setData($this->originalConfiguration['mailsystem.settings'])->save();
     }
@@ -699,7 +708,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
    * @param mixed $value
    *   The original value of the configuration.
    */
-  protected function storeOriginalConfiguration($name, $value) {
+  protected function storeOriginalConfiguration(string $name, mixed $value): void {
     if (!isset($this->originalConfiguration[$name])) {
       $this->originalConfiguration[$name] = $value;
     }

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Driver\Cores;
 
 use Drupal\Core\DrupalKernel;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Driver\Exception\BootstrapException;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\language\Entity\ConfigurableLanguage;
@@ -444,7 +445,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
    * @return \Drupal\Core\Entity\EntityFieldManagerInterface
    *   The entity field manager.
    */
-  protected function getEntityFieldManager(): object {
+  protected function getEntityFieldManager(): EntityFieldManagerInterface {
     return \Drupal::service('entity_field.manager');
   }
 

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Cores;
 
 use Drupal\Core\DrupalKernel;
@@ -36,7 +38,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function bootstrap() {
+  public function bootstrap(): void {
     // Validate, and prepare environment for Drupal bootstrap.
     if (!defined('DRUPAL_ROOT')) {
       define('DRUPAL_ROOT', $this->drupalRoot);
@@ -67,7 +69,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function clearCache() {
+  public function clearCache(): void {
     // Need to change into the Drupal root directory or the registry explodes.
     drupal_flush_all_caches();
   }
@@ -108,7 +110,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function nodeDelete($node) {
+  public function nodeDelete($node): void {
     $node = $node instanceof NodeInterface ? $node : Node::load($node->nid);
     if ($node instanceof NodeInterface) {
       $node->delete();
@@ -127,7 +129,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function userCreate(\stdClass $user) {
+  public function userCreate(\stdClass $user): void {
     $this->validateDrupalSite();
 
     // Default status to TRUE if not explicitly creating a blocked user.
@@ -180,7 +182,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function roleDelete($role_name) {
+  public function roleDelete($role_name): void {
     $role = Role::load($role_name);
 
     if ($role) {
@@ -191,7 +193,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function processBatch() {
+  public function processBatch(): void {
     $this->validateDrupalSite();
     if ($batch =& batch_get()) {
       $batch['progressive'] = FALSE;
@@ -254,14 +256,14 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function userDelete(\stdClass $user) {
+  public function userDelete(\stdClass $user): void {
     user_cancel([], $user->uid, 'user_cancel_delete');
   }
 
   /**
    * {@inheritdoc}
    */
-  public function userAddRole(\stdClass $user, $role_name) {
+  public function userAddRole(\stdClass $user, $role_name): void {
     // Allow both machine and human role names.
     $query = \Drupal::entityQuery('user_role');
     $conditions = $query->orConditionGroup()
@@ -282,7 +284,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function validateDrupalSite() {
+  public function validateDrupalSite(): void {
     if ('default' !== $this->uri) {
       // Fake the necessary HTTP headers that Drupal needs:
       $drupal_base_url = parse_url($this->uri);
@@ -332,7 +334,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function termCreate(\stdClass $term) {
+  public function termCreate(\stdClass $term): \stdClass {
     $term->vid = $term->vocabulary_machine_name;
 
     if (!empty($term->parent)) {
@@ -357,7 +359,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function termDelete(\stdClass $term) {
+  public function termDelete(\stdClass $term): void {
     $term = $term instanceof TermInterface ? $term : Term::load($term->tid);
     if ($term instanceof TermInterface) {
       $term->delete();
@@ -367,14 +369,14 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function getModuleList() {
+  public function getModuleList(): array {
     return array_keys(\Drupal::moduleHandler()->getModuleList());
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getExtensionPathList() {
+  public function getExtensionPathList(): array {
     $paths = [];
 
     // Get enabled modules.
@@ -395,14 +397,14 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
    * @param array $base_fields
    *   Base fields to be expanded in addition to user defined fields.
    */
-  public function expandEntityBaseFields($entity_type, \StdClass $entity, array $base_fields) {
+  public function expandEntityBaseFields($entity_type, \StdClass $entity, array $base_fields): void {
     $this->expandEntityFields($entity_type, $entity, $base_fields);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getEntityFieldTypes($entity_type, array $base_fields = []) {
+  public function getEntityFieldTypes($entity_type, array $base_fields = []): array {
     $return = [];
     $entity_field_manager = $this->getEntityFieldManager();
     $fields = $entity_field_manager->getFieldStorageDefinitions($entity_type);
@@ -421,7 +423,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function isField($entity_type, $field_name) {
+  public function isField($entity_type, $field_name): bool {
     $fields = $this->getEntityFieldManager()->getFieldStorageDefinitions($entity_type);
     return (isset($fields[$field_name]) && $fields[$field_name] instanceof FieldStorageConfig);
   }
@@ -429,7 +431,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function isBaseField($entity_type, $field_name) {
+  public function isBaseField($entity_type, $field_name): bool {
     $base_fields = $this->getEntityFieldManager()->getBaseFieldDefinitions($entity_type);
     return isset($base_fields[$field_name]);
   }
@@ -440,14 +442,14 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
    * @return \Drupal\Core\Entity\EntityFieldManagerInterface
    *   The entity field manager.
    */
-  protected function getEntityFieldManager() {
+  protected function getEntityFieldManager(): object {
     return \Drupal::service('entity_field.manager');
   }
 
   /**
    * {@inheritdoc}
    */
-  public function languageCreate(\stdClass $language) {
+  public function languageCreate(\stdClass $language): \stdClass|false {
     $langcode = $language->langcode;
 
     // Enable a language only if it has not been enabled already.
@@ -466,7 +468,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function languageDelete(\stdClass $language) {
+  public function languageDelete(\stdClass $language): void {
     $configurable_language = ConfigurableLanguage::load($language->langcode);
     $configurable_language->delete();
   }
@@ -474,7 +476,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function clearStaticCaches() {
+  public function clearStaticCaches(): void {
     drupal_static_reset();
     \Drupal::service('cache_tags.invalidator')->resetChecksums();
     foreach (\Drupal::entityTypeManager()->getDefinitions() as $definition) {
@@ -499,7 +501,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function configSet($name, $key, $value) {
+  public function configSet($name, $key, $value): void {
     \Drupal::configFactory()->getEditable($name)
       ->set($key, $value)
       ->save();
@@ -540,7 +542,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function entityDelete($entity_type, $entity) {
+  public function entityDelete($entity_type, $entity): void {
     $entity = $entity instanceof EntityInterface ? $entity : \Drupal::entityTypeManager()->getStorage($entity_type)->load($entity->id);
     if ($entity instanceof EntityInterface) {
       $entity->delete();
@@ -550,21 +552,21 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function moduleInstall($module_name) {
+  public function moduleInstall($module_name): void {
     \Drupal::service('module_installer')->install([$module_name]);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function moduleUninstall($module_name) {
+  public function moduleUninstall($module_name): void {
     \Drupal::service('module_installer')->uninstall([$module_name]);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function startCollectingMail() {
+  public function startCollectingMail(): void {
     $config = \Drupal::configFactory()->getEditable('system.mail');
     $mail_config = $config->getRawData();
 
@@ -580,7 +582,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function stopCollectingMail() {
+  public function stopCollectingMail(): void {
     $config = \Drupal::configFactory()->getEditable('system.mail');
     $config->setData($this->originalConfiguration['system.mail'])->save();
     // Re-enable the mailsystem module's mail if enabled.
@@ -594,14 +596,14 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
     \Drupal::state()->resetCache();
     $mail = \Drupal::state()->get('system.test_mail_collector') ?: [];
     // Discard cancelled mail.
-    $mail = array_values(array_filter($mail, fn($mail_item) => $mail_item['send'] == TRUE));
+    $mail = array_values(array_filter($mail, fn(array $mail_item): bool => $mail_item['send'] == TRUE));
     return $mail;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function clearMail() {
+  public function clearMail(): void {
     \Drupal::state()->set('system.test_mail_collector', []);
   }
 
@@ -638,7 +640,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * Recursively replaces mail sender plugins with the test collector.
    */
-  protected function replaceMailSenders(array $config_tree) {
+  protected function replaceMailSenders(array $config_tree): array {
     foreach ($config_tree as $key => $values) {
       if (!is_array($values)) {
         continue;
@@ -667,7 +669,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function login(\stdClass $user) {
+  public function login(\stdClass $user): void {
     $account = User::load($user->uid);
     \Drupal::service('account_switcher')->switchTo($account);
   }
@@ -675,7 +677,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
   /**
    * {@inheritdoc}
    */
-  public function logout() {
+  public function logout(): void {
     // AccountSwitcher::switchBack() throws RuntimeException when the stack is
     // empty. Loop until that happens to ensure all stacked accounts are popped.
     try {
@@ -683,7 +685,7 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
         \Drupal::service('account_switcher')->switchBack();
       }
     }
-    catch (\RuntimeException $runtime_exception) {
+    catch (\RuntimeException) {
     }
   }
 

--- a/src/Drupal/Driver/DriverInterface.php
+++ b/src/Drupal/Driver/DriverInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\Driver;
 
+use Drupal\Component\Utility\Random;
+
 /**
  * Driver interface.
  */
@@ -12,42 +14,42 @@ interface DriverInterface {
   /**
    * Returns a random generator.
    */
-  public function getRandom();
+  public function getRandom(): Random;
 
   /**
    * Bootstraps operations, as needed.
    */
-  public function bootstrap();
+  public function bootstrap(): void;
 
   /**
    * Determines if the driver has been bootstrapped.
    */
-  public function isBootstrapped();
+  public function isBootstrapped(): bool;
 
   /**
    * Creates a user.
    */
-  public function userCreate(\stdClass $user);
+  public function userCreate(\stdClass $user): void;
 
   /**
    * Deletes a user.
    */
-  public function userDelete(\stdClass $user);
+  public function userDelete(\stdClass $user): void;
 
   /**
    * Processes a batch of actions.
    */
-  public function processBatch();
+  public function processBatch(): void;
 
   /**
    * Adds a role for a user.
    *
-   * @param object $user
+   * @param \stdClass $user
    *   A user object.
    * @param string $role
    *   The role name to assign.
    */
-  public function userAddRole(\stdClass $user, $role);
+  public function userAddRole(\stdClass $user, string $role): void;
 
   /**
    * Retrieves watchdog entries.
@@ -62,7 +64,7 @@ interface DriverInterface {
    * @return string
    *   Watchdog output.
    */
-  public function fetchWatchdog($count = 10, $type = NULL, $severity = NULL);
+  public function fetchWatchdog(int $count = 10, ?string $type = NULL, ?string $severity = NULL): string;
 
   /**
    * Clears Drupal caches.
@@ -70,12 +72,12 @@ interface DriverInterface {
    * @param string $type
    *   Type of cache to clear defaults to all.
    */
-  public function clearCache($type = NULL);
+  public function clearCache(?string $type = NULL): void;
 
   /**
    * Clears static Drupal caches.
    */
-  public function clearStaticCaches();
+  public function clearStaticCaches(): void;
 
   /**
    * Creates a node.
@@ -86,7 +88,7 @@ interface DriverInterface {
    * @return object
    *   The node object including the node ID in the case of new nodes.
    */
-  public function createNode($node);
+  public function createNode(object $node): object;
 
   /**
    * Deletes a node.
@@ -94,45 +96,45 @@ interface DriverInterface {
    * @param object $node
    *   Fully loaded node object.
    */
-  public function nodeDelete($node);
+  public function nodeDelete(object $node): void;
 
   /**
    * Runs cron.
    */
-  public function runCron();
+  public function runCron(): bool;
 
   /**
    * Creates a taxonomy term.
    *
-   * @param object $term
+   * @param \stdClass $term
    *   Term object.
    *
    * @return object
    *   The term object including the term ID in the case of new terms.
    */
-  public function createTerm(\stdClass $term);
+  public function createTerm(\stdClass $term): object;
 
   /**
    * Deletes a taxonomy term.
    *
-   * @param object $term
+   * @param \stdClass $term
    *   Term object to delete.
    *
    * @return bool
    *   Status constant indicating deletion.
    */
-  public function termDelete(\stdClass $term);
+  public function termDelete(\stdClass $term): bool;
 
   /**
    * Creates a role.
    *
-   * @param array $permissions
+   * @param array<string> $permissions
    *   An array of permissions to create the role with.
    *
    * @return string
    *   Role name of newly created role.
    */
-  public function roleCreate(array $permissions);
+  public function roleCreate(array $permissions): string;
 
   /**
    * Deletes a role.
@@ -140,7 +142,7 @@ interface DriverInterface {
    * @param string $rid
    *   A role name to delete.
    */
-  public function roleDelete($rid);
+  public function roleDelete(string $rid): void;
 
   /**
    * Check if the specified field is an actual Drupal field.
@@ -153,7 +155,7 @@ interface DriverInterface {
    * @return bool
    *   TRUE if the field exists in the entity type, FALSE if not.
    */
-  public function isField($entity_type, $field_name);
+  public function isField(string $entity_type, string $field_name): bool;
 
   /**
    * Checks if the specified field is a Drupal base field.
@@ -166,7 +168,7 @@ interface DriverInterface {
    * @return bool
    *   TRUE if the given field is a base field, FALSE otherwise.
    */
-  public function isBaseField($entity_type, $field_name);
+  public function isBaseField(string $entity_type, string $field_name): bool;
 
   /**
    * Returns a configuration item.
@@ -179,7 +181,7 @@ interface DriverInterface {
    * @return mixed
    *   The data that was requested.
    */
-  public function configGet($name, $key);
+  public function configGet(string $name, string $key): mixed;
 
   /**
    * Sets a value in a configuration object.
@@ -191,40 +193,40 @@ interface DriverInterface {
    * @param mixed $value
    *   Value to associate with identifier.
    */
-  public function configSet($name, $key, $value);
+  public function configSet(string $name, string $key, mixed $value): void;
 
   /**
    * Creates an entity of a given type.
    *
    * @param string $entity_type
    *   The entity type ID.
-   * @param object $entity
+   * @param \stdClass $entity
    *   The entity to create.
    *
    * @return object
    *   The created entity with `id` set.
    */
-  public function createEntity($entity_type, \stdClass $entity);
+  public function createEntity(string $entity_type, \stdClass $entity): object;
 
   /**
    * Deletes an entity of a given type.
    *
    * @param string $entity_type
    *   The entity type ID.
-   * @param object $entity
+   * @param \stdClass $entity
    *   The entity to delete.
    */
-  public function entityDelete($entity_type, \stdClass $entity);
+  public function entityDelete(string $entity_type, \stdClass $entity): void;
 
   /**
    * Enable the test mail collector.
    */
-  public function startCollectingMail();
+  public function startCollectingMail(): void;
 
   /**
    * Restore normal operation of outgoing mail.
    */
-  public function stopCollectingMail();
+  public function stopCollectingMail(): void;
 
   /**
    * Get any mail collected by the test mail collector.
@@ -233,12 +235,12 @@ interface DriverInterface {
    *   An array of collected emails, each formatted as a Drupal 8
    *   \Drupal\Core\Mail\MailInterface::mail $message array.
    */
-  public function getMail();
+  public function getMail(): array;
 
   /**
    * Empty the test mail collector store of any collected mail.
    */
-  public function clearMail();
+  public function clearMail(): void;
 
   /**
    * Send a mail.
@@ -255,7 +257,7 @@ interface DriverInterface {
    * @return bool
    *   Whether the email was sent successfully.
    */
-  public function sendMail($body, $subject, $to, $langcode);
+  public function sendMail(string $body, string $subject, string $to, string $langcode): bool;
 
   /**
    * Installs a module.
@@ -263,7 +265,7 @@ interface DriverInterface {
    * @param string $module_name
    *   The machine name of the module to install.
    */
-  public function moduleInstall($module_name);
+  public function moduleInstall(string $module_name): void;
 
   /**
    * Uninstalls a module.
@@ -271,6 +273,6 @@ interface DriverInterface {
    * @param string $module_name
    *   The machine name of the module to uninstall.
    */
-  public function moduleUninstall($module_name);
+  public function moduleUninstall(string $module_name): void;
 
 }

--- a/src/Drupal/Driver/DriverInterface.php
+++ b/src/Drupal/Driver/DriverInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver;
 
 /**

--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver;
 
 use Drupal\Driver\Cores\CoreAuthenticationInterface;
@@ -14,10 +16,8 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
 
   /**
    * Track whether Drupal has been bootstrapped.
-   *
-   * @var bool
    */
-  private $bootstrapped = FALSE;
+  private bool $bootstrapped = FALSE;
 
   /**
    * Drupal core object.
@@ -58,12 +58,12 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
    * @throws \Drupal\Driver\Exception\BootstrapException
    *   Thrown when the Drupal installation is not found in the given root path.
    */
-  public function __construct($drupal_root, $uri) {
+  public function __construct(string $drupal_root, $uri) {
     $this->drupalRoot = realpath($drupal_root);
+    $this->uri = $uri;
     if (!$this->drupalRoot) {
       throw new BootstrapException(sprintf('No Drupal installation found at %s', $drupal_root));
     }
-    $this->uri = $uri;
     $this->version = $this->getDrupalVersion();
   }
 
@@ -77,7 +77,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
   /**
    * {@inheritdoc}
    */
-  public function bootstrap() {
+  public function bootstrap(): void {
     $this->getCore()->bootstrap();
     $this->bootstrapped = TRUE;
   }
@@ -85,7 +85,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
   /**
    * {@inheritdoc}
    */
-  public function isBootstrapped() {
+  public function isBootstrapped(): bool {
     // Assume the blackbox is always bootstrapped.
     return $this->bootstrapped;
   }
@@ -93,42 +93,42 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
   /**
    * {@inheritdoc}
    */
-  public function userCreate(\stdClass $user) {
+  public function userCreate(\stdClass $user): void {
     $this->getCore()->userCreate($user);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function userDelete(\stdClass $user) {
+  public function userDelete(\stdClass $user): void {
     $this->getCore()->userDelete($user);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function processBatch() {
+  public function processBatch(): void {
     $this->getCore()->processBatch();
   }
 
   /**
    * {@inheritdoc}
    */
-  public function userAddRole(\stdClass $user, $role_name) {
+  public function userAddRole(\stdClass $user, $role_name): void {
     $this->getCore()->userAddRole($user, $role_name);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function fetchWatchdog($count = 10, $type = NULL, $severity = NULL) {
+  public function fetchWatchdog($count = 10, $type = NULL, $severity = NULL): never {
     throw new PendingException(sprintf('Currently no ability to access watchdog entries in %s', $this));
   }
 
   /**
    * {@inheritdoc}
    */
-  public function clearCache($type = NULL) {
+  public function clearCache($type = NULL): void {
     $this->getCore()->clearCache();
   }
 
@@ -172,7 +172,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
    *   The major version number. Drupal 10+ all return 8 because they share
    *   the same driver (Drupal8.php).
    */
-  protected function detectMajorVersion() {
+  protected function detectMajorVersion(): int {
     $version_files = [
       '/autoload.php',
       '/core/includes/bootstrap.inc',
@@ -202,7 +202,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
   /**
    * Reads the Drupal VERSION constant.
    */
-  protected function readVersionConstant() {
+  protected function readVersionConstant(): string {
     if (defined(\Drupal::class . '::VERSION')) {
       return \Drupal::VERSION;
     }
@@ -216,7 +216,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
    * @param array $available_cores
    *   A major-version-keyed array of available core controllers.
    */
-  public function setCore(array $available_cores) {
+  public function setCore(array $available_cores): void {
     if (!isset($available_cores[$this->version])) {
       throw new BootstrapException(sprintf('There is no available Drupal core controller for Drupal version %s.', $this->version));
     }
@@ -226,7 +226,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
   /**
    * Automatically set the core from the current version.
    */
-  public function setCoreFromVersion() {
+  public function setCoreFromVersion(): void {
     $core = '\Drupal\Driver\Cores\Drupal' . $this->getDrupalVersion();
     $this->core = new $core($this->drupalRoot, $this->uri);
   }
@@ -255,7 +255,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
   /**
    * {@inheritdoc}
    */
-  public function runCron() {
+  public function runCron(): void {
     if (!$this->getCore()->runCron()) {
       throw new \Exception('Failed to run cron.');
     }
@@ -285,7 +285,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
   /**
    * {@inheritdoc}
    */
-  public function roleDelete($rid) {
+  public function roleDelete($rid): void {
     $this->getCore()->roleDelete($rid);
   }
 
@@ -313,7 +313,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
   /**
    * {@inheritdoc}
    */
-  public function languageDelete($language) {
+  public function languageDelete($language): void {
     $this->getCore()->languageDelete($language);
   }
 
@@ -327,14 +327,14 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
   /**
    * {@inheritdoc}
    */
-  public function configSet($name, $key, $value) {
+  public function configSet($name, $key, $value): void {
     $this->getCore()->configSet($name, $key, $value);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function clearStaticCaches() {
+  public function clearStaticCaches(): void {
     $this->getCore()->clearStaticCaches();
   }
 
@@ -390,24 +390,24 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
   /**
    * {@inheritdoc}
    */
-  public function moduleInstall($module_name) {
+  public function moduleInstall($module_name): void {
     $this->getCore()->moduleInstall($module_name);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function moduleUninstall($module_name) {
+  public function moduleUninstall($module_name): void {
     $this->getCore()->moduleUninstall($module_name);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function login(\stdClass $user) {
+  public function login(\stdClass $user): void {
     $auth = $this->getAuthCore();
 
-    if ($auth) {
+    if ($auth instanceof CoreAuthenticationInterface) {
       $auth->login($user);
     }
   }
@@ -415,10 +415,10 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
   /**
    * {@inheritdoc}
    */
-  public function logout() {
+  public function logout(): void {
     $auth = $this->getAuthCore();
 
-    if ($auth) {
+    if ($auth instanceof CoreAuthenticationInterface) {
       $auth->logout();
     }
   }
@@ -429,7 +429,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
    * @return \Drupal\Driver\Cores\CoreAuthenticationInterface|null
    *   The authentication-capable core, or NULL.
    */
-  protected function getAuthCore() {
+  protected function getAuthCore(): ?CoreAuthenticationInterface {
     $core = $this->getCore();
 
     return $core instanceof CoreAuthenticationInterface ? $core : NULL;

--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\Driver;
 
+use Drupal\Component\Utility\Random;
+use Drupal\Driver\Cores\CoreInterface;
 use Drupal\Driver\Cores\CoreAuthenticationInterface;
 use Drupal\Driver\Exception\BootstrapException;
-
-use Behat\Behat\Tester\Exception\PendingException;
 
 /**
  * Fully bootstraps Drupal and uses native API calls.
@@ -21,31 +21,23 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
 
   /**
    * Drupal core object.
-   *
-   * @var \Drupal\Driver\Cores\CoreInterface
    */
-  public $core;
+  public CoreInterface $core;
 
   /**
    * System path to the Drupal installation.
-   *
-   * @var string
    */
-  private $drupalRoot;
+  private readonly string $drupalRoot;
 
   /**
    * URI for the Drupal installation.
-   *
-   * @var string
    */
-  private $uri;
+  private readonly string $uri;
 
   /**
    * Drupal core version.
-   *
-   * @var int
    */
-  public $version;
+  public int $version;
 
   /**
    * Set Drupal root and URI.
@@ -58,10 +50,10 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
    * @throws \Drupal\Driver\Exception\BootstrapException
    *   Thrown when the Drupal installation is not found in the given root path.
    */
-  public function __construct(string $drupal_root, $uri) {
+  public function __construct(string $drupal_root, string $uri) {
     $this->drupalRoot = realpath($drupal_root);
     $this->uri = $uri;
-    if (!$this->drupalRoot) {
+    if ($this->drupalRoot === '' || $this->drupalRoot === '0') {
       throw new BootstrapException(sprintf('No Drupal installation found at %s', $drupal_root));
     }
     $this->version = $this->getDrupalVersion();
@@ -70,7 +62,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
   /**
    * {@inheritdoc}
    */
-  public function getRandom() {
+  public function getRandom(): Random {
     return $this->getCore()->getRandom();
   }
 
@@ -122,7 +114,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
    * {@inheritdoc}
    */
   public function fetchWatchdog($count = 10, $type = NULL, $severity = NULL): never {
-    throw new PendingException(sprintf('Currently no ability to access watchdog entries in %s', $this));
+    throw new \RuntimeException(sprintf('Currently no ability to access watchdog entries in %s', $this));
   }
 
   /**
@@ -135,7 +127,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
   /**
    * {@inheritdoc}
    */
-  public function getSubDriverPaths() {
+  public function getSubDriverPaths(): array {
     // Ensure system is bootstrapped.
     if (!$this->isBootstrapped()) {
       $this->bootstrap();
@@ -155,7 +147,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
    *
    * @see drush_drupal_version()
    */
-  public function getDrupalVersion() {
+  public function getDrupalVersion(): int {
     if ($this->version !== NULL) {
       return $this->version;
     }
@@ -213,7 +205,7 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
   /**
    * Instantiate and set Drupal core class.
    *
-   * @param array $available_cores
+   * @param array<int, \Drupal\Driver\Cores\CoreInterface> $available_cores
    *   A major-version-keyed array of available core controllers.
    */
   public function setCore(array $available_cores): void {
@@ -234,51 +226,49 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
   /**
    * Return current core.
    */
-  public function getCore() {
+  public function getCore(): CoreInterface {
     return $this->core;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function createNode($node) {
+  public function createNode($node): object {
     return $this->getCore()->nodeCreate($node);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function nodeDelete($node) {
-    return $this->getCore()->nodeDelete($node);
+  public function nodeDelete($node): void {
+    $this->getCore()->nodeDelete($node);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function runCron(): void {
-    if (!$this->getCore()->runCron()) {
-      throw new \Exception('Failed to run cron.');
-    }
+  public function runCron(): bool {
+    return $this->getCore()->runCron();
   }
 
   /**
    * {@inheritdoc}
    */
-  public function createTerm(\stdClass $term) {
+  public function createTerm(\stdClass $term): object {
     return $this->getCore()->termCreate($term);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function termDelete(\stdClass $term) {
+  public function termDelete(\stdClass $term): bool {
     return $this->getCore()->termDelete($term);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function roleCreate(array $permissions) {
+  public function roleCreate(array $permissions): string {
     return $this->getCore()->roleCreate($permissions);
   }
 
@@ -292,35 +282,35 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
   /**
    * {@inheritdoc}
    */
-  public function isField($entity_type, $field_name) {
+  public function isField($entity_type, $field_name): bool {
     return $this->getCore()->isField($entity_type, $field_name);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function isBaseField($entity_type, $field_name) {
+  public function isBaseField($entity_type, $field_name): bool {
     return $this->getCore()->isBaseField($entity_type, $field_name);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function languageCreate($language) {
+  public function languageCreate(\stdClass $language): \stdClass|false {
     return $this->getCore()->languageCreate($language);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function languageDelete($language): void {
+  public function languageDelete(\stdClass $language): void {
     $this->getCore()->languageDelete($language);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function configGet($name, $key) {
+  public function configGet($name, $key): mixed {
     return $this->getCore()->configGet($name, $key);
   }
 
@@ -341,49 +331,49 @@ class DrupalDriver implements DriverInterface, SubDriverFinderInterface, Authent
   /**
    * {@inheritdoc}
    */
-  public function createEntity($entity_type, \stdClass $entity) {
+  public function createEntity($entity_type, \stdClass $entity): object {
     return $this->getCore()->entityCreate($entity_type, $entity);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function entityDelete($entity_type, \stdClass $entity) {
-    return $this->getCore()->entityDelete($entity_type, $entity);
+  public function entityDelete($entity_type, \stdClass $entity): void {
+    $this->getCore()->entityDelete($entity_type, $entity);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function startCollectingMail() {
-    return $this->getCore()->startCollectingMail();
+  public function startCollectingMail(): void {
+    $this->getCore()->startCollectingMail();
   }
 
   /**
    * {@inheritdoc}
    */
-  public function stopCollectingMail() {
-    return $this->getCore()->stopCollectingMail();
+  public function stopCollectingMail(): void {
+    $this->getCore()->stopCollectingMail();
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getMail() {
+  public function getMail(): array {
     return $this->getCore()->getMail();
   }
 
   /**
    * {@inheritdoc}
    */
-  public function clearMail() {
-    return $this->getCore()->clearMail();
+  public function clearMail(): void {
+    $this->getCore()->clearMail();
   }
 
   /**
    * {@inheritdoc}
    */
-  public function sendMail($body, $subject, $to, $langcode) {
+  public function sendMail($body, $subject, $to, $langcode): bool {
     return $this->getCore()->sendMail($body, $subject, $to, $langcode);
   }
 

--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -15,26 +15,20 @@ use Symfony\Component\Process\Process;
 class DrushDriver extends BaseDriver {
   /**
    * Store a drush alias for tests requiring shell access.
-   *
-   * @var string
    */
-  public $alias;
+  public string $alias;
 
   /**
    * Stores the root path to a Drupal installation.
    *
    * This is an alternative to using drush aliases.
-   *
-   * @var string
    */
-  public $root;
+  public string $root;
 
   /**
    * Store the path to drush binary.
-   *
-   * @var string
    */
-  public $binary;
+  public string $binary;
 
   /**
    * Track bootstrapping.
@@ -48,17 +42,13 @@ class DrushDriver extends BaseDriver {
 
   /**
    * Global arguments or options for drush commands.
-   *
-   * @var string
    */
-  private $arguments = '';
+  private string $arguments = '';
 
   /**
    * Tracks legacy drush.
-   *
-   * @var bool
    */
-  protected static $isLegacyDrush;
+  protected static bool $isLegacyDrush;
 
   /**
    * Set drush alias or root path.
@@ -76,7 +66,7 @@ class DrushDriver extends BaseDriver {
    * @throws \Drupal\Driver\Exception\BootstrapException
    *   Thrown when a required parameter is missing.
    */
-  public function __construct($alias = NULL, $root_path = NULL, $binary = 'drush', ?Random $random = NULL) {
+  public function __construct(?string $alias = NULL, ?string $root_path = NULL, string $binary = 'drush', ?Random $random = NULL) {
     if (!empty($alias)) {
       // Trim off the '@' symbol if it has been added.
       $alias = ltrim($alias, '@');
@@ -113,7 +103,7 @@ class DrushDriver extends BaseDriver {
    * @return string
    *   The resolved binary path.
    */
-  protected function resolveProjectDrush($fallback) {
+  protected function resolveProjectDrush(string $fallback): string {
     // Try Composer's runtime bin directory.
     $composer_bin = getenv('COMPOSER_BIN_DIR');
     if ($composer_bin && file_exists($composer_bin . '/drush')) {
@@ -214,16 +204,16 @@ class DrushDriver extends BaseDriver {
    * Drush 12+ table format where the ID is the first numeric value in the
    * data row.
    */
-  protected function parseUserId($info): ?int {
+  protected function parseUserId(string $info): ?int {
     // Legacy format: "User ID : 123".
-    if (preg_match('/User ID\s+:\s+(\d+)/', (string) $info, $matches)) {
+    if (preg_match('/User ID\s+:\s+(\d+)/', $info, $matches)) {
       return (int) $matches[1];
     }
 
     // Drush 12+ table format: extract the first numeric value from the first
     // data row (the row after the header separator).
-    if (preg_match('/User ID/', (string) $info)) {
-      $lines = explode("\n", trim((string) $info));
+    if (preg_match('/User ID/', $info)) {
+      $lines = explode("\n", trim($info));
       foreach ($lines as $line) {
         // Skip header, separator, and empty lines.
         $trimmed = trim($line, " \t\n\r\0\x0B-");
@@ -280,16 +270,16 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function clearCache($type = 'all'): ?string {
+  public function clearCache($type = 'all'): void {
     if (self::$isLegacyDrush) {
-      return $this->drush('cache-clear', [$type], []);
+      $this->drush('cache-clear', [$type], []);
+      return;
     }
 
     // Drush-only cache clear does not need a full rebuild.
     if ($type === 'drush') {
       $this->drush('cache-clear', ['drush'], []);
-
-      return NULL;
+      return;
     }
 
     // Both 'all' and 'drush' clear the drush cache first.
@@ -297,7 +287,7 @@ class DrushDriver extends BaseDriver {
       $this->drush('cache-clear', ['drush'], []);
     }
 
-    return $this->drush('cache:rebuild');
+    $this->drush('cache:rebuild');
   }
 
   /**
@@ -320,7 +310,7 @@ class DrushDriver extends BaseDriver {
    * @return object
    *   The decoded JSON object.
    */
-  protected function decodeJsonObject($output): mixed {
+  protected function decodeJsonObject(string $output): mixed {
     // Remove anything before the first '{'.
     $output = preg_replace('/^[^\{]*/', '', $output);
     // Remove anything after the last '}'.
@@ -331,7 +321,7 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function createEntity($entity_type, \StdClass $entity): mixed {
+  public function createEntity($entity_type, \StdClass $entity): object {
     $payload = [
       'entity_type' => $entity_type,
       'entity' => $entity,
@@ -354,7 +344,7 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function createNode($node): mixed {
+  public function createNode($node): object {
     if (isset($node->author)) {
       $user_output = $this->drush('user-information', [sprintf('"%s"', $node->author)]);
       $uid = $this->parseUserId($user_output);
@@ -377,7 +367,7 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function createTerm(\stdClass $term): mixed {
+  public function createTerm(\stdClass $term): object {
     return $this->callBehatCommand('create-term', $term);
   }
 
@@ -392,7 +382,7 @@ class DrushDriver extends BaseDriver {
    * @return object
    *   The decoded response object.
    */
-  protected function callBehatCommand($sub_command, $payload): mixed {
+  protected function callBehatCommand(string $sub_command, mixed $payload): object {
     $result = $this->drush('behat', [$sub_command, escapeshellarg(json_encode($payload))], []);
 
     return $this->decodeJsonObject($result);
@@ -401,8 +391,9 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function termDelete(\stdClass $term): void {
+  public function termDelete(\stdClass $term): bool {
     $this->drush('behat', ['delete-term', escapeshellarg(json_encode($term))], []);
+    return TRUE;
   }
 
   /**
@@ -431,21 +422,21 @@ class DrushDriver extends BaseDriver {
    * @param string $arguments
    *   Global arguments to add to every drush command.
    */
-  public function setArguments($arguments): void {
+  public function setArguments(string $arguments): void {
     $this->arguments = $arguments;
   }
 
   /**
    * Get common drush arguments.
    */
-  public function getArguments() {
+  public function getArguments(): string {
     return $this->arguments;
   }
 
   /**
    * Parse arguments into a string.
    *
-   * @param array $arguments
+   * @param array<string, string|null> $arguments
    *   An array of argument/option names to values.
    *
    * @return string
@@ -467,8 +458,15 @@ class DrushDriver extends BaseDriver {
 
   /**
    * Execute a drush command.
+   *
+   * @param string $command
+   *   The Drush command to execute.
+   * @param array<int, string> $arguments
+   *   Positional arguments to pass to Drush.
+   * @param array<string, string|bool|null> $options
+   *   Options to pass to Drush.
    */
-  public function drush($command, array $arguments = [], array $options = []): string {
+  public function drush(string $command, array $arguments = [], array $options = []): string {
     $argument_string = implode(' ', $arguments);
 
     if (isset(static::$isLegacyDrush) && static::$isLegacyDrush) {
@@ -510,8 +508,9 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function runCron(): void {
+  public function runCron(): bool {
     $this->drush('cron');
+    return TRUE;
   }
 
   /**
@@ -530,8 +529,16 @@ class DrushDriver extends BaseDriver {
 
   /**
    * Run Drush commands dynamically from a DrupalContext.
+   *
+   * @param string $name
+   *   The method name, used as a Drush command.
+   * @param array<int, string> $arguments
+   *   The method arguments, forwarded to Drush.
+   *
+   * @return string
+   *   The Drush command output.
    */
-  public function __call(string $name, array $arguments) {
+  public function __call(string $name, array $arguments): string {
     return $this->drush($name, $arguments);
   }
 

--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver;
 
 use Drupal\Component\Utility\Random;
@@ -36,17 +38,13 @@ class DrushDriver extends BaseDriver {
 
   /**
    * Track bootstrapping.
-   *
-   * @var bool
    */
-  private $bootstrapped = FALSE;
+  private bool $bootstrapped = FALSE;
 
   /**
    * Random generator.
-   *
-   * @var \Drupal\Component\Utility\Random
    */
-  private $random;
+  private readonly ?Random $random;
 
   /**
    * Global arguments or options for drush commands.
@@ -134,14 +132,14 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function getRandom() {
+  public function getRandom(): Random {
     return $this->random;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function bootstrap() {
+  public function bootstrap(): void {
     // Check that the given alias works.
     // @todo check that this is a functioning alias.
     // See http://drupal.org/node/1615450
@@ -163,7 +161,7 @@ class DrushDriver extends BaseDriver {
    * @return bool
    *   Returns TRUE if drush is older than drush 9.
    */
-  protected function isLegacyDrush() {
+  protected function isLegacyDrush(): bool {
     try {
       // Try for a drush 9 version.
       $output = trim($this->drush('version', [], ['format' => 'string']));
@@ -173,7 +171,7 @@ class DrushDriver extends BaseDriver {
       $version = preg_match('/(\d+\.\d+\.\d+(\.\d+)?)\s*$/', $output, $matches) ? $matches[1] : $output;
       return version_compare($version, '9', '<=');
     }
-    catch (\RuntimeException $runtime_exception) {
+    catch (\RuntimeException) {
       // The version of drush is old enough that only `--version` was available,
       // so this is a legacy version.
       return TRUE;
@@ -183,14 +181,14 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function isBootstrapped() {
+  public function isBootstrapped(): bool {
     return $this->bootstrapped;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function userCreate(\stdClass $user) {
+  public function userCreate(\stdClass $user): void {
     $arguments = [
       sprintf('"%s"', $user->name),
     ];
@@ -216,16 +214,16 @@ class DrushDriver extends BaseDriver {
    * Drush 12+ table format where the ID is the first numeric value in the
    * data row.
    */
-  protected function parseUserId($info) {
+  protected function parseUserId($info): ?int {
     // Legacy format: "User ID : 123".
-    if (preg_match('/User ID\s+:\s+(\d+)/', $info, $matches)) {
+    if (preg_match('/User ID\s+:\s+(\d+)/', (string) $info, $matches)) {
       return (int) $matches[1];
     }
 
     // Drush 12+ table format: extract the first numeric value from the first
     // data row (the row after the header separator).
-    if (preg_match('/User ID/', $info)) {
-      $lines = explode("\n", trim($info));
+    if (preg_match('/User ID/', (string) $info)) {
+      $lines = explode("\n", trim((string) $info));
       foreach ($lines as $line) {
         // Skip header, separator, and empty lines.
         $trimmed = trim($line, " \t\n\r\0\x0B-");
@@ -247,7 +245,7 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function userDelete(\stdClass $user) {
+  public function userDelete(\stdClass $user): void {
     $arguments = [sprintf('"%s"', $user->name)];
     $options = [
       'yes' => NULL,
@@ -259,7 +257,7 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function userAddRole(\stdClass $user, $role) {
+  public function userAddRole(\stdClass $user, $role): void {
     $arguments = [
       sprintf('"%s"', $role),
       sprintf('"%s"', $user->name),
@@ -270,7 +268,7 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function fetchWatchdog($count = 10, $type = NULL, $severity = NULL) {
+  public function fetchWatchdog($count = 10, $type = NULL, $severity = NULL): string {
     $options = [
       'count' => $count,
       'type' => $type,
@@ -282,7 +280,7 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function clearCache($type = 'all') {
+  public function clearCache($type = 'all'): ?string {
     if (self::$isLegacyDrush) {
       return $this->drush('cache-clear', [$type], []);
     }
@@ -305,7 +303,7 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function clearStaticCaches() {
+  public function clearStaticCaches(): void {
     // The drush driver does each operation as a separate request;
     // therefore, 'clearStaticCaches' can be a no-op.
   }
@@ -322,18 +320,18 @@ class DrushDriver extends BaseDriver {
    * @return object
    *   The decoded JSON object.
    */
-  protected function decodeJsonObject($output) {
+  protected function decodeJsonObject($output): mixed {
     // Remove anything before the first '{'.
     $output = preg_replace('/^[^\{]*/', '', $output);
     // Remove anything after the last '}'.
-    $output = preg_replace('/[^\}]*$/s', '', $output);
-    return json_decode($output);
+    $output = preg_replace('/[^\}]*$/s', '', (string) $output);
+    return json_decode((string) $output);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function createEntity($entity_type, \StdClass $entity) {
+  public function createEntity($entity_type, \StdClass $entity): mixed {
     $payload = [
       'entity_type' => $entity_type,
       'entity' => $entity,
@@ -345,7 +343,7 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function entityDelete($entity_type, \StdClass $entity) {
+  public function entityDelete($entity_type, \StdClass $entity): void {
     $payload = [
       'entity_type' => $entity_type,
       'entity' => $entity,
@@ -356,7 +354,7 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function createNode($node) {
+  public function createNode($node): mixed {
     if (isset($node->author)) {
       $user_output = $this->drush('user-information', [sprintf('"%s"', $node->author)]);
       $uid = $this->parseUserId($user_output);
@@ -372,14 +370,14 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function nodeDelete($node) {
+  public function nodeDelete($node): void {
     $this->drush('behat', ['delete-node', escapeshellarg(json_encode($node))], []);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function createTerm(\stdClass $term) {
+  public function createTerm(\stdClass $term): mixed {
     return $this->callBehatCommand('create-term', $term);
   }
 
@@ -394,7 +392,7 @@ class DrushDriver extends BaseDriver {
    * @return object
    *   The decoded response object.
    */
-  protected function callBehatCommand($sub_command, $payload) {
+  protected function callBehatCommand($sub_command, $payload): mixed {
     $result = $this->drush('behat', [$sub_command, escapeshellarg(json_encode($payload))], []);
 
     return $this->decodeJsonObject($result);
@@ -403,14 +401,14 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function termDelete(\stdClass $term) {
+  public function termDelete(\stdClass $term): void {
     $this->drush('behat', ['delete-term', escapeshellarg(json_encode($term))], []);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function isField($entity_type, $field_name) {
+  public function isField($entity_type, $field_name): bool {
     // If the Behat Drush Endpoint is not installed on the site-under-test,
     // then the drush() method will throw an exception. In this instance, we
     // want to treat all potential fields as non-fields.  This allows the
@@ -420,9 +418,9 @@ class DrushDriver extends BaseDriver {
       $value = [$entity_type, $field_name];
       $arguments = ['is-field', escapeshellarg(json_encode($value))];
       $result = $this->drush('behat', $arguments, []);
-      return strpos($result, "true\n") !== FALSE;
+      return str_contains($result, "true\n");
     }
-    catch (\Exception $exception) {
+    catch (\Exception) {
       return FALSE;
     }
   }
@@ -433,7 +431,7 @@ class DrushDriver extends BaseDriver {
    * @param string $arguments
    *   Global arguments to add to every drush command.
    */
-  public function setArguments($arguments) {
+  public function setArguments($arguments): void {
     $this->arguments = $arguments;
   }
 
@@ -453,7 +451,7 @@ class DrushDriver extends BaseDriver {
    * @return string
    *   The parsed arguments.
    */
-  protected static function parseArguments(array $arguments) {
+  protected static function parseArguments(array $arguments): string {
     $option_string = '';
 
     foreach ($arguments as $name => $value) {
@@ -470,7 +468,7 @@ class DrushDriver extends BaseDriver {
   /**
    * Execute a drush command.
    */
-  public function drush($command, array $arguments = [], array $options = []) {
+  public function drush($command, array $arguments = [], array $options = []): string {
     $argument_string = implode(' ', $arguments);
 
     if (isset(static::$isLegacyDrush) && static::$isLegacyDrush) {
@@ -504,7 +502,7 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function processBatch() {
+  public function processBatch(): void {
     // Do nothing. Drush should internally handle any needs for processing
     // batch ops.
   }
@@ -512,28 +510,28 @@ class DrushDriver extends BaseDriver {
   /**
    * {@inheritdoc}
    */
-  public function runCron() {
+  public function runCron(): void {
     $this->drush('cron');
   }
 
   /**
    * {@inheritdoc}
    */
-  public function moduleInstall($module_name) {
+  public function moduleInstall($module_name): void {
     $this->drush('pm-enable', [$module_name], ['yes' => TRUE]);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function moduleUninstall($module_name) {
+  public function moduleUninstall($module_name): void {
     $this->drush('pm-uninstall', [$module_name], ['yes' => TRUE]);
   }
 
   /**
    * Run Drush commands dynamically from a DrupalContext.
    */
-  public function __call($name, $arguments) {
+  public function __call(string $name, array $arguments) {
     return $this->drush($name, $arguments);
   }
 

--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -38,7 +38,7 @@ class DrushDriver extends BaseDriver {
   /**
    * Random generator.
    */
-  private readonly ?Random $random;
+  private readonly Random $random;
 
   /**
    * Global arguments or options for drush commands.
@@ -307,8 +307,8 @@ class DrushDriver extends BaseDriver {
    * @param string $output
    *   The output from Drush.
    *
-   * @return object
-   *   The decoded JSON object.
+   * @return mixed
+   *   The decoded JSON value.
    */
   protected function decodeJsonObject(string $output): mixed {
     // Remove anything before the first '{'.

--- a/src/Drupal/Driver/Exception/BootstrapException.php
+++ b/src/Drupal/Driver/Exception/BootstrapException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Exception;
 
 /**

--- a/src/Drupal/Driver/Exception/BootstrapException.php
+++ b/src/Drupal/Driver/Exception/BootstrapException.php
@@ -19,7 +19,7 @@ class BootstrapException extends Exception {
    * @param \Exception $previous
    *   Optional previous exception that was thrown.
    */
-  public function __construct($message, $code = 0, ?\Exception $previous = NULL) {
+  public function __construct(string $message, int $code = 0, ?\Exception $previous = NULL) {
     parent::__construct($message, NULL, $code, $previous);
   }
 

--- a/src/Drupal/Driver/Exception/Exception.php
+++ b/src/Drupal/Driver/Exception/Exception.php
@@ -36,10 +36,10 @@ abstract class Exception extends \Exception {
   /**
    * Returns exception driver.
    *
-   * @return \Drupal\Driver\DriverInterface
-   *   The driver where the exception occurred.
+   * @return \Drupal\Driver\DriverInterface|null
+   *   The driver where the exception occurred, or NULL if not set.
    */
-  public function getDriver(): DriverInterface {
+  public function getDriver(): ?DriverInterface {
     return $this->driver;
   }
 

--- a/src/Drupal/Driver/Exception/Exception.php
+++ b/src/Drupal/Driver/Exception/Exception.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Exception;
 
 use Drupal\Driver\DriverInterface;
@@ -11,10 +13,8 @@ abstract class Exception extends \Exception {
 
   /**
    * The driver where the exception occurred.
-   *
-   * @var \Drupal\Driver\DriverInterface
    */
-  private $driver;
+  private readonly ?DriverInterface $driver;
 
   /**
    * Initializes Drupal driver manager exception.
@@ -30,7 +30,6 @@ abstract class Exception extends \Exception {
    */
   public function __construct($message, ?DriverInterface $driver = NULL, $code = 0, ?\Exception $previous = NULL) {
     $this->driver = $driver;
-
     parent::__construct($message, $code, $previous);
   }
 

--- a/src/Drupal/Driver/Exception/Exception.php
+++ b/src/Drupal/Driver/Exception/Exception.php
@@ -28,7 +28,7 @@ abstract class Exception extends \Exception {
    * @param \Exception $previous
    *   Optional previous exception that was thrown.
    */
-  public function __construct($message, ?DriverInterface $driver = NULL, $code = 0, ?\Exception $previous = NULL) {
+  public function __construct(string $message, ?DriverInterface $driver = NULL, int $code = 0, ?\Exception $previous = NULL) {
     $this->driver = $driver;
     parent::__construct($message, $code, $previous);
   }
@@ -39,7 +39,7 @@ abstract class Exception extends \Exception {
    * @return \Drupal\Driver\DriverInterface
    *   The driver where the exception occurred.
    */
-  public function getDriver() {
+  public function getDriver(): DriverInterface {
     return $this->driver;
   }
 

--- a/src/Drupal/Driver/Exception/UnsupportedDriverActionException.php
+++ b/src/Drupal/Driver/Exception/UnsupportedDriverActionException.php
@@ -23,7 +23,7 @@ class UnsupportedDriverActionException extends Exception {
    * @param \Exception $previous
    *   Previous exception.
    */
-  public function __construct($template, DriverInterface $driver, $code = 0, ?\Exception $previous = NULL) {
+  public function __construct(string $template, DriverInterface $driver, int $code = 0, ?\Exception $previous = NULL) {
     $message = sprintf($template, $driver::class);
 
     parent::__construct($message, $driver, $code, $previous);

--- a/src/Drupal/Driver/Exception/UnsupportedDriverActionException.php
+++ b/src/Drupal/Driver/Exception/UnsupportedDriverActionException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Exception;
 
 use Drupal\Driver\DriverInterface;
@@ -22,7 +24,7 @@ class UnsupportedDriverActionException extends Exception {
    *   Previous exception.
    */
   public function __construct($template, DriverInterface $driver, $code = 0, ?\Exception $previous = NULL) {
-    $message = sprintf($template, get_class($driver));
+    $message = sprintf($template, $driver::class);
 
     parent::__construct($message, $driver, $code, $previous);
   }

--- a/src/Drupal/Driver/Fields/Drupal8/AbstractHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/AbstractHandler.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\Driver\Fields\Drupal8;
 
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Driver\Fields\FieldHandlerInterface;
 
 /**
@@ -12,17 +14,13 @@ use Drupal\Driver\Fields\FieldHandlerInterface;
 abstract class AbstractHandler implements FieldHandlerInterface {
   /**
    * Field storage definition.
-   *
-   * @var \Drupal\field\Entity\FieldStorageConfig
    */
-  protected $fieldInfo;
+  protected FieldStorageDefinitionInterface $fieldInfo;
 
   /**
    * Field configuration definition.
-   *
-   * @var \Drupal\field\Entity\FieldConfig
    */
-  protected $fieldConfig;
+  protected FieldDefinitionInterface $fieldConfig;
 
   /**
    * Constructs an AbstractHandler object.
@@ -37,7 +35,7 @@ abstract class AbstractHandler implements FieldHandlerInterface {
    * @throws \Exception
    *   Thrown when the given field name does not exist on the entity.
    */
-  public function __construct(\StdClass $entity, $entity_type, $field_name) {
+  public function __construct(\StdClass $entity, string $entity_type, string $field_name) {
     if (empty($entity_type)) {
       throw new \Exception("You must specify an entity type in order to parse entity fields.");
     }

--- a/src/Drupal/Driver/Fields/Drupal8/AbstractHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/AbstractHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 use Drupal\Driver\Fields\FieldHandlerInterface;

--- a/src/Drupal/Driver/Fields/Drupal8/AddressHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/AddressHandler.php
@@ -25,6 +25,9 @@ class AddressHandler extends AbstractHandler {
 
   /**
    * Returns address sub-fields that are not hidden by field overrides.
+   *
+   * @return array<int, string>
+   *   Visible address field names.
    */
   protected function getVisibleAddressFields(): array {
     $fields = [
@@ -62,8 +65,16 @@ class AddressHandler extends AbstractHandler {
 
   /**
    * Normalises a single address delta into a keyed array.
+   *
+   * @param mixed $value
+   *   A single address value (string or array).
+   * @param array<int, string> $visible_fields
+   *   The list of visible address field names.
+   *
+   * @return array<string, mixed>
+   *   A keyed array of address field values.
    */
-  protected function normaliseDelta($value, array $visible_fields): array {
+  protected function normaliseDelta(mixed $value, array $visible_fields): array {
     if (is_string($value)) {
       return [reset($visible_fields) => $value];
     }

--- a/src/Drupal/Driver/Fields/Drupal8/AddressHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/AddressHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 /**
@@ -10,7 +12,7 @@ class AddressHandler extends AbstractHandler {
   /**
    * {@inheritdoc}
    */
-  public function expand($values) {
+  public function expand($values): array {
     $visible_fields = $this->getVisibleAddressFields();
     $result = [];
 
@@ -24,7 +26,7 @@ class AddressHandler extends AbstractHandler {
   /**
    * Returns address sub-fields that are not hidden by field overrides.
    */
-  protected function getVisibleAddressFields() {
+  protected function getVisibleAddressFields(): array {
     $fields = [
       'given_name',
       'additional_name',
@@ -47,7 +49,7 @@ class AddressHandler extends AbstractHandler {
       }
 
       // Convert camelCase override keys to snake_case field names.
-      $snake_key = strtolower(preg_replace('/([A-Z])/', '_$1', $key));
+      $snake_key = strtolower((string) preg_replace('/([A-Z])/', '_$1', (string) $key));
       $index = array_search($snake_key, $fields, TRUE);
 
       if ($index !== FALSE) {
@@ -61,7 +63,7 @@ class AddressHandler extends AbstractHandler {
   /**
    * Normalises a single address delta into a keyed array.
    */
-  protected function normaliseDelta($value, array $visible_fields) {
+  protected function normaliseDelta($value, array $visible_fields): array {
     if (is_string($value)) {
       return [reset($visible_fields) => $value];
     }

--- a/src/Drupal/Driver/Fields/Drupal8/DaterangeHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/DaterangeHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
@@ -14,7 +16,7 @@ class DaterangeHandler extends DatetimeHandler {
   /**
    * {@inheritdoc}
    */
-  public function expand($values) {
+  public function expand($values): array {
     $site_timezone = new \DateTimeZone(\Drupal::config('system.date')->get('timezone.default'));
     $storage_timezone = new \DateTimeZone(DateTimeItemInterface::STORAGE_TIMEZONE);
     $result = [];

--- a/src/Drupal/Driver/Fields/Drupal8/DatetimeHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/DatetimeHandler.php
@@ -16,7 +16,7 @@ class DatetimeHandler extends AbstractHandler {
   /**
    * {@inheritdoc}
    */
-  public function expand($values) {
+  public function expand($values): array {
     $site_timezone = new \DateTimeZone(\Drupal::config('system.date')->get('timezone.default'));
     $storage_timezone = new \DateTimeZone(DateTimeItemInterface::STORAGE_TIMEZONE);
 
@@ -30,17 +30,17 @@ class DatetimeHandler extends AbstractHandler {
   /**
    * Formats a date value for storage based on the field's datetime_type.
    *
-   * @param string $value
+   * @param string|null $value
    *   The raw date value, optionally prefixed with "relative:".
    * @param \DateTimeZone $site_timezone
    *   The site timezone.
    * @param \DateTimeZone $storage_timezone
    *   The storage timezone.
    *
-   * @return string
-   *   The formatted date string.
+   * @return string|null
+   *   The formatted date string, or null for empty values.
    */
-  protected function formatDateValue($value, \DateTimeZone $site_timezone, \DateTimeZone $storage_timezone) {
+  protected function formatDateValue(?string $value, \DateTimeZone $site_timezone, \DateTimeZone $storage_timezone): ?string {
     if ($value === NULL || $value === '') {
       return NULL;
     }

--- a/src/Drupal/Driver/Fields/Drupal8/DatetimeHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/DatetimeHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 use Drupal\Core\Datetime\DrupalDateTime;
@@ -43,7 +45,7 @@ class DatetimeHandler extends AbstractHandler {
       return NULL;
     }
 
-    if (strpos($value, 'relative:') !== FALSE) {
+    if (str_contains($value, 'relative:')) {
       $value = trim(str_replace('relative:', '', $value));
     }
 

--- a/src/Drupal/Driver/Fields/Drupal8/DefaultHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/DefaultHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 /**

--- a/src/Drupal/Driver/Fields/Drupal8/DefaultHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/DefaultHandler.php
@@ -12,8 +12,8 @@ class DefaultHandler extends AbstractHandler {
   /**
    * {@inheritdoc}
    */
-  public function expand($values) {
-    return $values;
+  public function expand(mixed $values): array {
+    return (array) $values;
   }
 
 }

--- a/src/Drupal/Driver/Fields/Drupal8/EmbridgeAssetItemHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EmbridgeAssetItemHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 /**

--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 /**
@@ -10,7 +12,7 @@ class EntityReferenceHandler extends AbstractHandler {
   /**
    * {@inheritdoc}
    */
-  public function expand($values) {
+  public function expand($values): array {
     $return = [];
     $entity_type_id = $this->fieldInfo->getSetting('target_type');
     $entity_definition = \Drupal::entityTypeManager()->getDefinition($entity_type_id);

--- a/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/EntityReferenceHandler.php
@@ -62,7 +62,7 @@ class EntityReferenceHandler extends AbstractHandler {
    * @return mixed
    *   Array of bundle names, or NULL if not able to determine bundles.
    */
-  protected function getTargetBundles() {
+  protected function getTargetBundles(): mixed {
     $settings = $this->fieldConfig->getSettings();
     if (!empty($settings['handler_settings']['target_bundles'])) {
       return $settings['handler_settings']['target_bundles'];

--- a/src/Drupal/Driver/Fields/Drupal8/FileHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/FileHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 /**
@@ -10,11 +12,11 @@ class FileHandler extends AbstractHandler {
   /**
    * {@inheritdoc}
    */
-  public function expand($values) {
+  public function expand($values): array {
     $return = [];
     foreach ((array) $values as $value) {
       $file_path = is_array($value) ? $value['target_id'] ?? $value[0] : $value;
-      $file_extension = pathinfo($file_path, PATHINFO_EXTENSION);
+      $file_extension = pathinfo((string) $file_path, PATHINFO_EXTENSION);
       $data = file_get_contents($file_path);
 
       if ($data === FALSE) {

--- a/src/Drupal/Driver/Fields/Drupal8/FileHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/FileHandler.php
@@ -15,8 +15,8 @@ class FileHandler extends AbstractHandler {
   public function expand($values): array {
     $return = [];
     foreach ((array) $values as $value) {
-      $file_path = is_array($value) ? $value['target_id'] ?? $value[0] : $value;
-      $file_extension = pathinfo((string) $file_path, PATHINFO_EXTENSION);
+      $file_path = (string) (is_array($value) ? $value['target_id'] ?? $value[0] : $value);
+      $file_extension = pathinfo($file_path, PATHINFO_EXTENSION);
       $data = file_get_contents($file_path);
 
       if ($data === FALSE) {

--- a/src/Drupal/Driver/Fields/Drupal8/ImageHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/ImageHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 /**
@@ -10,7 +12,7 @@ class ImageHandler extends AbstractHandler {
   /**
    * {@inheritdoc}
    */
-  public function expand($values) {
+  public function expand($values): array {
     $file_path = $values[0];
     $file_contents = file_get_contents($file_path);
 

--- a/src/Drupal/Driver/Fields/Drupal8/LinkHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/LinkHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 /**
@@ -10,7 +12,7 @@ class LinkHandler extends AbstractHandler {
   /**
    * {@inheritdoc}
    */
-  public function expand($values) {
+  public function expand($values): array {
     $return = [];
     foreach ($values as $value) {
       // Support URI-only string values.
@@ -22,7 +24,7 @@ class LinkHandler extends AbstractHandler {
         'title' => $value['title'] ?? $value[0] ?? NULL,
         'uri' => $value['uri'] ?? $value[1] ?? NULL,
         'options' => [],
-      ], fn ($v) => $v !== NULL);
+      ], fn ($v): bool => $v !== NULL);
       // 'options' is required to be an array, otherwise the utility class
       // Drupal\Core\Utility\UnroutedUrlAssembler::assemble() will complain.
       $options = $value['options'] ?? $value[2] ?? NULL;

--- a/src/Drupal/Driver/Fields/Drupal8/ListFloatHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/ListFloatHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 /**

--- a/src/Drupal/Driver/Fields/Drupal8/ListHandlerBase.php
+++ b/src/Drupal/Driver/Fields/Drupal8/ListHandlerBase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 /**

--- a/src/Drupal/Driver/Fields/Drupal8/ListHandlerBase.php
+++ b/src/Drupal/Driver/Fields/Drupal8/ListHandlerBase.php
@@ -14,7 +14,7 @@ abstract class ListHandlerBase extends AbstractHandler {
   /**
    * {@inheritdoc}
    */
-  public function expand($values) {
+  public function expand(mixed $values): array {
     $return = [];
 
     // Load allowed values from field storage.

--- a/src/Drupal/Driver/Fields/Drupal8/ListIntegerHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/ListIntegerHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 /**

--- a/src/Drupal/Driver/Fields/Drupal8/ListStringHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/ListStringHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 /**

--- a/src/Drupal/Driver/Fields/Drupal8/NameHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/NameHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 /**
@@ -12,14 +14,14 @@ class NameHandler extends AbstractHandler {
   /**
    * {@inheritdoc}
    */
-  public function expand($values) {
+  public function expand($values): array {
     $return = [];
     $components = ['title', 'given', 'middle', 'family', 'generational', 'credentials'];
 
     foreach ($values as $value) {
       if (is_string($value)) {
         // Support "Family, Given" shorthand.
-        $parts = array_map('trim', explode(',', $value));
+        $parts = array_map(trim(...), explode(',', $value));
         $return[] = [
           'family' => $parts[0] ?? NULL,
           'given' => $parts[1] ?? NULL,

--- a/src/Drupal/Driver/Fields/Drupal8/OgStandardReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/OgStandardReferenceHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 /**

--- a/src/Drupal/Driver/Fields/Drupal8/SupportedImageHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/SupportedImageHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 /**
@@ -15,7 +17,7 @@ class SupportedImageHandler extends AbstractHandler {
   /**
    * {@inheritdoc}
    */
-  public function expand($values) {
+  public function expand($values): array {
     $return_values = [];
 
     // Standardize single/multi-value input.

--- a/src/Drupal/Driver/Fields/Drupal8/TaxonomyTermReferenceHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/TaxonomyTermReferenceHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 /**
@@ -10,7 +12,7 @@ class TaxonomyTermReferenceHandler extends AbstractHandler {
   /**
    * {@inheritdoc}
    */
-  public function expand($values) {
+  public function expand($values): array {
     $return = [];
     foreach ($values as $name) {
       $terms = \Drupal::entityTypeManager()

--- a/src/Drupal/Driver/Fields/Drupal8/TextWithSummaryHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/TextWithSummaryHandler.php
@@ -14,8 +14,8 @@ class TextWithSummaryHandler implements FieldHandlerInterface {
   /**
    * {@inheritdoc}
    */
-  public function expand($values) {
-    return $values;
+  public function expand(mixed $values): array {
+    return (array) $values;
   }
 
 }

--- a/src/Drupal/Driver/Fields/Drupal8/TextWithSummaryHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/TextWithSummaryHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 use Drupal\Driver\Fields\FieldHandlerInterface;

--- a/src/Drupal/Driver/Fields/Drupal8/TimeHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/TimeHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields\Drupal8;
 
 /**
@@ -10,7 +12,7 @@ class TimeHandler extends AbstractHandler {
   /**
    * {@inheritdoc}
    */
-  public function expand($values) {
+  public function expand($values): array {
     return array_map(function ($value) {
       // Value is numeric so it is safe to assume we have the seconds passed in
       // the storage format (seconds past midnight).

--- a/src/Drupal/Driver/Fields/FieldHandlerInterface.php
+++ b/src/Drupal/Driver/Fields/FieldHandlerInterface.php
@@ -22,10 +22,10 @@ interface FieldHandlerInterface {
    * @param mixed $values
    *   A single value or an array of field values to save on the entity.
    *
-   * @return array
+   * @return array<int|string, mixed>
    *   An array of field values in the format expected by the entity storage
    *   handlers in the driver's version of Drupal.
    */
-  public function expand($values);
+  public function expand(mixed $values): array;
 
 }

--- a/src/Drupal/Driver/Fields/FieldHandlerInterface.php
+++ b/src/Drupal/Driver/Fields/FieldHandlerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver\Fields;
 
 /**

--- a/src/Drupal/Driver/SubDriverFinderInterface.php
+++ b/src/Drupal/Driver/SubDriverFinderInterface.php
@@ -12,9 +12,9 @@ interface SubDriverFinderInterface {
   /**
    * Returns an array of paths in which to look for Drupal sub-drivers.
    *
-   * @return array
+   * @return array<string>
    *   An array of paths in which to find sub-drivers.
    */
-  public function getSubDriverPaths();
+  public function getSubDriverPaths(): array;
 
 }

--- a/src/Drupal/Driver/SubDriverFinderInterface.php
+++ b/src/Drupal/Driver/SubDriverFinderInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Driver;
 
 /**

--- a/tests/Drupal/Tests/Driver/BlackboxDriverTest.php
+++ b/tests/Drupal/Tests/Driver/BlackboxDriverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\Driver;
 
 use Drupal\Driver\BlackboxDriver;
@@ -14,7 +16,7 @@ class BlackboxDriverTest extends TestCase {
   /**
    * Tests that BlackboxDriver considers itself bootstrapped.
    */
-  public function testIsBootstrappedReturnsTrue() {
+  public function testIsBootstrappedReturnsTrue(): void {
     $driver = new BlackboxDriver();
     $this->assertTrue($driver->isBootstrapped());
   }
@@ -22,7 +24,7 @@ class BlackboxDriverTest extends TestCase {
   /**
    * Tests that bootstrap() is a no-op.
    */
-  public function testBootstrapIsNoop() {
+  public function testBootstrapIsNoop(): void {
     $driver = new BlackboxDriver();
     $this->assertNull($driver->bootstrap());
   }
@@ -30,7 +32,7 @@ class BlackboxDriverTest extends TestCase {
   /**
    * Tests that isField() always returns FALSE in the blackbox driver.
    */
-  public function testIsFieldReturnsFalse() {
+  public function testIsFieldReturnsFalse(): void {
     $driver = new BlackboxDriver();
     $this->assertFalse($driver->isField('node', 'field_body'));
   }
@@ -38,7 +40,7 @@ class BlackboxDriverTest extends TestCase {
   /**
    * Tests that isBaseField() always returns FALSE in the blackbox driver.
    */
-  public function testIsBaseFieldReturnsFalse() {
+  public function testIsBaseFieldReturnsFalse(): void {
     $driver = new BlackboxDriver();
     $this->assertFalse($driver->isBaseField('node', 'title'));
   }
@@ -55,7 +57,7 @@ class BlackboxDriverTest extends TestCase {
    *
    * @dataProvider dataProviderUnsupportedActionsThrow
    */
-  public function testUnsupportedActionsThrow($method, array $args, $message_fragment) {
+  public function testUnsupportedActionsThrow(string $method, array $args, string $message_fragment): void {
     $driver = new BlackboxDriver();
 
     $this->expectException(UnsupportedDriverActionException::class);
@@ -67,39 +69,36 @@ class BlackboxDriverTest extends TestCase {
   /**
    * Data provider listing every BaseDriver method that must be unsupported.
    */
-  public static function dataProviderUnsupportedActionsThrow() {
+  public static function dataProviderUnsupportedActionsThrow(): \Iterator {
     $user = new \stdClass();
     $term = new \stdClass();
     $entity = new \stdClass();
-
-    return [
-      'getRandom' => ['getRandom', [], 'generate random'],
-      'userCreate' => ['userCreate', [$user], 'create users'],
-      'userDelete' => ['userDelete', [$user], 'delete users'],
-      'processBatch' => ['processBatch', [], 'process batch actions'],
-      'userAddRole' => ['userAddRole', [$user, 'editor'], 'add roles'],
-      'fetchWatchdog' => ['fetchWatchdog', [], 'access watchdog entries'],
-      'clearCache' => ['clearCache', [], 'clear Drupal caches'],
-      'clearStaticCaches' => ['clearStaticCaches', [], 'clear static caches'],
-      'createNode' => ['createNode', [new \stdClass()], 'create nodes'],
-      'nodeDelete' => ['nodeDelete', [new \stdClass()], 'delete nodes'],
-      'runCron' => ['runCron', [], 'run cron'],
-      'createTerm' => ['createTerm', [$term], 'create terms'],
-      'termDelete' => ['termDelete', [$term], 'delete terms'],
-      'roleCreate' => ['roleCreate', [[]], 'create roles'],
-      'roleDelete' => ['roleDelete', [1], 'delete roles'],
-      'configGet' => ['configGet', ['system.site', 'name'], 'config get'],
-      'configSet' => ['configSet', ['system.site', 'name', 'v'], 'config set'],
-      'createEntity' => ['createEntity', ['node', $entity], 'create entities using the generic Entity API'],
-      'entityDelete' => ['entityDelete', ['node', $entity], 'delete entities using the generic Entity API'],
-      'startCollectingMail' => ['startCollectingMail', [], 'work with mail'],
-      'stopCollectingMail' => ['stopCollectingMail', [], 'work with mail'],
-      'getMail' => ['getMail', [], 'work with mail'],
-      'clearMail' => ['clearMail', [], 'work with mail'],
-      'sendMail' => ['sendMail', ['body', 'subject', 'to', 'en'], 'work with mail'],
-      'moduleInstall' => ['moduleInstall', ['node'], 'install modules'],
-      'moduleUninstall' => ['moduleUninstall', ['node'], 'uninstall modules'],
-    ];
+    yield 'getRandom' => ['getRandom', [], 'generate random'];
+    yield 'userCreate' => ['userCreate', [$user], 'create users'];
+    yield 'userDelete' => ['userDelete', [$user], 'delete users'];
+    yield 'processBatch' => ['processBatch', [], 'process batch actions'];
+    yield 'userAddRole' => ['userAddRole', [$user, 'editor'], 'add roles'];
+    yield 'fetchWatchdog' => ['fetchWatchdog', [], 'access watchdog entries'];
+    yield 'clearCache' => ['clearCache', [], 'clear Drupal caches'];
+    yield 'clearStaticCaches' => ['clearStaticCaches', [], 'clear static caches'];
+    yield 'createNode' => ['createNode', [new \stdClass()], 'create nodes'];
+    yield 'nodeDelete' => ['nodeDelete', [new \stdClass()], 'delete nodes'];
+    yield 'runCron' => ['runCron', [], 'run cron'];
+    yield 'createTerm' => ['createTerm', [$term], 'create terms'];
+    yield 'termDelete' => ['termDelete', [$term], 'delete terms'];
+    yield 'roleCreate' => ['roleCreate', [[]], 'create roles'];
+    yield 'roleDelete' => ['roleDelete', [1], 'delete roles'];
+    yield 'configGet' => ['configGet', ['system.site', 'name'], 'config get'];
+    yield 'configSet' => ['configSet', ['system.site', 'name', 'v'], 'config set'];
+    yield 'createEntity' => ['createEntity', ['node', $entity], 'create entities using the generic Entity API'];
+    yield 'entityDelete' => ['entityDelete', ['node', $entity], 'delete entities using the generic Entity API'];
+    yield 'startCollectingMail' => ['startCollectingMail', [], 'work with mail'];
+    yield 'stopCollectingMail' => ['stopCollectingMail', [], 'work with mail'];
+    yield 'getMail' => ['getMail', [], 'work with mail'];
+    yield 'clearMail' => ['clearMail', [], 'work with mail'];
+    yield 'sendMail' => ['sendMail', ['body', 'subject', 'to', 'en'], 'work with mail'];
+    yield 'moduleInstall' => ['moduleInstall', ['node'], 'install modules'];
+    yield 'moduleUninstall' => ['moduleUninstall', ['node'], 'uninstall modules'];
   }
 
 }

--- a/tests/Drupal/Tests/Driver/BlackboxDriverTest.php
+++ b/tests/Drupal/Tests/Driver/BlackboxDriverTest.php
@@ -26,7 +26,8 @@ class BlackboxDriverTest extends TestCase {
    */
   public function testBootstrapIsNoop(): void {
     $driver = new BlackboxDriver();
-    $this->assertNull($driver->bootstrap());
+    $driver->bootstrap();
+    $this->addToAssertionCount(1);
   }
 
   /**
@@ -50,7 +51,7 @@ class BlackboxDriverTest extends TestCase {
    *
    * @param string $method
    *   The BaseDriver method name to invoke.
-   * @param array $args
+   * @param array<int, mixed> $args
    *   Positional arguments to pass to the method.
    * @param string $message_fragment
    *   A substring that must appear in the exception message.
@@ -87,7 +88,7 @@ class BlackboxDriverTest extends TestCase {
     yield 'createTerm' => ['createTerm', [$term], 'create terms'];
     yield 'termDelete' => ['termDelete', [$term], 'delete terms'];
     yield 'roleCreate' => ['roleCreate', [[]], 'create roles'];
-    yield 'roleDelete' => ['roleDelete', [1], 'delete roles'];
+    yield 'roleDelete' => ['roleDelete', ['editor'], 'delete roles'];
     yield 'configGet' => ['configGet', ['system.site', 'name'], 'config get'];
     yield 'configSet' => ['configSet', ['system.site', 'name', 'v'], 'config set'];
     yield 'createEntity' => ['createEntity', ['node', $entity], 'create entities using the generic Entity API'];

--- a/tests/Drupal/Tests/Driver/Drupal8FieldMethodsTest.php
+++ b/tests/Drupal/Tests/Driver/Drupal8FieldMethodsTest.php
@@ -199,7 +199,7 @@ namespace Drupal\Tests\Driver {
     /**
      * {@inheritdoc}
      */
-    protected function getEntityFieldManager(): object {
+    protected function getEntityFieldManager(): EntityFieldManagerInterface {
       return $this->entityFieldManager;
     }
 

--- a/tests/Drupal/Tests/Driver/Drupal8FieldMethodsTest.php
+++ b/tests/Drupal/Tests/Driver/Drupal8FieldMethodsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 // Define a stub FieldStorageConfig in the correct namespace so that
 // instanceof checks in Drupal8::isField() work without a full Drupal bootstrap.
 // This must be declared before any class that references it.
@@ -7,9 +9,10 @@
 namespace Drupal\field\Entity {
   if (!class_exists(\Drupal\field\Entity\FieldStorageConfig::class)) {
     class FieldStorageConfig {
-      protected $type;
-      public function __construct(string $type) { $this->type = $type; }
-      public function getType() { return $this->type; }
+      public function __construct(protected string $type)
+      {
+      }
+      public function getType(): string { return $this->type; }
     }
   }
 }
@@ -38,7 +41,7 @@ namespace Drupal\Tests\Driver {
      *
      * @dataProvider dataProviderIsBaseField
      */
-    public function testIsBaseField($field_name, $expected) {
+    public function testIsBaseField(string $field_name, bool $expected): void {
       $core = $this->createTestCore();
       $this->assertSame($expected, $core->isBaseField('node', $field_name));
     }
@@ -46,13 +49,11 @@ namespace Drupal\Tests\Driver {
     /**
      * Data provider for testIsBaseField().
      */
-    public function dataProviderIsBaseField() {
-      return [
-        'non-computed base field' => ['title', TRUE],
-        'computed base field' => ['moderation_state', TRUE],
-        'configurable field' => ['field_tags', FALSE],
-        'unknown field' => ['nonexistent', FALSE],
-      ];
+    public function dataProviderIsBaseField(): \Iterator {
+      yield 'non-computed base field' => ['title', TRUE];
+      yield 'computed base field' => ['moderation_state', TRUE];
+      yield 'configurable field' => ['field_tags', FALSE];
+      yield 'unknown field' => ['nonexistent', FALSE];
     }
 
     /**
@@ -65,7 +66,7 @@ namespace Drupal\Tests\Driver {
      *
      * @dataProvider dataProviderIsField
      */
-    public function testIsField($field_name, $expected) {
+    public function testIsField(string $field_name, bool $expected): void {
       $core = $this->createTestCore();
       $this->assertSame($expected, $core->isField('node', $field_name));
     }
@@ -73,13 +74,11 @@ namespace Drupal\Tests\Driver {
     /**
      * Data provider for testIsField().
      */
-    public function dataProviderIsField() {
-      return [
-        'configurable field' => ['field_tags', TRUE],
-        'non-computed base field' => ['title', FALSE],
-        'computed base field' => ['moderation_state', FALSE],
-        'unknown field' => ['nonexistent', FALSE],
-      ];
+    public function dataProviderIsField(): \Iterator {
+      yield 'configurable field' => ['field_tags', TRUE];
+      yield 'non-computed base field' => ['title', FALSE];
+      yield 'computed base field' => ['moderation_state', FALSE];
+      yield 'unknown field' => ['nonexistent', FALSE];
     }
 
     /**
@@ -94,7 +93,7 @@ namespace Drupal\Tests\Driver {
      *
      * @dataProvider dataProviderGetEntityFieldTypes
      */
-    public function testGetEntityFieldTypes(array $base_fields_arg, array $expected_fields, array $unexpected_fields) {
+    public function testGetEntityFieldTypes(array $base_fields_arg, array $expected_fields, array $unexpected_fields): void {
       $core = $this->createTestCore();
       $result = $core->getEntityFieldTypes('node', $base_fields_arg);
 
@@ -109,28 +108,26 @@ namespace Drupal\Tests\Driver {
     /**
      * Data provider for testGetEntityFieldTypes().
      */
-    public function dataProviderGetEntityFieldTypes() {
-      return [
-        'no base fields requested' => [
+    public function dataProviderGetEntityFieldTypes(): \Iterator {
+      yield 'no base fields requested' => [
         [],
         ['field_tags'],
         ['title', 'moderation_state'],
-        ],
-        'non-computed base field requested' => [
+      ];
+      yield 'non-computed base field requested' => [
         ['title'],
         ['field_tags', 'title'],
         ['moderation_state'],
-        ],
-        'computed base field requested' => [
+      ];
+      yield 'computed base field requested' => [
         ['moderation_state'],
         ['field_tags', 'moderation_state'],
         ['title'],
-        ],
-        'multiple base fields requested' => [
+      ];
+      yield 'multiple base fields requested' => [
         ['title', 'moderation_state'],
         ['field_tags', 'title', 'moderation_state'],
         [],
-        ],
       ];
     }
 
@@ -140,7 +137,7 @@ namespace Drupal\Tests\Driver {
      * @return \Drupal\Tests\Driver\TestDrupal8Core
      *   The test core instance.
      */
-    protected function createTestCore() {
+    protected function createTestCore(): TestDrupal8Core {
       // Non-computed base field.
       $title_field = $this->createMock(BaseFieldDefinition::class);
       $title_field->method('getType')->willReturn('string');
@@ -195,14 +192,14 @@ namespace Drupal\Tests\Driver {
      * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
      *   The mock entity field manager.
      */
-    public function setEntityFieldManager(EntityFieldManagerInterface $entity_field_manager) {
+    public function setEntityFieldManager(EntityFieldManagerInterface $entity_field_manager): void {
       $this->entityFieldManager = $entity_field_manager;
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function getEntityFieldManager() {
+    protected function getEntityFieldManager(): object {
       return $this->entityFieldManager;
     }
 

--- a/tests/Drupal/Tests/Driver/Drupal8FieldMethodsTest.php
+++ b/tests/Drupal/Tests/Driver/Drupal8FieldMethodsTest.php
@@ -84,11 +84,11 @@ namespace Drupal\Tests\Driver {
     /**
      * Tests that 'getEntityFieldTypes()' includes computed base fields.
      *
-     * @param array $base_fields_arg
+     * @param array<string> $base_fields_arg
      *   The $base_fields argument to pass.
-     * @param array $expected_fields
+     * @param array<string> $expected_fields
      *   The expected field names in the result.
-     * @param array $unexpected_fields
+     * @param array<string> $unexpected_fields
      *   Field names that should NOT be in the result.
      *
      * @dataProvider dataProviderGetEntityFieldTypes
@@ -183,10 +183,8 @@ namespace Drupal\Tests\Driver {
 
     /**
      * The mock entity field manager.
-     *
-     * @var \Drupal\Core\Entity\EntityFieldManagerInterface
      */
-    protected $entityFieldManager;
+    protected EntityFieldManagerInterface $entityFieldManager;
 
     /**
      * Sets the mock entity field manager.

--- a/tests/Drupal/Tests/Driver/Drupal8FieldMethodsTest.php
+++ b/tests/Drupal/Tests/Driver/Drupal8FieldMethodsTest.php
@@ -27,7 +27,7 @@ namespace Drupal\Tests\Driver {
   use PHPUnit\Framework\TestCase;
 
   /**
-   * Tests for Drupal8 field methods: isBaseField(), isField(), getEntityFieldTypes().
+   * Tests 'isBaseField()', 'isField()', and 'getEntityFieldTypes()' methods.
    */
   class Drupal8FieldMethodsTest extends TestCase {
 
@@ -146,12 +146,13 @@ namespace Drupal\Tests\Driver {
       $moderation_state_field = $this->createMock(BaseFieldDefinition::class);
       $moderation_state_field->method('getType')->willReturn('string');
 
-      // Configurable field — use stub that passes instanceof FieldStorageConfig.
+      // Configurable field - stub that passes instanceof FieldStorageConfig.
       $field_tags = new FieldStorageConfig('entity_reference');
 
       $entity_field_manager = $this->createMock(EntityFieldManagerInterface::class);
 
-      // getFieldStorageDefinitions: returns non-computed base fields + configurable fields.
+      // getFieldStorageDefinitions: returns non-computed base fields and
+      // configurable fields.
       $entity_field_manager->method('getFieldStorageDefinitions')
         ->with('node')
         ->willReturn([
@@ -159,7 +160,8 @@ namespace Drupal\Tests\Driver {
           'field_tags' => $field_tags,
         ]);
 
-      // getBaseFieldDefinitions: returns ALL base fields (computed + non-computed).
+      // getBaseFieldDefinitions: returns ALL base fields (computed and
+      // non-computed).
       $entity_field_manager->method('getBaseFieldDefinitions')
         ->with('node')
         ->willReturn([

--- a/tests/Drupal/Tests/Driver/Drupal8FieldMethodsTest.php
+++ b/tests/Drupal/Tests/Driver/Drupal8FieldMethodsTest.php
@@ -49,7 +49,7 @@ namespace Drupal\Tests\Driver {
     /**
      * Data provider for testIsBaseField().
      */
-    public function dataProviderIsBaseField(): \Iterator {
+    public static function dataProviderIsBaseField(): \Iterator {
       yield 'non-computed base field' => ['title', TRUE];
       yield 'computed base field' => ['moderation_state', TRUE];
       yield 'configurable field' => ['field_tags', FALSE];
@@ -74,7 +74,7 @@ namespace Drupal\Tests\Driver {
     /**
      * Data provider for testIsField().
      */
-    public function dataProviderIsField(): \Iterator {
+    public static function dataProviderIsField(): \Iterator {
       yield 'configurable field' => ['field_tags', TRUE];
       yield 'non-computed base field' => ['title', FALSE];
       yield 'computed base field' => ['moderation_state', FALSE];
@@ -108,7 +108,7 @@ namespace Drupal\Tests\Driver {
     /**
      * Data provider for testGetEntityFieldTypes().
      */
-    public function dataProviderGetEntityFieldTypes(): \Iterator {
+    public static function dataProviderGetEntityFieldTypes(): \Iterator {
       yield 'no base fields requested' => [
         [],
         ['field_tags'],

--- a/tests/Drupal/Tests/Driver/Drupal8PermissionsTest.php
+++ b/tests/Drupal/Tests/Driver/Drupal8PermissionsTest.php
@@ -90,16 +90,26 @@ class Drupal8PermissionsTest extends TestCase {
 
   /**
    * Invokes the protected 'convertPermissions()' method by reference.
+   *
+   * @param \Drupal\Driver\Cores\Drupal8 $core
+   *   The core instance to invoke the method on.
+   * @param array<string> &$permissions
+   *   The permissions array to convert.
    */
-  protected function callConvertPermissions(Drupal8 $core, array &$permissions) {
+  protected function callConvertPermissions(Drupal8 $core, array &$permissions): void {
     $method = new \ReflectionMethod($core, 'convertPermissions');
     $method->invokeArgs($core, [&$permissions]);
   }
 
   /**
    * Invokes the protected 'checkPermissions()' method by reference.
+   *
+   * @param \Drupal\Driver\Cores\Drupal8 $core
+   *   The core instance to invoke the method on.
+   * @param array<string> &$permissions
+   *   The permissions array to check.
    */
-  protected function callCheckPermissions(Drupal8 $core, array &$permissions) {
+  protected function callCheckPermissions(Drupal8 $core, array &$permissions): void {
     $method = new \ReflectionMethod($core, 'checkPermissions');
     $method->invokeArgs($core, [&$permissions]);
   }
@@ -107,10 +117,10 @@ class Drupal8PermissionsTest extends TestCase {
   /**
    * Returns an anonymous Stringable that mimics a Drupal TranslatableMarkup.
    */
-  protected function stringable($label): object {
+  protected function stringable(string $label): object {
     return new class($label) {
 
-      public function __construct(private $label) {}
+      public function __construct(private readonly string $label) {}
 
       /**
        * Renders the stringable into its label.
@@ -132,12 +142,15 @@ class TestDrupal8PermissionsCore extends Drupal8 {
   /**
    * Stored permissions keyed by machine name.
    *
-   * @var array
+   * @var array<string, mixed>
    */
-  protected $permissions = [];
+  protected array $permissions = [];
 
   /**
    * Sets the permissions returned by 'getAllPermissions()'.
+   *
+   * @param array<string, mixed> $permissions
+   *   The permissions to set.
    */
   public function setPermissions(array $permissions): void {
     $this->permissions = $permissions;
@@ -146,7 +159,7 @@ class TestDrupal8PermissionsCore extends Drupal8 {
   /**
    * {@inheritdoc}
    */
-  protected function getAllPermissions() {
+  protected function getAllPermissions(): array {
     return $this->permissions;
   }
 

--- a/tests/Drupal/Tests/Driver/Drupal8PermissionsTest.php
+++ b/tests/Drupal/Tests/Driver/Drupal8PermissionsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\Driver;
 
 use Drupal\Driver\Cores\Drupal8;
@@ -19,7 +21,7 @@ class Drupal8PermissionsTest extends TestCase {
    * regressions where automated refactoring flips the comparison to strict
    * mode without adding the cast.
    */
-  public function testConvertPermissionsMapsStringableTitlesToMachineNames() {
+  public function testConvertPermissionsMapsStringableTitlesToMachineNames(): void {
     $core = new TestDrupal8PermissionsCore(__DIR__, 'default');
     $core->setPermissions([
       'administer content types' => [
@@ -39,7 +41,7 @@ class Drupal8PermissionsTest extends TestCase {
   /**
    * Tests that titles already in machine name form are left unchanged.
    */
-  public function testConvertPermissionsLeavesMachineNamesAlone() {
+  public function testConvertPermissionsLeavesMachineNamesAlone(): void {
     $core = new TestDrupal8PermissionsCore(__DIR__, 'default');
     $core->setPermissions([
       'administer users' => [
@@ -56,7 +58,7 @@ class Drupal8PermissionsTest extends TestCase {
   /**
    * Tests that 'checkPermissions()' passes for valid machine names.
    */
-  public function testCheckPermissionsAcceptsValidMachineNames() {
+  public function testCheckPermissionsAcceptsValidMachineNames(): void {
     $core = new TestDrupal8PermissionsCore(__DIR__, 'default');
     $core->setPermissions([
       'administer users' => ['title' => 'Administer users'],
@@ -72,7 +74,7 @@ class Drupal8PermissionsTest extends TestCase {
   /**
    * Tests that 'checkPermissions()' throws for unknown machine names.
    */
-  public function testCheckPermissionsThrowsForUnknownPermission() {
+  public function testCheckPermissionsThrowsForUnknownPermission(): void {
     $core = new TestDrupal8PermissionsCore(__DIR__, 'default');
     $core->setPermissions([
       'administer users' => ['title' => 'Administer users'],
@@ -91,7 +93,6 @@ class Drupal8PermissionsTest extends TestCase {
    */
   protected function callConvertPermissions(Drupal8 $core, array &$permissions) {
     $method = new \ReflectionMethod($core, 'convertPermissions');
-    $method->setAccessible(TRUE);
     $method->invokeArgs($core, [&$permissions]);
   }
 
@@ -100,14 +101,13 @@ class Drupal8PermissionsTest extends TestCase {
    */
   protected function callCheckPermissions(Drupal8 $core, array &$permissions) {
     $method = new \ReflectionMethod($core, 'checkPermissions');
-    $method->setAccessible(TRUE);
     $method->invokeArgs($core, [&$permissions]);
   }
 
   /**
    * Returns an anonymous Stringable that mimics a Drupal TranslatableMarkup.
    */
-  protected function stringable($label) {
+  protected function stringable($label): object {
     return new class($label) {
 
       public function __construct(private $label) {}
@@ -139,7 +139,7 @@ class TestDrupal8PermissionsCore extends Drupal8 {
   /**
    * Sets the permissions returned by 'getAllPermissions()'.
    */
-  public function setPermissions(array $permissions) {
+  public function setPermissions(array $permissions): void {
     $this->permissions = $permissions;
   }
 

--- a/tests/Drupal/Tests/Driver/Drupal8Test.php
+++ b/tests/Drupal/Tests/Driver/Drupal8Test.php
@@ -18,10 +18,8 @@ class Drupal8Test extends TestCase {
 
   /**
    * The original REQUEST_TIME value.
-   *
-   * @var int
    */
-  protected $originalRequestTime;
+  protected int $originalRequestTime;
 
   /**
    * {@inheritdoc}

--- a/tests/Drupal/Tests/Driver/Drupal8Test.php
+++ b/tests/Drupal/Tests/Driver/Drupal8Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\Driver;
 
 use Drupal\Core\CronInterface;
@@ -42,7 +44,7 @@ class Drupal8Test extends TestCase {
   /**
    * Tests that `runCron()` refreshes `REQUEST_TIME` before running cron.
    */
-  public function testRunCronRefreshesRequestTime() {
+  public function testRunCronRefreshesRequestTime(): void {
     $before = time();
     $stale_time = $before - 60;
 

--- a/tests/Drupal/Tests/Driver/Drupal8Test.php
+++ b/tests/Drupal/Tests/Driver/Drupal8Test.php
@@ -19,7 +19,7 @@ class Drupal8Test extends TestCase {
   /**
    * The original REQUEST_TIME value.
    */
-  protected int $originalRequestTime;
+  protected ?int $originalRequestTime = NULL;
 
   /**
    * {@inheritdoc}

--- a/tests/Drupal/Tests/Driver/DrushDriverTest.php
+++ b/tests/Drupal/Tests/Driver/DrushDriverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\Driver;
 
 use Drupal\Driver\DrushDriver;
@@ -14,7 +16,7 @@ class DrushDriverTest extends TestCase {
   /**
    * Tests instantiating the driver with only an alias.
    */
-  public function testWithAlias() {
+  public function testWithAlias(): void {
     $driver = new DrushDriver('alias');
     $this->assertEquals('alias', $driver->alias, 'The drush alias was not properly set.');
   }
@@ -22,7 +24,7 @@ class DrushDriverTest extends TestCase {
   /**
    * Tests instantiating the driver with a prefixed alias.
    */
-  public function testWithAliasPrefix() {
+  public function testWithAliasPrefix(): void {
     $driver = new DrushDriver('@alias');
     $this->assertEquals('alias', $driver->alias, 'The drush alias did not remove the "@" prefix.');
   }
@@ -30,7 +32,7 @@ class DrushDriverTest extends TestCase {
   /**
    * Tests instantiating the driver with only the root path.
    */
-  public function testWithRoot() {
+  public function testWithRoot(): void {
     // Bit of a hack here to use the path to this file, but all the driver cares
     // about during initialization is that the root be a directory.
     $driver = new DrushDriver('', __FILE__);
@@ -40,7 +42,7 @@ class DrushDriverTest extends TestCase {
   /**
    * Tests instantiating the driver with missing alias and root path.
    */
-  public function testWithNeither() {
+  public function testWithNeither(): void {
     $this->expectException(BootstrapException::class);
     new DrushDriver('', '');
   }
@@ -50,7 +52,7 @@ class DrushDriverTest extends TestCase {
    *
    * @dataProvider dataProviderIsLegacyDrush
    */
-  public function testIsLegacyDrush($drush_output, $expected) {
+  public function testIsLegacyDrush(string $drush_output, bool $expected): void {
     $driver = new TestDrushDriver('alias');
     $driver->drushOutput = $drush_output;
     $result = $driver->callIsLegacyDrush();
@@ -62,7 +64,7 @@ class DrushDriverTest extends TestCase {
    *
    * @dataProvider dataProviderParseUserId
    */
-  public function testParseUserId($drush_output, $expected) {
+  public function testParseUserId(string $drush_output, ?int $expected): void {
     $driver = new TestDrushDriver('alias');
     $result = $driver->callParseUserId($drush_output);
     $this->assertSame($expected, $result);
@@ -71,56 +73,52 @@ class DrushDriverTest extends TestCase {
   /**
    * Data provider for testParseUserId().
    */
-  public function dataProviderParseUserId() {
-    return [
-      'legacy key-value format' => [
-        "User ID   :   550895\nUser name :   test\n",
-        550895,
-      ],
-      'drush 12 table format' => [
-        " --------- ----------- ----------- --------------- ------------- \n  User ID   User name   User mail   User roles      User status  \n --------- ----------- ----------- --------------- ------------- \n  550895    test        test@ex.co  authenticated   1            \n --------- ----------- ----------- --------------- ------------- \n",
-        550895,
-      ],
-      'no user id present' => [
-        "Some random output\n",
-        NULL,
-      ],
-      'drush 12 table uid 1' => [
-        " --------- ----------- ----------- --------------- ------------- \n  User ID   User name   User mail   User roles      User status  \n --------- ----------- ----------- --------------- ------------- \n  1         admin       a@ex.co     administrator   1            \n --------- ----------- ----------- --------------- ------------- \n",
-        1,
-      ],
+  public function dataProviderParseUserId(): \Iterator {
+    yield 'legacy key-value format' => [
+      "User ID   :   550895\nUser name :   test\n",
+      550895,
+    ];
+    yield 'drush 12 table format' => [
+      " --------- ----------- ----------- --------------- ------------- \n  User ID   User name   User mail   User roles      User status  \n --------- ----------- ----------- --------------- ------------- \n  550895    test        test@ex.co  authenticated   1            \n --------- ----------- ----------- --------------- ------------- \n",
+      550895,
+    ];
+    yield 'no user id present' => [
+      "Some random output\n",
+      NULL,
+    ];
+    yield 'drush 12 table uid 1' => [
+      " --------- ----------- ----------- --------------- ------------- \n  User ID   User name   User mail   User roles      User status  \n --------- ----------- ----------- --------------- ------------- \n  1         admin       a@ex.co     administrator   1            \n --------- ----------- ----------- --------------- ------------- \n",
+      1,
     ];
   }
 
   /**
    * Data provider for testIsLegacyDrush().
    */
-  public function dataProviderIsLegacyDrush() {
-    return [
-      'clean modern version' => [
-        "12.5.2.0\n",
-        FALSE,
-      ],
-      'deprecation warnings before version' => [
-        "Deprecated: Drush\\Drush::shell(): Implicitly marking parameter \$env as nullable\nDeprecated: Consolidation\\Config\\Config::__construct(): ...\n12.5.2.0\n",
-        FALSE,
-      ],
-      'drush 9 version' => [
-        "9.7.2\n",
-        FALSE,
-      ],
-      'legacy drush version' => [
-        "8.4.12\n",
-        TRUE,
-      ],
-      'legacy version with noise' => [
-        "Some warning output\n8.1.0\n",
-        TRUE,
-      ],
-      'three-part modern version' => [
-        "13.0.0\n",
-        FALSE,
-      ],
+  public function dataProviderIsLegacyDrush(): \Iterator {
+    yield 'clean modern version' => [
+      "12.5.2.0\n",
+      FALSE,
+    ];
+    yield 'deprecation warnings before version' => [
+      "Deprecated: Drush\\Drush::shell(): Implicitly marking parameter \$env as nullable\nDeprecated: Consolidation\\Config\\Config::__construct(): ...\n12.5.2.0\n",
+      FALSE,
+    ];
+    yield 'drush 9 version' => [
+      "9.7.2\n",
+      FALSE,
+    ];
+    yield 'legacy drush version' => [
+      "8.4.12\n",
+      TRUE,
+    ];
+    yield 'legacy version with noise' => [
+      "Some warning output\n8.1.0\n",
+      TRUE,
+    ];
+    yield 'three-part modern version' => [
+      "13.0.0\n",
+      FALSE,
     ];
   }
 
@@ -141,21 +139,21 @@ class TestDrushDriver extends DrushDriver {
   /**
    * {@inheritdoc}
    */
-  public function drush($command, array $arguments = [], array $options = []) {
+  public function drush($command, array $arguments = [], array $options = []): string {
     return $this->drushOutput;
   }
 
   /**
    * Exposes `isLegacyDrush()` for testing.
    */
-  public function callIsLegacyDrush() {
+  public function callIsLegacyDrush(): bool {
     return $this->isLegacyDrush();
   }
 
   /**
    * Exposes `parseUserId()` for testing.
    */
-  public function callParseUserId($info) {
+  public function callParseUserId($info): ?int {
     return $this->parseUserId($info);
   }
 

--- a/tests/Drupal/Tests/Driver/DrushDriverTest.php
+++ b/tests/Drupal/Tests/Driver/DrushDriverTest.php
@@ -73,7 +73,7 @@ class DrushDriverTest extends TestCase {
   /**
    * Data provider for testParseUserId().
    */
-  public function dataProviderParseUserId(): \Iterator {
+  public static function dataProviderParseUserId(): \Iterator {
     yield 'legacy key-value format' => [
       "User ID   :   550895\nUser name :   test\n",
       550895,
@@ -95,7 +95,7 @@ class DrushDriverTest extends TestCase {
   /**
    * Data provider for testIsLegacyDrush().
    */
-  public function dataProviderIsLegacyDrush(): \Iterator {
+  public static function dataProviderIsLegacyDrush(): \Iterator {
     yield 'clean modern version' => [
       "12.5.2.0\n",
       FALSE,

--- a/tests/Drupal/Tests/Driver/DrushDriverTest.php
+++ b/tests/Drupal/Tests/Driver/DrushDriverTest.php
@@ -131,10 +131,8 @@ class TestDrushDriver extends DrushDriver {
 
   /**
    * The output to return from `drush()`.
-   *
-   * @var string
    */
-  public $drushOutput = '';
+  public string $drushOutput = '';
 
   /**
    * {@inheritdoc}
@@ -153,7 +151,7 @@ class TestDrushDriver extends DrushDriver {
   /**
    * Exposes `parseUserId()` for testing.
    */
-  public function callParseUserId($info): ?int {
+  public function callParseUserId(string $info): ?int {
     return $this->parseUserId($info);
   }
 

--- a/tests/Drupal/Tests/Driver/Exception/UnsupportedDriverActionExceptionTest.php
+++ b/tests/Drupal/Tests/Driver/Exception/UnsupportedDriverActionExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\Driver\Exception;
 
 use Drupal\Driver\DriverInterface;
@@ -14,9 +16,9 @@ class UnsupportedDriverActionExceptionTest extends TestCase {
   /**
    * Tests that the message template is populated with the driver class name.
    */
-  public function testMessageFormatting() {
+  public function testMessageFormatting(): void {
     $driver = $this->createMock(DriverInterface::class);
-    $driver_class = get_class($driver);
+    $driver_class = $driver::class;
 
     $exception = new UnsupportedDriverActionException('Action %s is not supported.', $driver);
 
@@ -26,7 +28,7 @@ class UnsupportedDriverActionExceptionTest extends TestCase {
   /**
    * Tests that the driver is accessible via getDriver().
    */
-  public function testGetDriverReturnsConstructorArgument() {
+  public function testGetDriverReturnsConstructorArgument(): void {
     $driver = $this->createMock(DriverInterface::class);
 
     $exception = new UnsupportedDriverActionException('%s', $driver);
@@ -37,7 +39,7 @@ class UnsupportedDriverActionExceptionTest extends TestCase {
   /**
    * Tests that code and previous exception are propagated to the parent.
    */
-  public function testCodeAndPreviousArePropagated() {
+  public function testCodeAndPreviousArePropagated(): void {
     $driver = $this->createMock(DriverInterface::class);
     $previous = new \RuntimeException('root cause');
 

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/AddressHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/AddressHandlerTest.php
@@ -161,15 +161,15 @@ class AddressHandlerTest extends TestCase {
   /**
    * Creates an AddressHandler with an injected fieldConfig mock.
    *
-   * @param array $field_overrides
+   * @param array<string, mixed> $field_overrides
    *   Address field override settings.
-   * @param array $available_countries
+   * @param array<string, string> $available_countries
    *   Available countries keyed by code.
    *
    * @return \Drupal\Driver\Fields\Drupal8\AddressHandler
    *   Handler instance with fieldConfig populated.
    */
-  protected function createHandler(array $field_overrides = [], array $available_countries = ['AU' => 'AU']) {
+  protected function createHandler(array $field_overrides = [], array $available_countries = ['AU' => 'AU']): AddressHandler {
     $field_config = $this->createMock(FieldDefinitionInterface::class);
     $field_config->method('getSettings')->willReturn([
       'field_overrides' => $field_overrides,

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/AddressHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/AddressHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\Driver\Fields\Drupal8;
 
 use Drupal\Core\Field\FieldDefinitionInterface;
@@ -14,7 +16,7 @@ class AddressHandlerTest extends TestCase {
   /**
    * Tests that a string value uses the first visible field.
    */
-  public function testStringValueUsesFirstVisibleField() {
+  public function testStringValueUsesFirstVisibleField(): void {
     $handler = $this->createHandler();
 
     $result = $handler->expand(['Just a name']);
@@ -25,7 +27,7 @@ class AddressHandlerTest extends TestCase {
   /**
    * Tests that keyed values are preserved and defaults filled in.
    */
-  public function testKeyedValuesAreKeptAndDefaultCountryApplied() {
+  public function testKeyedValuesAreKeptAndDefaultCountryApplied(): void {
     $handler = $this->createHandler();
 
     $result = $handler->expand([
@@ -47,7 +49,7 @@ class AddressHandlerTest extends TestCase {
   /**
    * Tests that numeric indices are assigned in the order of visible fields.
    */
-  public function testNumericIndicesMapToVisibleFieldOrder() {
+  public function testNumericIndicesMapToVisibleFieldOrder(): void {
     $handler = $this->createHandler();
 
     $result = $handler->expand([
@@ -66,7 +68,7 @@ class AddressHandlerTest extends TestCase {
   /**
    * Tests that hidden fields are removed from the visible field list.
    */
-  public function testHiddenFieldsAreSkippedForNumericIndices() {
+  public function testHiddenFieldsAreSkippedForNumericIndices(): void {
     $handler = $this->createHandler([
       'givenName' => ['override' => 'hidden'],
       'additionalName' => ['override' => 'hidden'],
@@ -87,7 +89,7 @@ class AddressHandlerTest extends TestCase {
   /**
    * Tests that non-hidden overrides do not alter the visible field list.
    */
-  public function testNonHiddenOverridesAreIgnored() {
+  public function testNonHiddenOverridesAreIgnored(): void {
     $handler = $this->createHandler([
       'givenName' => ['override' => 'optional'],
     ]);
@@ -107,7 +109,7 @@ class AddressHandlerTest extends TestCase {
   /**
    * Tests that excess numeric indices trigger an exception.
    */
-  public function testTooManyNumericIndicesThrows() {
+  public function testTooManyNumericIndicesThrows(): void {
     $handler = $this->createHandler([
       'additionalName' => ['override' => 'hidden'],
       'familyName' => ['override' => 'hidden'],
@@ -132,7 +134,7 @@ class AddressHandlerTest extends TestCase {
   /**
    * Tests that a non-numeric, unknown sub-field key throws an exception.
    */
-  public function testUnknownKeyThrows() {
+  public function testUnknownKeyThrows(): void {
     $handler = $this->createHandler();
 
     $this->expectException(\RuntimeException::class);
@@ -146,7 +148,7 @@ class AddressHandlerTest extends TestCase {
   /**
    * Tests that an explicit country_code is not overridden by the default.
    */
-  public function testExplicitCountryCodeIsPreserved() {
+  public function testExplicitCountryCodeIsPreserved(): void {
     $handler = $this->createHandler();
 
     $result = $handler->expand([
@@ -178,7 +180,6 @@ class AddressHandlerTest extends TestCase {
     $handler = $reflection->newInstanceWithoutConstructor();
 
     $property = new \ReflectionProperty(AddressHandler::class, 'fieldConfig');
-    $property->setAccessible(TRUE);
     $property->setValue($handler, $field_config);
 
     return $handler;

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/DaterangeHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/DaterangeHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\Driver\Fields\Drupal8;
 
 use Composer\InstalledVersions;
@@ -50,7 +52,7 @@ class DaterangeHandlerTest extends TestCase {
   /**
    * Tests that empty start/end values produce NULL entries.
    */
-  public function testExpandHandlesEmptyValuesAsNull() {
+  public function testExpandHandlesEmptyValuesAsNull(): void {
     $reflection = new \ReflectionClass(DaterangeHandler::class);
     $handler = $reflection->newInstanceWithoutConstructor();
 

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/DaterangeHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/DaterangeHandlerTest.php
@@ -70,7 +70,7 @@ class DaterangeHandlerTest extends TestCase {
   /**
    * Loads the datetime module interface from the Composer-resolved core path.
    */
-  protected function loadDatetimeModuleInterface() {
+  protected function loadDatetimeModuleInterface(): bool {
     if (interface_exists(DateTimeItemInterface::class)) {
       return TRUE;
     }

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/DatetimeHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/DatetimeHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\Driver\Fields\Drupal8;
 
 use Composer\InstalledVersions;
@@ -52,7 +54,7 @@ class DatetimeHandlerTest extends TestCase {
   /**
    * Tests that empty strings and NULLs pass through as NULL values.
    */
-  public function testExpandPreservesEmptyValuesAsNull() {
+  public function testExpandPreservesEmptyValuesAsNull(): void {
     $handler = $this->createHandler('datetime');
 
     $result = $handler->expand(['', NULL]);
@@ -73,7 +75,6 @@ class DatetimeHandlerTest extends TestCase {
     $handler = $reflection->newInstanceWithoutConstructor();
 
     $property = new \ReflectionProperty(DatetimeHandler::class, 'fieldInfo');
-    $property->setAccessible(TRUE);
     $property->setValue($handler, $field_info);
 
     return $handler;

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/DatetimeHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/DatetimeHandlerTest.php
@@ -65,7 +65,7 @@ class DatetimeHandlerTest extends TestCase {
   /**
    * Creates a DatetimeHandler with a fieldInfo mock returning datetime_type.
    */
-  protected function createHandler($datetime_type) {
+  protected function createHandler(string $datetime_type): DatetimeHandler {
     $field_info = $this->createMock(FieldStorageDefinitionInterface::class);
     $field_info->method('getSetting')
       ->with('datetime_type')
@@ -87,7 +87,7 @@ class DatetimeHandlerTest extends TestCase {
    * coverage, so the relevant files are loaded explicitly. Returns TRUE when
    * DateTimeItemInterface is available after loading.
    */
-  protected function loadDatetimeModuleInterface() {
+  protected function loadDatetimeModuleInterface(): bool {
     if (interface_exists(DateTimeItemInterface::class)) {
       return TRUE;
     }

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/DefaultHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/DefaultHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\Driver\Fields\Drupal8;
 
 use Drupal\Driver\Fields\Drupal8\DefaultHandler;
@@ -13,7 +15,7 @@ class DefaultHandlerTest extends TestCase {
   /**
    * Tests that expand() returns the input unchanged.
    */
-  public function testExpandReturnsValuesUnchanged() {
+  public function testExpandReturnsValuesUnchanged(): void {
     $reflection = new \ReflectionClass(DefaultHandler::class);
     $handler = $reflection->newInstanceWithoutConstructor();
 

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/EntityReferenceHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/EntityReferenceHandlerTest.php
@@ -66,8 +66,16 @@ class EntityReferenceHandlerTest extends TestCase {
 
   /**
    * Creates an EntityReferenceHandler with mocked fieldInfo and fieldConfig.
+   *
+   * @param string $target_type
+   *   The target entity type ID.
+   * @param array<string, string> $target_bundles
+   *   Target bundle restrictions.
+   *
+   * @return \Drupal\Driver\Fields\Drupal8\EntityReferenceHandler
+   *   A handler instance with fieldInfo and fieldConfig populated.
    */
-  protected function createHandler($target_type, array $target_bundles) {
+  protected function createHandler(string $target_type, array $target_bundles = []): EntityReferenceHandler {
     $field_info = $this->createMock(FieldStorageDefinitionInterface::class);
     $field_info->method('getSetting')
       ->with('target_type')
@@ -93,7 +101,7 @@ class EntityReferenceHandlerTest extends TestCase {
   /**
    * Sets up a Drupal container whose queries always return no results.
    */
-  protected function setUpEmptyQueryContainer($entity_type_id) {
+  protected function setUpEmptyQueryContainer(string $entity_type_id): void {
     $definition = $this->createMock(EntityTypeInterface::class);
     $definition->method('getKey')->willReturnMap([
       ['id', 'nid'],
@@ -109,12 +117,12 @@ class EntityReferenceHandlerTest extends TestCase {
 
     $storage = new class($query) {
 
-      public function __construct(private $query) {}
+      public function __construct(private readonly QueryInterface $query) {}
 
       /**
        * Returns the injected entity query.
        */
-      public function getQuery() {
+      public function getQuery(): QueryInterface {
         return $this->query;
       }
 

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/EntityReferenceHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/EntityReferenceHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\Driver\Fields\Drupal8;
 
 use Drupal\Core\DependencyInjection\ContainerBuilder;
@@ -30,7 +32,7 @@ class EntityReferenceHandlerTest extends TestCase {
   /**
    * Tests that unknown values raise an exception.
    */
-  public function testExpandThrowsWhenNoEntityMatches() {
+  public function testExpandThrowsWhenNoEntityMatches(): void {
     $handler = $this->createHandler('node', []);
     $this->setUpEmptyQueryContainer('node');
 
@@ -43,11 +45,10 @@ class EntityReferenceHandlerTest extends TestCase {
   /**
    * Tests getTargetBundles() returns configured bundles.
    */
-  public function testGetTargetBundlesReturnsConfiguredBundles() {
+  public function testGetTargetBundlesReturnsConfiguredBundles(): void {
     $handler = $this->createHandler('node', ['article', 'page']);
 
     $reflection = new \ReflectionMethod(EntityReferenceHandler::class, 'getTargetBundles');
-    $reflection->setAccessible(TRUE);
 
     $this->assertSame(['article', 'page'], $reflection->invoke($handler));
   }
@@ -55,11 +56,10 @@ class EntityReferenceHandlerTest extends TestCase {
   /**
    * Tests getTargetBundles() returns NULL when none configured.
    */
-  public function testGetTargetBundlesReturnsNullWhenEmpty() {
+  public function testGetTargetBundlesReturnsNullWhenEmpty(): void {
     $handler = $this->createHandler('node', []);
 
     $reflection = new \ReflectionMethod(EntityReferenceHandler::class, 'getTargetBundles');
-    $reflection->setAccessible(TRUE);
 
     $this->assertNull($reflection->invoke($handler));
   }
@@ -82,11 +82,9 @@ class EntityReferenceHandlerTest extends TestCase {
     $handler = $reflection->newInstanceWithoutConstructor();
 
     $info_property = new \ReflectionProperty(EntityReferenceHandler::class, 'fieldInfo');
-    $info_property->setAccessible(TRUE);
     $info_property->setValue($handler, $field_info);
 
     $config_property = new \ReflectionProperty(EntityReferenceHandler::class, 'fieldConfig');
-    $config_property->setAccessible(TRUE);
     $config_property->setValue($handler, $field_config);
 
     return $handler;

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/FileHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/FileHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\Driver\Fields\Drupal8;
 
 use Drupal\Core\DependencyInjection\ContainerBuilder;
@@ -22,7 +24,7 @@ class FileHandlerTest extends TestCase {
   /**
    * Tests that unreadable files throw a descriptive exception.
    */
-  public function testExpandThrowsWhenFileCannotBeRead() {
+  public function testExpandThrowsWhenFileCannotBeRead(): void {
     $handler = $this->createHandler();
 
     $this->expectException(\Exception::class);
@@ -34,7 +36,7 @@ class FileHandlerTest extends TestCase {
   /**
    * Tests that string paths produce a single target entry with defaults.
    */
-  public function testExpandHandlesStringValueWithDefaults() {
+  public function testExpandHandlesStringValueWithDefaults(): void {
     $path = $this->createTempFile('png');
     $this->setFileRepositoryWithReturnId(99);
 
@@ -50,7 +52,7 @@ class FileHandlerTest extends TestCase {
   /**
    * Tests that keyed array values honour their explicit overrides.
    */
-  public function testExpandHandlesArrayValueWithOverrides() {
+  public function testExpandHandlesArrayValueWithOverrides(): void {
     $path = $this->createTempFile('pdf');
     $this->setFileRepositoryWithReturnId(42);
 
@@ -72,7 +74,7 @@ class FileHandlerTest extends TestCase {
   /**
    * Creates a FileHandler that bypasses the parent constructor.
    */
-  protected function createHandler() {
+  protected function createHandler(): FileHandler {
     $reflection = new \ReflectionClass(FileHandler::class);
     return $reflection->newInstanceWithoutConstructor();
   }
@@ -80,7 +82,7 @@ class FileHandlerTest extends TestCase {
   /**
    * Creates a temporary file and returns its path.
    */
-  protected function createTempFile($extension) {
+  protected function createTempFile(string $extension): string {
     $path = tempnam(sys_get_temp_dir(), 'drupal-driver-') . '.' . $extension;
     file_put_contents($path, 'fixture');
     return $path;
@@ -108,7 +110,7 @@ class FileHandlerTest extends TestCase {
       /**
        * Saves the file entity (no-op in the test double).
        */
-      public function save() {
+      public function save(): void {
       }
 
     };

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/FileHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/FileHandlerTest.php
@@ -95,15 +95,15 @@ class FileHandlerTest extends TestCase {
    * FileRepositoryInterface ship with the file module rather than drupal/core
    * and are therefore not guaranteed to be autoloadable in isolation.
    */
-  protected function setFileRepositoryWithReturnId($file_id) {
+  protected function setFileRepositoryWithReturnId(int $file_id): void {
     $file = new class($file_id) {
 
-      public function __construct(private $file_id) {}
+      public function __construct(private readonly int $file_id) {}
 
       /**
        * Returns the stored file entity ID.
        */
-      public function id() {
+      public function id(): int {
         return $this->file_id;
       }
 
@@ -117,12 +117,12 @@ class FileHandlerTest extends TestCase {
 
     $repository = new class($file) {
 
-      public function __construct(private $file) {}
+      public function __construct(private readonly mixed $file) {}
 
       /**
        * Writes data to a destination and returns the stored file entity.
        */
-      public function writeData($data, $destination) {
+      public function writeData(string $data, string $destination): mixed {
         return $this->file;
       }
 

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/ImageHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/ImageHandlerTest.php
@@ -79,15 +79,15 @@ class ImageHandlerTest extends TestCase {
    * FileRepositoryInterface ship with the file module rather than drupal/core
    * and are therefore not guaranteed to be autoloadable in isolation.
    */
-  protected function setFileRepositoryWithReturnId($file_id) {
+  protected function setFileRepositoryWithReturnId(int $file_id): void {
     $file = new class($file_id) {
 
-      public function __construct(private $file_id) {}
+      public function __construct(private readonly int $file_id) {}
 
       /**
        * Returns the stored file entity ID.
        */
-      public function id() {
+      public function id(): int {
         return $this->file_id;
       }
 
@@ -101,12 +101,12 @@ class ImageHandlerTest extends TestCase {
 
     $repository = new class($file) {
 
-      public function __construct(private $file) {}
+      public function __construct(private readonly mixed $file) {}
 
       /**
        * Writes data to a destination and returns the stored file entity.
        */
-      public function writeData($data, $destination) {
+      public function writeData(string $data, string $destination): mixed {
         return $this->file;
       }
 

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/ImageHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/ImageHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\Driver\Fields\Drupal8;
 
 use Drupal\Core\DependencyInjection\ContainerBuilder;
@@ -22,7 +24,7 @@ class ImageHandlerTest extends TestCase {
   /**
    * Tests that unreadable files throw a descriptive exception.
    */
-  public function testExpandThrowsWhenFileCannotBeRead() {
+  public function testExpandThrowsWhenFileCannotBeRead(): void {
     $handler = $this->createHandler();
 
     $this->expectException(\Exception::class);
@@ -34,7 +36,7 @@ class ImageHandlerTest extends TestCase {
   /**
    * Tests that a readable path is expanded into an image field value.
    */
-  public function testExpandReturnsImageValueWithDefaultAltAndTitle() {
+  public function testExpandReturnsImageValueWithDefaultAltAndTitle(): void {
     $path = tempnam(sys_get_temp_dir(), 'drupal-driver-') . '.jpg';
     file_put_contents($path, 'fixture');
     $this->setFileRepositoryWithReturnId(7);
@@ -49,7 +51,7 @@ class ImageHandlerTest extends TestCase {
   /**
    * Tests that alt and title extras are propagated when provided.
    */
-  public function testExpandPropagatesAltAndTitleExtras() {
+  public function testExpandPropagatesAltAndTitleExtras(): void {
     $path = tempnam(sys_get_temp_dir(), 'drupal-driver-') . '.jpg';
     file_put_contents($path, 'fixture');
     $this->setFileRepositoryWithReturnId(12);
@@ -65,7 +67,7 @@ class ImageHandlerTest extends TestCase {
   /**
    * Creates an ImageHandler that bypasses the parent constructor.
    */
-  protected function createHandler() {
+  protected function createHandler(): ImageHandler {
     $reflection = new \ReflectionClass(ImageHandler::class);
     return $reflection->newInstanceWithoutConstructor();
   }
@@ -92,7 +94,7 @@ class ImageHandlerTest extends TestCase {
       /**
        * Saves the file entity (no-op in the test double).
        */
-      public function save() {
+      public function save(): void {
       }
 
     };

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/ListHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/ListHandlerTest.php
@@ -78,13 +78,13 @@ class ListHandlerTest extends TestCase {
    *
    * @param string $class_name
    *   The handler class to instantiate.
-   * @param array $allowed_values
+   * @param array<string, string> $allowed_values
    *   The allowed_values map to inject via the fieldInfo setting.
    *
    * @return object
    *   The handler instance with fieldInfo populated.
    */
-  protected function createHandler($class_name, array $allowed_values) {
+  protected function createHandler(string $class_name, array $allowed_values): object {
     $field_info = $this->createMock(FieldStorageDefinitionInterface::class);
     $field_info->method('getSetting')
       ->with('allowed_values')

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/ListHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/ListHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\Driver\Fields\Drupal8;
 
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
@@ -16,7 +18,7 @@ class ListHandlerTest extends TestCase {
   /**
    * Tests that values matching allowed_values labels are mapped to keys.
    */
-  public function testExpandMapsLabelsToKeys() {
+  public function testExpandMapsLabelsToKeys(): void {
     $handler = $this->createHandler(ListStringHandler::class, [
       'red' => 'Red',
       'green' => 'Green',
@@ -29,7 +31,7 @@ class ListHandlerTest extends TestCase {
   /**
    * Tests that unmatched values fall through unchanged.
    */
-  public function testExpandReturnsOriginalValuesWhenNoMatch() {
+  public function testExpandReturnsOriginalValuesWhenNoMatch(): void {
     $handler = $this->createHandler(ListStringHandler::class, [
       'a' => 'Alpha',
     ]);
@@ -40,7 +42,7 @@ class ListHandlerTest extends TestCase {
   /**
    * Tests that integer list values are mapped to keys.
    */
-  public function testIntegerListMapsLabelsToKeys() {
+  public function testIntegerListMapsLabelsToKeys(): void {
     $handler = $this->createHandler(ListIntegerHandler::class, [
       1 => 'One',
       2 => 'Two',
@@ -52,7 +54,7 @@ class ListHandlerTest extends TestCase {
   /**
    * Tests that float list values are mapped to keys.
    */
-  public function testFloatListMapsLabelsToKeys() {
+  public function testFloatListMapsLabelsToKeys(): void {
     $handler = $this->createHandler(ListFloatHandler::class, [
       '1.5' => 'One and a half',
     ]);
@@ -63,7 +65,7 @@ class ListHandlerTest extends TestCase {
   /**
    * Tests that a scalar value is cast to an array before lookup.
    */
-  public function testExpandCastsScalarToArray() {
+  public function testExpandCastsScalarToArray(): void {
     $handler = $this->createHandler(ListStringHandler::class, [
       'k' => 'Label',
     ]);
@@ -92,7 +94,6 @@ class ListHandlerTest extends TestCase {
     $handler = $reflection->newInstanceWithoutConstructor();
 
     $property = new \ReflectionProperty($class_name, 'fieldInfo');
-    $property->setAccessible(TRUE);
     $property->setValue($handler, $field_info);
 
     return $handler;

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/SupportedImageHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/SupportedImageHandlerTest.php
@@ -134,15 +134,15 @@ class SupportedImageHandlerTest extends TestCase {
    * FileRepositoryInterface ship with the file module rather than drupal/core
    * and are therefore not guaranteed to be autoloadable in isolation.
    */
-  protected function setFileRepositoryWithReturnId($file_id) {
+  protected function setFileRepositoryWithReturnId(int $file_id): void {
     $file = new class($file_id) {
 
-      public function __construct(private $file_id) {}
+      public function __construct(private readonly int $file_id) {}
 
       /**
        * Returns the stored file entity ID.
        */
-      public function id() {
+      public function id(): int {
         return $this->file_id;
       }
 
@@ -156,12 +156,12 @@ class SupportedImageHandlerTest extends TestCase {
 
     $repository = new class($file) {
 
-      public function __construct(private $file) {}
+      public function __construct(private readonly mixed $file) {}
 
       /**
        * Writes data to a destination and returns the stored file entity.
        */
-      public function writeData($data, $destination) {
+      public function writeData(string $data, string $destination): mixed {
         return $this->file;
       }
 

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/SupportedImageHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/SupportedImageHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\Driver\Fields\Drupal8;
 
 use Drupal\Core\DependencyInjection\ContainerBuilder;
@@ -22,7 +24,7 @@ class SupportedImageHandlerTest extends TestCase {
   /**
    * Tests that unreadable files throw a descriptive exception.
    */
-  public function testExpandThrowsWhenFileCannotBeRead() {
+  public function testExpandThrowsWhenFileCannotBeRead(): void {
     $handler = $this->createHandler();
 
     $this->expectException(\Exception::class);
@@ -34,7 +36,7 @@ class SupportedImageHandlerTest extends TestCase {
   /**
    * Tests that a string input is normalised into a single-item result.
    */
-  public function testExpandNormalisesStringInputToSingleItem() {
+  public function testExpandNormalisesStringInputToSingleItem(): void {
     $path = $this->createTempFile('jpg');
     $this->setFileRepositoryWithReturnId(3);
 
@@ -58,7 +60,7 @@ class SupportedImageHandlerTest extends TestCase {
   /**
    * Tests that caption and attribution metadata are preserved.
    */
-  public function testExpandPreservesCaptionAndAttributionMetadata() {
+  public function testExpandPreservesCaptionAndAttributionMetadata(): void {
     $path = $this->createTempFile('png');
     $this->setFileRepositoryWithReturnId(5);
 
@@ -92,7 +94,7 @@ class SupportedImageHandlerTest extends TestCase {
   /**
    * Tests that a single array with target_id is wrapped as a single item.
    */
-  public function testExpandWrapsSingleKeyedArrayInput() {
+  public function testExpandWrapsSingleKeyedArrayInput(): void {
     $path = $this->createTempFile('jpg');
     $this->setFileRepositoryWithReturnId(8);
 
@@ -111,7 +113,7 @@ class SupportedImageHandlerTest extends TestCase {
   /**
    * Creates a SupportedImageHandler that bypasses the parent constructor.
    */
-  protected function createHandler() {
+  protected function createHandler(): SupportedImageHandler {
     $reflection = new \ReflectionClass(SupportedImageHandler::class);
     return $reflection->newInstanceWithoutConstructor();
   }
@@ -119,7 +121,7 @@ class SupportedImageHandlerTest extends TestCase {
   /**
    * Creates a temporary file with the given extension.
    */
-  protected function createTempFile($extension) {
+  protected function createTempFile(string $extension): string {
     $path = tempnam(sys_get_temp_dir(), 'drupal-driver-') . '.' . $extension;
     file_put_contents($path, 'fixture');
     return $path;
@@ -147,7 +149,7 @@ class SupportedImageHandlerTest extends TestCase {
       /**
        * Saves the file entity (no-op in the test double).
        */
-      public function save() {
+      public function save(): void {
       }
 
     };

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/TaxonomyTermReferenceHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/TaxonomyTermReferenceHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\Driver\Fields\Drupal8;
 
 use Drupal\Core\DependencyInjection\ContainerBuilder;
@@ -24,13 +26,13 @@ class TaxonomyTermReferenceHandlerTest extends TestCase {
   /**
    * Tests that a matching term returns its ID.
    */
-  public function testExpandReturnsTermId() {
+  public function testExpandReturnsTermId(): void {
     $term = new class {
 
       /**
        * Returns the term entity ID.
        */
-      public function id() {
+      public function id(): int {
         return 17;
       }
 
@@ -46,7 +48,7 @@ class TaxonomyTermReferenceHandlerTest extends TestCase {
   /**
    * Tests that an unknown term name raises an exception.
    */
-  public function testExpandThrowsWhenTermNotFound() {
+  public function testExpandThrowsWhenTermNotFound(): void {
     $this->setUpStorageWithResult([]);
 
     $handler = $this->createHandler();
@@ -60,7 +62,7 @@ class TaxonomyTermReferenceHandlerTest extends TestCase {
   /**
    * Creates a handler that bypasses the parent constructor.
    */
-  protected function createHandler() {
+  protected function createHandler(): TaxonomyTermReferenceHandler {
     $reflection = new \ReflectionClass(TaxonomyTermReferenceHandler::class);
     return $reflection->newInstanceWithoutConstructor();
   }

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/TaxonomyTermReferenceHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/TaxonomyTermReferenceHandlerTest.php
@@ -69,8 +69,11 @@ class TaxonomyTermReferenceHandlerTest extends TestCase {
 
   /**
    * Sets up a Drupal container that returns the supplied lookup results.
+   *
+   * @param array<string, mixed> $lookup
+   *   Map of term names to entity arrays.
    */
-  protected function setUpStorageWithResult(array $lookup) {
+  protected function setUpStorageWithResult(array $lookup): void {
     $storage = $this->createMock(EntityStorageInterface::class);
     $storage->method('loadByProperties')
       ->willReturnCallback(fn($properties) => $lookup[$properties['name']] ?? []);

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/TextWithSummaryHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/TextWithSummaryHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\Driver\Fields\Drupal8;
 
 use Drupal\Driver\Fields\Drupal8\TextWithSummaryHandler;
@@ -13,7 +15,7 @@ class TextWithSummaryHandlerTest extends TestCase {
   /**
    * Tests that expand() returns the input unchanged.
    */
-  public function testExpandReturnsValuesUnchanged() {
+  public function testExpandReturnsValuesUnchanged(): void {
     $handler = new TextWithSummaryHandler();
 
     $values = [

--- a/tests/Drupal/Tests/Driver/LinkHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/LinkHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\Driver;
 
 use Drupal\Driver\Fields\Drupal8\LinkHandler;
@@ -20,7 +22,7 @@ class LinkHandlerTest extends TestCase {
    *
    * @dataProvider dataProviderExpand
    */
-  public function testExpand(array $input, array $expected) {
+  public function testExpand(array $input, array $expected): void {
     $handler = $this->createHandler();
     $result = $handler->expand($input);
     $this->assertSame($expected, $result);
@@ -29,17 +31,16 @@ class LinkHandlerTest extends TestCase {
   /**
    * Data provider for testExpand().
    */
-  public function dataProviderExpand() {
-    return [
-      'numeric indices' => [
+  public function dataProviderExpand(): \Iterator {
+    yield 'numeric indices' => [
         [['My link', 'https://example.com']],
         [['title' => 'My link', 'uri' => 'https://example.com', 'options' => []]],
-      ],
-      'named keys' => [
+    ];
+    yield 'named keys' => [
         [['title' => 'My link', 'uri' => 'https://example.com']],
         [['title' => 'My link', 'uri' => 'https://example.com', 'options' => []]],
-      ],
-      'numeric indices with options' => [
+    ];
+    yield 'numeric indices with options' => [
         [['My link', 'https://example.com', 'target=_blank&rel=nofollow']],
         [[
           'title' => 'My link',
@@ -47,12 +48,12 @@ class LinkHandlerTest extends TestCase {
           'options' => ['target' => '_blank', 'rel' => 'nofollow'],
         ],
         ],
-      ],
-      'named keys with options' => [
+    ];
+    yield 'named keys with options' => [
         [['title' => 'My link', 'uri' => 'https://example.com', 'options' => 'target=_blank']],
         [['title' => 'My link', 'uri' => 'https://example.com', 'options' => ['target' => '_blank']]],
-      ],
-      'multiple values' => [
+    ];
+    yield 'multiple values' => [
         [
           ['First', 'https://first.com'],
           ['title' => 'Second', 'uri' => 'https://second.com'],
@@ -61,16 +62,16 @@ class LinkHandlerTest extends TestCase {
           ['title' => 'First', 'uri' => 'https://first.com', 'options' => []],
           ['title' => 'Second', 'uri' => 'https://second.com', 'options' => []],
         ],
-      ],
-      'no options returns empty array' => [
+    ];
+    yield 'no options returns empty array' => [
         [['title' => 'Link', 'uri' => 'https://example.com']],
         [['title' => 'Link', 'uri' => 'https://example.com', 'options' => []]],
-      ],
-      'uri-only string' => [
+    ];
+    yield 'uri-only string' => [
         ['https://example.com'],
         [['uri' => 'https://example.com', 'options' => []]],
-      ],
-      'mixed uri-only and full' => [
+    ];
+    yield 'mixed uri-only and full' => [
         [
           'https://first.com',
           ['title' => 'Second', 'uri' => 'https://second.com'],
@@ -79,7 +80,6 @@ class LinkHandlerTest extends TestCase {
           ['uri' => 'https://first.com', 'options' => []],
           ['title' => 'Second', 'uri' => 'https://second.com', 'options' => []],
         ],
-      ],
     ];
   }
 
@@ -89,7 +89,7 @@ class LinkHandlerTest extends TestCase {
    * @return \Drupal\Driver\Fields\Drupal8\LinkHandler
    *   The handler instance.
    */
-  protected function createHandler() {
+  protected function createHandler(): LinkHandler {
     $reflection = new \ReflectionClass(LinkHandler::class);
     return $reflection->newInstanceWithoutConstructor();
   }

--- a/tests/Drupal/Tests/Driver/LinkHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/LinkHandlerTest.php
@@ -31,7 +31,7 @@ class LinkHandlerTest extends TestCase {
   /**
    * Data provider for testExpand().
    */
-  public function dataProviderExpand(): \Iterator {
+  public static function dataProviderExpand(): \Iterator {
     yield 'numeric indices' => [
         [['My link', 'https://example.com']],
         [['title' => 'My link', 'uri' => 'https://example.com', 'options' => []]],

--- a/tests/Drupal/Tests/Driver/LinkHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/LinkHandlerTest.php
@@ -15,9 +15,9 @@ class LinkHandlerTest extends TestCase {
   /**
    * Tests link field expansion.
    *
-   * @param array $input
+   * @param array<int, mixed> $input
    *   The input values to expand.
-   * @param array $expected
+   * @param array<int, mixed> $expected
    *   The expected expanded values.
    *
    * @dataProvider dataProviderExpand

--- a/tests/Drupal/Tests/Driver/NameHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/NameHandlerTest.php
@@ -15,9 +15,9 @@ class NameHandlerTest extends TestCase {
   /**
    * Tests name field expansion.
    *
-   * @param array $input
+   * @param array<int, mixed> $input
    *   The input values to expand.
-   * @param array $expected
+   * @param array<int, mixed> $expected
    *   The expected expanded values.
    *
    * @dataProvider dataProviderExpand

--- a/tests/Drupal/Tests/Driver/NameHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/NameHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\Driver;
 
 use Drupal\Driver\Fields\Drupal8\NameHandler;
@@ -20,7 +22,7 @@ class NameHandlerTest extends TestCase {
    *
    * @dataProvider dataProviderExpand
    */
-  public function testExpand(array $input, array $expected) {
+  public function testExpand(array $input, array $expected): void {
     $handler = $this->createHandler();
     $result = $handler->expand($input);
     $this->assertSame($expected, $result);
@@ -29,25 +31,24 @@ class NameHandlerTest extends TestCase {
   /**
    * Data provider for testExpand().
    */
-  public function dataProviderExpand() {
-    return [
-      'string shorthand family, given' => [
+  public function dataProviderExpand(): \Iterator {
+    yield 'string shorthand family, given' => [
         ['Doe, John'],
         [['family' => 'Doe', 'given' => 'John']],
-      ],
-      'string shorthand family only' => [
+    ];
+    yield 'string shorthand family only' => [
         ['Doe'],
         [['family' => 'Doe', 'given' => NULL]],
-      ],
-      'named keys' => [
+    ];
+    yield 'named keys' => [
         [['given' => 'John', 'family' => 'Doe', 'middle' => 'Q']],
         [['given' => 'John', 'family' => 'Doe', 'middle' => 'Q']],
-      ],
-      'numeric indices' => [
+    ];
+    yield 'numeric indices' => [
         [['Dr', 'John', 'Quincy', 'Doe']],
         [['title' => 'Dr', 'given' => 'John', 'middle' => 'Quincy', 'family' => 'Doe']],
-      ],
-      'multiple values' => [
+    ];
+    yield 'multiple values' => [
         [
           'Doe, John',
           ['given' => 'Jane', 'family' => 'Smith'],
@@ -56,7 +57,6 @@ class NameHandlerTest extends TestCase {
           ['family' => 'Doe', 'given' => 'John'],
           ['given' => 'Jane', 'family' => 'Smith'],
         ],
-      ],
     ];
   }
 
@@ -66,7 +66,7 @@ class NameHandlerTest extends TestCase {
    * @return \Drupal\Driver\Fields\Drupal8\NameHandler
    *   The handler instance.
    */
-  protected function createHandler() {
+  protected function createHandler(): NameHandler {
     $reflection = new \ReflectionClass(NameHandler::class);
     return $reflection->newInstanceWithoutConstructor();
   }

--- a/tests/Drupal/Tests/Driver/NameHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/NameHandlerTest.php
@@ -31,7 +31,7 @@ class NameHandlerTest extends TestCase {
   /**
    * Data provider for testExpand().
    */
-  public function dataProviderExpand(): \Iterator {
+  public static function dataProviderExpand(): \Iterator {
     yield 'string shorthand family, given' => [
         ['Doe, John'],
         [['family' => 'Doe', 'given' => 'John']],

--- a/tests/Drupal/Tests/Driver/TimeHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/TimeHandlerTest.php
@@ -31,7 +31,7 @@ class TimeHandlerTest extends TestCase {
   /**
    * Data provider for testExpand().
    */
-  public function dataProviderExpand(): \Iterator {
+  public static function dataProviderExpand(): \Iterator {
     // Seconds past midnight for known times.
     // 9:30 AM = 9*3600 + 30*60 = 34200.
     // 2:15:30 PM = 14*3600 + 15*60 + 30 = 51330.

--- a/tests/Drupal/Tests/Driver/TimeHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/TimeHandlerTest.php
@@ -15,9 +15,9 @@ class TimeHandlerTest extends TestCase {
   /**
    * Tests time field expansion.
    *
-   * @param array $input
+   * @param array<int, mixed> $input
    *   The input values to expand.
-   * @param array $expected
+   * @param array<int, mixed> $expected
    *   The expected expanded values.
    *
    * @dataProvider dataProviderExpand

--- a/tests/Drupal/Tests/Driver/TimeHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/TimeHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\Driver;
 
 use Drupal\Driver\Fields\Drupal8\TimeHandler;
@@ -20,7 +22,7 @@ class TimeHandlerTest extends TestCase {
    *
    * @dataProvider dataProviderExpand
    */
-  public function testExpand(array $input, array $expected) {
+  public function testExpand(array $input, array $expected): void {
     $handler = $this->createHandler();
     $result = $handler->expand($input);
     $this->assertSame($expected, $result);
@@ -29,38 +31,35 @@ class TimeHandlerTest extends TestCase {
   /**
    * Data provider for testExpand().
    */
-  public function dataProviderExpand() {
+  public function dataProviderExpand(): \Iterator {
     // Seconds past midnight for known times.
     // 9:30 AM = 9*3600 + 30*60 = 34200.
     // 2:15:30 PM = 14*3600 + 15*60 + 30 = 51330.
     // Midnight = 0.
     $midnight = strtotime('today midnight');
-
-    return [
-      'numeric integer passthrough' => [
-        [34200],
-        [34200],
-      ],
-      'numeric string passthrough' => [
-        ['34200'],
-        ['34200'],
-      ],
-      'time string 9:30 AM' => [
-        ['9:30 AM'],
-        [strtotime('9:30 AM') - $midnight],
-      ],
-      'time string 14:15:30' => [
-        ['14:15:30'],
-        [strtotime('14:15:30') - $midnight],
-      ],
-      'time string midnight' => [
-        ['midnight'],
-        [0],
-      ],
-      'multiple mixed values' => [
-        [3600, '9:30 AM', '0'],
-        [3600, strtotime('9:30 AM') - $midnight, '0'],
-      ],
+    yield 'numeric integer passthrough' => [
+      [34200],
+      [34200],
+    ];
+    yield 'numeric string passthrough' => [
+      ['34200'],
+      ['34200'],
+    ];
+    yield 'time string 9:30 AM' => [
+      ['9:30 AM'],
+      [strtotime('9:30 AM') - $midnight],
+    ];
+    yield 'time string 14:15:30' => [
+      ['14:15:30'],
+      [strtotime('14:15:30') - $midnight],
+    ];
+    yield 'time string midnight' => [
+      ['midnight'],
+      [0],
+    ];
+    yield 'multiple mixed values' => [
+      [3600, '9:30 AM', '0'],
+      [3600, strtotime('9:30 AM') - $midnight, '0'],
     ];
   }
 
@@ -70,7 +69,7 @@ class TimeHandlerTest extends TestCase {
    * @return \Drupal\Driver\Fields\Drupal8\TimeHandler
    *   The handler instance.
    */
-  protected function createHandler() {
+  protected function createHandler(): TimeHandler {
     // Use reflection to bypass AbstractHandler constructor which requires
     // a full Drupal bootstrap.
     $reflection = new \ReflectionClass(TimeHandler::class);


### PR DESCRIPTION
> **Note:** This PR is one part of the v3.x upgrade. See the
> [3.x epic #312](https://github.com/jhedstrom/DrupalDriver/issues/312)
> for the full scope and related work.

Part of #312

## Summary

Introduces `declare(strict_types=1)` and PHP 8.2 parameter/return/property type declarations across all 57 files in the codebase (32 source files, 24 test files, plus `rector.php`). Rector is configured to mirror the Drupal Extension's setup, using `php82` sets, `typeDeclarations` and `naming` prepared sets, and `DeclareStrictTypesRector`. Switched from the unmaintained `palantirnet/drupal-rector ^0.20` to `rector/rector ^2.0` directly - the same dependency Drupal Extension uses.

## Changes

### Tooling
- `composer.json`: dropped `palantirnet/drupal-rector ^0.20`; added `rector/rector ^2.0` directly. Matches Drupal Extension's setup.
- `rector.php`: rewritten to mirror [Drupal Extension's rector config](https://github.com/jhedstrom/drupalextension/blob/main/rector.php). Key changes:
  - `withPhpSets(php74: TRUE)` -> `withPhpSets(php82: TRUE)`
  - Added `typeDeclarations` and `naming` to `withPreparedSets`
  - Added `DeclareStrictTypesRector` and `YieldDataProviderRector` rules
  - Added skips for rules that conflict with our codebase (e.g. `ChangeSwitchToMatchRector`, `CompleteDynamicPropertiesRector`, several `Naming` rules, `ClassPropertyAssignToConstructorPromotionRector`)
  - Added `withImportNames(importNames: TRUE, importDocBlockNames: FALSE, importShortClasses: FALSE)`
  - Added `withFileExtensions(['php', 'inc'])`

### Source code (`src/`)
- Added `declare(strict_types=1);` to every file (32 files).
- Added parameter and return type declarations across interfaces and concrete classes (`DriverInterface`, `CoreInterface`, `BaseDriver`, `BlackboxDriver`, `DrupalDriver`, `DrushDriver`, `AbstractCore`, `Drupal8`, all field handlers).
- Added property type declarations where rector could infer them.
- Manually reverted rector's constructor property promotion in `AbstractCore.php`, `Exception.php`, and `DrupalDriver.php` (the promotion mangled existing docblocks); skipped that rule going forward.
- Removed redundant `@return mixed[]` docblocks rector added when the signature already declares `: array` on `{@inheritdoc}` methods (PHPCS sniffs require a description otherwise).

### Tests (`tests/`)
- Added `declare(strict_types=1);` to every test file (24 files).
- Added `: void` return types on `setUp` / `tearDown` / test methods.
- Added `: array` return types on data providers.
- Yield-style refactor on data providers where applicable.
- Tightened type casts on test fixtures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced codebase with strict type declarations throughout for improved type safety
  * Modernized configuration for PHP 8.2+ compatibility
  * Updated test infrastructure with stronger typing and refactored data providers

* **Chores**
  * Updated development dependencies to latest versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->