### PR TITLE
[v3] Reordered driver methods into canonical capability-based layout and widened property visibility to 'protected'.

### DIFF
--- a/src/Drupal/Driver/BlackboxDriver.php
+++ b/src/Drupal/Driver/BlackboxDriver.php
@@ -17,7 +17,7 @@ class BlackboxDriver implements BlackboxDriverInterface {
   /**
    * Random generator.
    */
-  private readonly Random $random;
+  protected readonly Random $random;
 
   /**
    * Set up the driver with an optional random generator.

--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -18,7 +18,7 @@ class DrupalDriver implements DrupalDriverInterface {
   /**
    * Track whether Drupal has been bootstrapped.
    */
-  private bool $bootstrapped = FALSE;
+  protected bool $bootstrapped = FALSE;
 
   /**
    * Drupal core object.
@@ -28,12 +28,12 @@ class DrupalDriver implements DrupalDriverInterface {
   /**
    * System path to the Drupal installation.
    */
-  private readonly string $drupalRoot;
+  protected readonly string $drupalRoot;
 
   /**
    * URI for the Drupal installation.
    */
-  private readonly string $uri;
+  protected readonly string $uri;
 
   /**
    * Drupal core version.
@@ -86,55 +86,8 @@ class DrupalDriver implements DrupalDriverInterface {
   /**
    * {@inheritdoc}
    */
-  public function userCreate(\stdClass $user): void {
-    $this->getCore()->userCreate($user);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function userDelete(\stdClass $user): void {
-    $this->getCore()->userDelete($user);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function processBatch(): void {
     $this->getCore()->processBatch();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function userAddRole(\stdClass $user, string $role): void {
-    $this->getCore()->userAddRole($user, $role);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function watchdogFetch(int $count = 10, ?string $type = NULL, ?string $severity = NULL): string {
-    return $this->getCore()->watchdogFetch($count, $type, $severity);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function cacheClear(?string $type = NULL): void {
-    $this->getCore()->cacheClear($type);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getSubDriverPaths(): array {
-    // Ensure system is bootstrapped.
-    if (!$this->isBootstrapped()) {
-      $this->bootstrap();
-    }
-
-    return $this->getCore()->getExtensionPathList();
   }
 
   /**
@@ -150,48 +103,6 @@ class DrupalDriver implements DrupalDriverInterface {
    */
   public function getDrupalVersion(): int {
     return $this->version;
-  }
-
-  /**
-   * Detects the major Drupal version from the filesystem.
-   *
-   * @return int
-   *   The actual major version number (10, 11, 12, etc.).
-   */
-  protected function detectMajorVersion(): int {
-    $version_files = [
-      '/autoload.php',
-      '/core/includes/bootstrap.inc',
-    ];
-
-    foreach ($version_files as $path) {
-      if (file_exists($this->drupalRoot . $path)) {
-        require_once $this->drupalRoot . $path;
-      }
-    }
-
-    $version_string = $this->readVersionConstant();
-    $major = explode('.', $version_string)[0];
-
-    if (!is_numeric($major)) {
-      throw new BootstrapException(sprintf('Unable to extract major Drupal core version from version string %s.', $version_string));
-    }
-
-    if ((int) $major < 10) {
-      throw new BootstrapException(sprintf('Unsupported Drupal core version %s. Drupal 10 or higher is required.', $version_string));
-    }
-
-    return (int) $major;
-  }
-
-  /**
-   * Reads the Drupal VERSION constant.
-   *
-   * Subclasses override this to return a synthetic version for testing the
-   * non-numeric and sub-10 branches of 'detectMajorVersion()'.
-   */
-  protected function readVersionConstant(): string {
-    return \Drupal::VERSION;
   }
 
   /**
@@ -244,6 +155,75 @@ class DrupalDriver implements DrupalDriverInterface {
   /**
    * {@inheritdoc}
    */
+  public function getSubDriverPaths(): array {
+    // Ensure system is bootstrapped.
+    if (!$this->isBootstrapped()) {
+      $this->bootstrap();
+    }
+
+    return $this->getCore()->getExtensionPathList();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function login(\stdClass $user): void {
+    $auth = $this->getAuthCore();
+
+    if ($auth instanceof AuthenticationCapabilityInterface) {
+      $auth->login($user);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function logout(): void {
+    $auth = $this->getAuthCore();
+
+    if ($auth instanceof AuthenticationCapabilityInterface) {
+      $auth->logout();
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function cacheClear(?string $type = NULL): void {
+    $this->getCore()->cacheClear($type);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function cacheClearStatic(): void {
+    $this->getCore()->cacheClearStatic();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function configGet(string $name, string $key = ''): mixed {
+    return $this->getCore()->configGet($name, $key);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function configGetOriginal(string $name, string $key = ''): mixed {
+    return $this->getCore()->configGetOriginal($name, $key);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function configSet(string $name, string $key, mixed $value): void {
+    $this->getCore()->configSet($name, $key, $value);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function nodeCreate(\stdClass $node): object {
     return $this->getCore()->nodeCreate($node);
   }
@@ -253,13 +233,6 @@ class DrupalDriver implements DrupalDriverInterface {
    */
   public function nodeDelete(object $node): void {
     $this->getCore()->nodeDelete($node);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function cronRun(): bool {
-    return $this->getCore()->cronRun();
   }
 
   /**
@@ -279,15 +252,22 @@ class DrupalDriver implements DrupalDriverInterface {
   /**
    * {@inheritdoc}
    */
-  public function roleCreate(array $permissions): string {
-    return $this->getCore()->roleCreate($permissions);
+  public function entityCreate(string $entity_type, \stdClass $entity): object {
+    return $this->getCore()->entityCreate($entity_type, $entity);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function roleDelete(string $role_name): void {
-    $this->getCore()->roleDelete($role_name);
+  public function entityDelete(string $entity_type, object $entity): void {
+    $this->getCore()->entityDelete($entity_type, $entity);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function cronRun(): bool {
+    return $this->getCore()->cronRun();
   }
 
   /**
@@ -316,48 +296,6 @@ class DrupalDriver implements DrupalDriverInterface {
    */
   public function languageDelete(\stdClass $language): void {
     $this->getCore()->languageDelete($language);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function configGet(string $name, string $key = ''): mixed {
-    return $this->getCore()->configGet($name, $key);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function configGetOriginal(string $name, string $key = ''): mixed {
-    return $this->getCore()->configGetOriginal($name, $key);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function configSet(string $name, string $key, mixed $value): void {
-    $this->getCore()->configSet($name, $key, $value);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function cacheClearStatic(): void {
-    $this->getCore()->cacheClearStatic();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function entityCreate(string $entity_type, \stdClass $entity): object {
-    return $this->getCore()->entityCreate($entity_type, $entity);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function entityDelete(string $entity_type, object $entity): void {
-    $this->getCore()->entityDelete($entity_type, $entity);
   }
 
   /**
@@ -412,23 +350,85 @@ class DrupalDriver implements DrupalDriverInterface {
   /**
    * {@inheritdoc}
    */
-  public function login(\stdClass $user): void {
-    $auth = $this->getAuthCore();
-
-    if ($auth instanceof AuthenticationCapabilityInterface) {
-      $auth->login($user);
-    }
+  public function roleCreate(array $permissions): string {
+    return $this->getCore()->roleCreate($permissions);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function logout(): void {
-    $auth = $this->getAuthCore();
+  public function roleDelete(string $role_name): void {
+    $this->getCore()->roleDelete($role_name);
+  }
 
-    if ($auth instanceof AuthenticationCapabilityInterface) {
-      $auth->logout();
+  /**
+   * {@inheritdoc}
+   */
+  public function userCreate(\stdClass $user): void {
+    $this->getCore()->userCreate($user);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function userDelete(\stdClass $user): void {
+    $this->getCore()->userDelete($user);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function userAddRole(\stdClass $user, string $role): void {
+    $this->getCore()->userAddRole($user, $role);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function watchdogFetch(int $count = 10, ?string $type = NULL, ?string $severity = NULL): string {
+    return $this->getCore()->watchdogFetch($count, $type, $severity);
+  }
+
+  /**
+   * Detects the major Drupal version from the filesystem.
+   *
+   * @return int
+   *   The actual major version number (10, 11, 12, etc.).
+   */
+  protected function detectMajorVersion(): int {
+    $version_files = [
+      '/autoload.php',
+      '/core/includes/bootstrap.inc',
+    ];
+
+    foreach ($version_files as $path) {
+      if (file_exists($this->drupalRoot . $path)) {
+        require_once $this->drupalRoot . $path;
+      }
     }
+
+    $version_string = $this->readVersionConstant();
+    $major = explode('.', $version_string)[0];
+
+    if (!is_numeric($major)) {
+      throw new BootstrapException(sprintf('Unable to extract major Drupal core version from version string %s.', $version_string));
+    }
+
+    if ((int) $major < 10) {
+      throw new BootstrapException(sprintf('Unsupported Drupal core version %s. Drupal 10 or higher is required.', $version_string));
+    }
+
+    return (int) $major;
+  }
+
+  /**
+   * Reads the Drupal VERSION constant.
+   *
+   * Subclasses override this to return a synthetic version for testing the
+   * non-numeric and sub-10 branches of 'detectMajorVersion()'.
+   */
+  protected function readVersionConstant(): string {
+    return \Drupal::VERSION;
   }
 
   /**

--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -33,17 +33,17 @@ class DrushDriver implements DrushDriverInterface {
   /**
    * Track bootstrapping.
    */
-  private bool $bootstrapped = FALSE;
+  protected bool $bootstrapped = FALSE;
 
   /**
    * Random generator.
    */
-  private readonly Random $random;
+  protected readonly Random $random;
 
   /**
    * Global arguments or options for drush commands.
    */
-  private string $arguments = '';
+  protected string $arguments = '';
 
   /**
    * Tracks legacy drush.
@@ -95,31 +95,6 @@ class DrushDriver implements DrushDriverInterface {
   }
 
   /**
-   * Resolves the project-level Drush binary path.
-   *
-   * @param string $fallback
-   *   The fallback binary path if project-level Drush is not found.
-   *
-   * @return string
-   *   The resolved binary path.
-   */
-  protected function resolveProjectDrush(string $fallback): string {
-    // Try Composer's runtime bin directory.
-    $composer_bin = getenv('COMPOSER_BIN_DIR');
-    if ($composer_bin && file_exists($composer_bin . '/drush')) {
-      return $composer_bin . '/drush';
-    }
-
-    // Try common vendor/bin location relative to working directory.
-    $cwd = getcwd();
-    if ($cwd && file_exists($cwd . '/vendor/bin/drush')) {
-      return $cwd . '/vendor/bin/drush';
-    }
-
-    return $fallback;
-  }
-
-  /**
    * {@inheritdoc}
    */
   public function getRandom(): Random {
@@ -138,29 +113,6 @@ class DrushDriver implements DrushDriverInterface {
   }
 
   /**
-   * Determine if drush is a legacy version.
-   *
-   * @return bool
-   *   Returns TRUE if drush is older than drush 9.
-   */
-  protected function isLegacyDrush(): bool {
-    try {
-      // Try for a drush 9 version.
-      $output = trim($this->drush('version', [], ['format' => 'string']));
-      // On PHP 8.4, deprecation warnings from Drush dependencies may be
-      // written to stdout before the version string. Extract the actual
-      // version number from the output to avoid misdetection.
-      $version = preg_match('/(\d+\.\d+\.\d+(\.\d+)?)\s*$/', $output, $matches) ? $matches[1] : $output;
-      return version_compare($version, '9', '<=');
-    }
-    catch (\RuntimeException) {
-      // The version of drush is old enough that only `--version` was available,
-      // so this is a legacy version.
-      return TRUE;
-    }
-  }
-
-  /**
    * {@inheritdoc}
    */
   public function isBootstrapped(): bool {
@@ -170,98 +122,9 @@ class DrushDriver implements DrushDriverInterface {
   /**
    * {@inheritdoc}
    */
-  public function userCreate(\stdClass $user): void {
-    $arguments = [
-      sprintf('"%s"', $user->name),
-    ];
-    $options = [
-      'password' => $user->pass,
-      'mail' => $user->mail,
-    ];
-    $result = $this->drush('user-create', $arguments, $options);
-    if ($uid = $this->parseUserId($result)) {
-      $user->uid = $uid;
-    }
-    if (isset($user->roles) && is_array($user->roles)) {
-      foreach ($user->roles as $role) {
-        $this->userAddRole($user, $role);
-      }
-    }
-  }
-
-  /**
-   * Parse user id from drush user-information output.
-   *
-   * Supports both the legacy key-value format ("User ID : 123") and the
-   * Drush 12+ table format where the ID is the first numeric value in the
-   * data row.
-   */
-  protected function parseUserId(string $info): ?int {
-    // Legacy format: "User ID : 123".
-    if (preg_match('/User ID\s+:\s+(\d+)/', $info, $matches)) {
-      return (int) $matches[1];
-    }
-
-    // Drush 12+ table format: extract the first numeric value from the first
-    // data row (the row after the header separator).
-    if (preg_match('/User ID/', $info)) {
-      $lines = explode("\n", trim($info));
-      foreach ($lines as $line) {
-        // Skip header, separator, and empty lines.
-        $trimmed = trim($line, " \t\n\r\0\x0B-");
-        if ($trimmed === '') {
-          continue;
-        }
-        if (str_contains($trimmed, 'User ID')) {
-          continue;
-        }
-        // The first column in the data row is the User ID.
-        if (preg_match('/^\s*(\d+)\s/', $line, $matches)) {
-          return (int) $matches[1];
-        }
-      }
-    }
-    return NULL;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function userDelete(\stdClass $user): void {
-    $arguments = [sprintf('"%s"', $user->name)];
-    $options = [
-      'yes' => NULL,
-      'delete-content' => NULL,
-    ];
-    $this->drush('user-cancel', $arguments, $options);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function userAddRole(\stdClass $user, string $role): void {
-    $arguments = [
-      sprintf('"%s"', $role),
-      sprintf('"%s"', $user->name),
-    ];
-    $this->drush('user-add-role', $arguments);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function watchdogFetch(int $count = 10, ?string $type = NULL, ?string $severity = NULL): string {
-    // parseArguments() maps NULL values to bare --flag, so only include
-    // filters that have been explicitly set.
-    $options = ['count' => $count];
-    if ($type !== NULL) {
-      $options['type'] = $type;
-    }
-    if ($severity !== NULL) {
-      $options['severity'] = $severity;
-    }
-
-    return $this->drush('watchdog-show', [], $options);
+  public function processBatch(): void {
+    // Do nothing. Drush should internally handle any needs for processing
+    // batch ops.
   }
 
   /**
@@ -333,6 +196,28 @@ class DrushDriver implements DrushDriverInterface {
   /**
    * {@inheritdoc}
    */
+  public function cronRun(): bool {
+    $this->drush('cron');
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function moduleInstall(string $module_name): void {
+    $this->drush('pm-enable', [$module_name], ['yes' => NULL]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function moduleUninstall(string $module_name): void {
+    $this->drush('pm-uninstall', [$module_name], ['yes' => NULL]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function roleCreate(array $permissions): string {
     $random = $this->getRandom();
     $rid = strtolower($random->name(8, TRUE));
@@ -355,6 +240,68 @@ class DrushDriver implements DrushDriverInterface {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function userCreate(\stdClass $user): void {
+    $arguments = [
+      sprintf('"%s"', $user->name),
+    ];
+    $options = [
+      'password' => $user->pass,
+      'mail' => $user->mail,
+    ];
+    $result = $this->drush('user-create', $arguments, $options);
+    if ($uid = $this->parseUserId($result)) {
+      $user->uid = $uid;
+    }
+    if (isset($user->roles) && is_array($user->roles)) {
+      foreach ($user->roles as $role) {
+        $this->userAddRole($user, $role);
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function userDelete(\stdClass $user): void {
+    $arguments = [sprintf('"%s"', $user->name)];
+    $options = [
+      'yes' => NULL,
+      'delete-content' => NULL,
+    ];
+    $this->drush('user-cancel', $arguments, $options);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function userAddRole(\stdClass $user, string $role): void {
+    $arguments = [
+      sprintf('"%s"', $role),
+      sprintf('"%s"', $user->name),
+    ];
+    $this->drush('user-add-role', $arguments);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function watchdogFetch(int $count = 10, ?string $type = NULL, ?string $severity = NULL): string {
+    // parseArguments() maps NULL values to bare --flag, so only include
+    // filters that have been explicitly set.
+    $options = ['count' => $count];
+    if ($type !== NULL) {
+      $options['type'] = $type;
+    }
+    if ($severity !== NULL) {
+      $options['severity'] = $severity;
+    }
+
+    return $this->drush('watchdog-show', [], $options);
+  }
+
+  /**
    * Sets common drush arguments or options.
    *
    * @param string $arguments
@@ -369,29 +316,6 @@ class DrushDriver implements DrushDriverInterface {
    */
   public function getArguments(): string {
     return $this->arguments;
-  }
-
-  /**
-   * Parse arguments into a string.
-   *
-   * @param array<string, string|null> $arguments
-   *   An array of argument/option names to values.
-   *
-   * @return string
-   *   The parsed arguments.
-   */
-  protected static function parseArguments(array $arguments): string {
-    $option_string = '';
-
-    foreach ($arguments as $name => $value) {
-      if ($value === NULL) {
-        $option_string .= ' --' . $name;
-      }
-      else {
-        $option_string .= ' --' . $name . '=' . $value;
-      }
-    }
-    return $option_string;
   }
 
   /**
@@ -436,36 +360,6 @@ class DrushDriver implements DrushDriverInterface {
   }
 
   /**
-   * {@inheritdoc}
-   */
-  public function processBatch(): void {
-    // Do nothing. Drush should internally handle any needs for processing
-    // batch ops.
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function cronRun(): bool {
-    $this->drush('cron');
-    return TRUE;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function moduleInstall(string $module_name): void {
-    $this->drush('pm-enable', [$module_name], ['yes' => NULL]);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function moduleUninstall(string $module_name): void {
-    $this->drush('pm-uninstall', [$module_name], ['yes' => NULL]);
-  }
-
-  /**
    * Run Drush commands dynamically from a DrupalContext.
    *
    * @param string $name
@@ -478,6 +372,112 @@ class DrushDriver implements DrushDriverInterface {
    */
   public function __call(string $name, array $arguments): string {
     return $this->drush($name, $arguments);
+  }
+
+  /**
+   * Resolves the project-level Drush binary path.
+   *
+   * @param string $fallback
+   *   The fallback binary path if project-level Drush is not found.
+   *
+   * @return string
+   *   The resolved binary path.
+   */
+  protected function resolveProjectDrush(string $fallback): string {
+    // Try Composer's runtime bin directory.
+    $composer_bin = getenv('COMPOSER_BIN_DIR');
+    if ($composer_bin && file_exists($composer_bin . '/drush')) {
+      return $composer_bin . '/drush';
+    }
+
+    // Try common vendor/bin location relative to working directory.
+    $cwd = getcwd();
+    if ($cwd && file_exists($cwd . '/vendor/bin/drush')) {
+      return $cwd . '/vendor/bin/drush';
+    }
+
+    return $fallback;
+  }
+
+  /**
+   * Determine if drush is a legacy version.
+   *
+   * @return bool
+   *   Returns TRUE if drush is older than drush 9.
+   */
+  protected function isLegacyDrush(): bool {
+    try {
+      // Try for a drush 9 version.
+      $output = trim($this->drush('version', [], ['format' => 'string']));
+      // On PHP 8.4, deprecation warnings from Drush dependencies may be
+      // written to stdout before the version string. Extract the actual
+      // version number from the output to avoid misdetection.
+      $version = preg_match('/(\d+\.\d+\.\d+(\.\d+)?)\s*$/', $output, $matches) ? $matches[1] : $output;
+      return version_compare($version, '9', '<=');
+    }
+    catch (\RuntimeException) {
+      // The version of drush is old enough that only `--version` was available,
+      // so this is a legacy version.
+      return TRUE;
+    }
+  }
+
+  /**
+   * Parse user id from drush user-information output.
+   *
+   * Supports both the legacy key-value format ("User ID : 123") and the
+   * Drush 12+ table format where the ID is the first numeric value in the
+   * data row.
+   */
+  protected function parseUserId(string $info): ?int {
+    // Legacy format: "User ID : 123".
+    if (preg_match('/User ID\s+:\s+(\d+)/', $info, $matches)) {
+      return (int) $matches[1];
+    }
+
+    // Drush 12+ table format: extract the first numeric value from the first
+    // data row (the row after the header separator).
+    if (preg_match('/User ID/', $info)) {
+      $lines = explode("\n", trim($info));
+      foreach ($lines as $line) {
+        // Skip header, separator, and empty lines.
+        $trimmed = trim($line, " \t\n\r\0\x0B-");
+        if ($trimmed === '') {
+          continue;
+        }
+        if (str_contains($trimmed, 'User ID')) {
+          continue;
+        }
+        // The first column in the data row is the User ID.
+        if (preg_match('/^\s*(\d+)\s/', $line, $matches)) {
+          return (int) $matches[1];
+        }
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Parse arguments into a string.
+   *
+   * @param array<string, string|null> $arguments
+   *   An array of argument/option names to values.
+   *
+   * @return string
+   *   The parsed arguments.
+   */
+  protected static function parseArguments(array $arguments): string {
+    $option_string = '';
+
+    foreach ($arguments as $name => $value) {
+      if ($value === NULL) {
+        $option_string .= ' --' . $name;
+      }
+      else {
+        $option_string .= ' --' . $name . '=' . $value;
+      }
+    }
+    return $option_string;
   }
 
 }


### PR DESCRIPTION
## Summary

Reordered public methods in `DrupalDriver` and `DrushDriver` into a canonical capability-based layout that mirrors the alphabetical order of the `Drupal\Driver\Capability\*CapabilityInterface` namespace. Widened all `private` property declarations across `BlackboxDriver`, `DrupalDriver`, and `DrushDriver` to `protected` to allow subclassing. This is a pure structural change - no logic, signatures, or behaviour were altered.

The new layout makes it easy to see at a glance which capability group each method belongs to, and the consistent ordering across both drivers reduces cognitive friction when navigating between them.

## Changes

- **`DrupalDriver.php`** - Methods reordered into: lifecycle (`bootstrap`, `isBootstrapped`, `processBatch`, `getSubDriverPaths`), Authentication, Cache, Config, Content (nodes, terms, entities), Cron, Field, Language, Mail, Module, Role, User, Watchdog, then protected helpers (`detectMajorVersion`, `readVersionConstant`, `setCoreFromVersion`, `getCore`, `getAuthCore`). Properties `$bootstrapped`, `$drupalRoot`, and `$uri` widened from `private` to `protected`.
- **`DrushDriver.php`** - Methods reordered to match the same capability grouping: lifecycle, Cache, Config, Content, Cron, Module, Role, User, Watchdog, then public magic (`__call`), then protected helpers (`resolveProjectDrush`, `isLegacyDrush`, `parseUserId`, `parseArguments`, `drush`, `getArguments`, `setArguments`). Properties `$bootstrapped`, `$random`, and `$arguments` widened from `private` to `protected`.
- **`BlackboxDriver.php`** - Property `$random` widened from `private readonly` to `protected readonly`.

## Before / After

**DrupalDriver method order (simplified)**

```
BEFORE (historical accretion)           AFTER (canonical capability order)
────────────────────────────────────    ────────────────────────────────────
bootstrap()                             bootstrap()
isBootstrapped()                        isBootstrapped()
userCreate()          ← User            processBatch()
userDelete()          ← User            getSubDriverPaths()
processBatch()                          ├─ Authentication
userAddRole()         ← User            │  login()
watchdogFetch()       ← Watchdog        │  logout()
cacheClear()          ← Cache           ├─ Cache
getSubDriverPaths()                     │  cacheClear()
getVersion()          ← internal        │  cacheClearStatic()
detectMajorVersion()  ← helper          ├─ Config
readVersionConstant() ← helper          │  configGet()
setCoreFromVersion()  ← internal        │  configGetOriginal()
getCore()             ← internal        │  configSet()
getAuthCore()         ← internal        ├─ Content
nodeCreate()          ← Content         │  nodeCreate()
nodeDelete()          ← Content         │  nodeDelete()
cronRun()             ← Cron            │  termCreate()
termCreate()          ← Content         │  termDelete()
termDelete()          ← Content         │  entityCreate()
roleCreate()          ← Role            │  entityDelete()
roleDelete()          ← Role            ├─ Cron
fieldExists()         ← Field           │  cronRun()
fieldIsBase()         ← Field           ├─ Field
languageCreate()      ← Language        │  fieldExists()
languageDelete()      ← Language        │  fieldIsBase()
configGet()           ← Config          ├─ Language
configGetOriginal()   ← Config          │  languageCreate()
configSet()           ← Config          │  languageDelete()
cacheClearStatic()    ← Cache           ├─ Module
entityCreate()        ← Content         │  moduleInstall()
entityDelete()        ← Content         │  moduleUninstall()
moduleInstall()       ← Module          ├─ Role
moduleUninstall()     ← Module          │  roleCreate()
login()               ← Auth            │  roleDelete()
logout()              ← Auth            ├─ User
                                        │  userCreate()
                                        │  userDelete()
                                        │  userAddRole()
                                        ├─ Watchdog
                                        │  watchdogFetch()
                                        └─ helpers (protected)
                                           detectMajorVersion()
                                           readVersionConstant()
                                           setCoreFromVersion()
                                           getCore() / getAuthCore()
```

**DrushDriver** follows the same reordering pattern; protected helpers (`resolveProjectDrush`, `isLegacyDrush`, `parseUserId`, `parseArguments`) moved to the bottom after `__call`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal class hierarchies to improve extensibility for specialized implementations.
  * Reorganized method implementations within driver classes while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->