### PR TITLE
[#270] Fixed 'entityCreate()' base field expansion and dynamic id key resolution.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "drevops/phpcs-standard": "^0.7.0",
         "drupal/address": "^2.0.4",
         "drupal/coder": "~8.3.0",
+        "drupal/commerce": "^3.0",
         "drupal/core-composer-scaffold": "^10.5 || ^11.2",
         "drupal/core-dev": "^10.5 || ^11.2",
         "drupal/core-recommended": "^10.5 || ^11.2",

--- a/src/Drupal/Driver/Core/Core.php
+++ b/src/Drupal/Driver/Core/Core.php
@@ -823,6 +823,18 @@ class Core implements CoreInterface {
   public function entityDelete(string $entity_type, object $entity): void {
     if (!$entity instanceof EntityInterface) {
       $id_key = \Drupal::entityTypeManager()->getDefinition($entity_type)->getKey('id');
+
+      // Fail loudly if the stub does not carry the resolved id key. Without
+      // this guard a missing property would silently call storage->load(NULL)
+      // - the delete would appear to succeed while doing nothing.
+      if (!is_string($id_key) || !isset($entity->$id_key)) {
+        throw new \InvalidArgumentException(sprintf(
+          'Cannot delete an entity of type "%s" from a stub without the id key "%s" set.',
+          $entity_type,
+          (string) $id_key,
+        ));
+      }
+
       $entity = \Drupal::entityTypeManager()->getStorage($entity_type)->load($entity->$id_key);
     }
 

--- a/src/Drupal/Driver/Core/Core.php
+++ b/src/Drupal/Driver/Core/Core.php
@@ -146,6 +146,13 @@ class Core implements CoreInterface {
    *   defined fields.
    */
   protected function expandEntityFields(string $entity_type, \stdClass $entity, array $base_fields = []): void {
+    // Include any base fields present as properties on the entity object so
+    // their values travel through the field-handler pipeline alongside
+    // configured fields. Without this, base entity-reference fields such as
+    // 'commerce_product.variations' or 'user.roles' would never reach
+    // EntityReferenceHandler and could not be populated from a stub.
+    $base_fields = array_values(array_unique(array_merge($base_fields, $this->detectBaseFieldsOnEntity($entity_type, $entity))));
+
     $field_types = $this->getEntityFieldTypes($entity_type, $base_fields);
 
     foreach (array_keys($field_types) as $field_name) {
@@ -154,6 +161,42 @@ class Core implements CoreInterface {
           ->expand($entity->$field_name);
       }
     }
+  }
+
+  /**
+   * Returns the names of base fields set as properties on the entity.
+   *
+   * The entity type's id key and bundle key are excluded: they identify the
+   * record itself and must not pass through the field-handler pipeline, where
+   * they would be treated as look-up values (e.g. expanding node's 'type'
+   * through EntityReferenceHandler would try to resolve the bundle string as
+   * a NodeType config entity reference and discard the plain string form).
+   *
+   * @param string $entity_type
+   *   The entity type ID.
+   * @param \stdClass $entity
+   *   Entity stub whose properties are inspected.
+   *
+   * @return array<string>
+   *   Base field names whose corresponding property is set on the stub.
+   */
+  protected function detectBaseFieldsOnEntity(string $entity_type, \stdClass $entity): array {
+    $definition = \Drupal::entityTypeManager()->getDefinition($entity_type);
+    $skip = array_filter([$definition->getKey('id'), $definition->getKey('bundle')]);
+
+    $detected = [];
+
+    foreach (array_keys($this->getEntityFieldManager()->getBaseFieldDefinitions($entity_type)) as $field_name) {
+      if (in_array($field_name, $skip, TRUE)) {
+        continue;
+      }
+
+      if (property_exists($entity, $field_name)) {
+        $detected[] = $field_name;
+      }
+    }
+
+    return $detected;
   }
 
   /**
@@ -742,9 +785,11 @@ class Core implements CoreInterface {
       throw new \InvalidArgumentException('You must specify an entity type to create an entity.');
     }
 
-    // If the bundle field is empty, put the inferred bundle value in it.
-    $bundle_key = \Drupal::entityTypeManager()->getDefinition($entity_type)->getKey('bundle');
+    $definition = \Drupal::entityTypeManager()->getDefinition($entity_type);
+    $bundle_key = $definition->getKey('bundle');
+    $id_key = $definition->getKey('id');
 
+    // If the bundle field is empty, put the inferred bundle value in it.
     if (!isset($entity->$bundle_key) && isset($entity->step_bundle)) {
       $entity->$bundle_key = $entity->step_bundle;
     }
@@ -764,8 +809,10 @@ class Core implements CoreInterface {
     $created_entity = \Drupal::entityTypeManager()->getStorage($entity_type)->create((array) $entity);
     $created_entity->save();
 
-    // Mutate the stub so callers holding the reference can still read ->id.
-    $entity->id = $created_entity->id();
+    // Mutate the stub under the entity type's own id key ('uid' for user,
+    // 'nid' for node, 'tid' for term, 'id' for entity_test and others), so
+    // callers can round-trip it back through entityDelete().
+    $entity->$id_key = $created_entity->id();
 
     return $created_entity;
   }
@@ -774,7 +821,10 @@ class Core implements CoreInterface {
    * {@inheritdoc}
    */
   public function entityDelete(string $entity_type, object $entity): void {
-    $entity = $entity instanceof EntityInterface ? $entity : \Drupal::entityTypeManager()->getStorage($entity_type)->load($entity->id);
+    if (!$entity instanceof EntityInterface) {
+      $id_key = \Drupal::entityTypeManager()->getDefinition($entity_type)->getKey('id');
+      $entity = \Drupal::entityTypeManager()->getStorage($entity_type)->load($entity->$id_key);
+    }
 
     if ($entity instanceof EntityInterface) {
       $entity->delete();

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreEntityCreateCommerceKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreEntityCreateCommerceKernelTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\Driver\Kernel\Core;
+
+use Drupal\commerce_product\Entity\Product;
+use Drupal\commerce_store\Entity\Store;
+use Drupal\Driver\Core\Core;
+use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Kernel test exercising 'entityCreate()' on a 'commerce_product' stub.
+ *
+ * This is the canonical scenario from #270: a stub sets
+ * 'commerce_product.variations' - a BASE entity_reference field targeting
+ * 'commerce_product_variation' - and expects the driver to resolve each
+ * referenced variation and attach it to the product on save. Without the
+ * base-field auto-detection in 'expandEntityFields()', variations are
+ * filtered out of the field-handler pipeline, reach entity storage in raw
+ * scalar form, and the product is saved with no variations attached.
+ *
+ * The test dogfoods the driver end-to-end: both the variation and the
+ * product are created via 'Core::entityCreate()', then the product is
+ * loaded back via the entity type manager to assert the resolved
+ * relationship.
+ *
+ * @group core
+ */
+#[Group('core')]
+class CoreEntityCreateCommerceKernelTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   *
+   * @var array<string>
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'filter',
+    'options',
+    'views',
+    'path',
+    'path_alias',
+    'address',
+    'datetime',
+    'entity',
+    'inline_entity_form',
+    'state_machine',
+    'commerce',
+    'commerce_price',
+    'commerce_store',
+    'commerce_product',
+  ];
+
+  /**
+   * The Core driver under test.
+   */
+  protected Core $core;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('path_alias');
+    $this->installEntitySchema('commerce_currency');
+    $this->installEntitySchema('commerce_store');
+    $this->installEntitySchema('commerce_product_variation');
+    $this->installEntitySchema('commerce_product');
+    $this->installConfig(['system', 'user', 'filter', 'commerce_store', 'commerce_product']);
+
+    // Import USD so the price-backed product variation type can resolve
+    // its currency; required even when the stub does not set a price.
+    $this->container->get('commerce_price.currency_importer')->import('USD');
+
+    // Create a default store so products have a resolvable owner context.
+    Store::create([
+      'type' => 'online',
+      'name' => 'Default',
+      'mail' => 'admin@example.com',
+      'default_currency' => 'USD',
+      'address' => ['country_code' => 'US'],
+    ])->save();
+
+    $this->core = new Core($this->root);
+  }
+
+  /**
+   * Tests 'entityCreate()' resolves 'commerce_product.variations'.
+   */
+  public function testEntityCreateExpandsProductVariationsBaseField(): void {
+    $variation_stub = (object) [
+      'type' => 'default',
+      'sku' => 'SKU-001',
+      'title' => 'Test variation',
+    ];
+    $this->core->entityCreate('commerce_product_variation', $variation_stub);
+
+    $this->assertNotEmpty(
+      $variation_stub->variation_id,
+      'entityCreate populated commerce_product_variation.variation_id on the stub.',
+    );
+
+    $product_stub = (object) [
+      'type' => 'default',
+      'title' => 'Test product',
+      'variations' => [$variation_stub->variation_id],
+    ];
+    $this->core->entityCreate('commerce_product', $product_stub);
+
+    $this->assertNotEmpty(
+      $product_stub->product_id,
+      'entityCreate populated commerce_product.product_id on the stub.',
+    );
+
+    $product = Product::load((int) $product_stub->product_id);
+    $this->assertInstanceOf(Product::class, $product);
+
+    $variation_ids = array_map(intval(...), $product->getVariationIds());
+    $this->assertContains(
+      (int) $variation_stub->variation_id,
+      $variation_ids,
+      'product.variations base entity_reference resolved to the variation id.',
+    );
+  }
+
+}

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreEntityMethodsKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreEntityMethodsKernelTest.php
@@ -101,6 +101,16 @@ class CoreEntityMethodsKernelTest extends KernelTestBase {
   }
 
   /**
+   * Tests 'entityDelete()' rejects a stub missing the resolved id key.
+   */
+  public function testEntityDeleteRejectsStubMissingIdKey(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/stub without the id key "uid" set/');
+
+    $this->core->entityDelete('user', (object) ['name' => 'missing-uid']);
+  }
+
+  /**
    * Tests base entity-reference fields round-trip through entityCreate().
    *
    * 'user.roles' is a base entity_reference field targeting the user_role

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreEntityMethodsKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreEntityMethodsKernelTest.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Driver\Core\Core;
 use Drupal\entity_test\EntityTestHelper;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -97,6 +98,35 @@ class CoreEntityMethodsKernelTest extends KernelTestBase {
     $this->core->entityCreate('user', $stub);
 
     $this->assertSame(['uma'], $stub->name, 'base field "name" was routed through the handler pipeline.');
+  }
+
+  /**
+   * Tests base entity-reference fields round-trip through entityCreate().
+   *
+   * 'user.roles' is a base entity_reference field targeting the user_role
+   * config entity type - structurally the same scenario that motivated the
+   * fix (a stub sets a base entity-reference field by label/id and expects
+   * the driver to resolve and attach it). Before the fix, base entity-ref
+   * fields set on a stub were filtered out of the handler pipeline and
+   * never reached EntityReferenceHandler, so the reference was silently
+   * dropped. This test pins the end-to-end round-trip: stub -> driver ->
+   * storage -> reload -> assertion.
+   */
+  public function testEntityCreateExpandsBaseEntityReferenceFieldOnStub(): void {
+    Role::create(['id' => 'editor', 'label' => 'Editor'])->save();
+
+    $stub = (object) [
+      'name' => 'vic',
+      'mail' => 'vic@example.com',
+      'status' => 1,
+      'roles' => ['editor'],
+    ];
+
+    $this->core->entityCreate('user', $stub);
+
+    $account = User::load((int) $stub->uid);
+    $this->assertInstanceOf(User::class, $account);
+    $this->assertContains('editor', $account->getRoles(), 'entityCreate routed user.roles through EntityReferenceHandler for base-field expansion.');
   }
 
   /**

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreEntityMethodsKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreEntityMethodsKernelTest.php
@@ -49,6 +49,12 @@ class CoreEntityMethodsKernelTest extends KernelTestBase {
 
   /**
    * Tests 'entityCreate()' followed by 'entityDelete()' using a stub object.
+   *
+   * The user entity type's id key is 'uid', so entityCreate should populate
+   * the stub under 'uid' (not the generic 'id' property), and entityDelete
+   * should load by that same key. This matches the convention already used
+   * by nodeCreate/nodeDelete (nid), userCreate (uid), and termCreate/
+   * termDelete (tid).
    */
   public function testEntityCreateAndDeleteWithStub(): void {
     $stub = (object) [
@@ -60,13 +66,37 @@ class CoreEntityMethodsKernelTest extends KernelTestBase {
     $created = $this->core->entityCreate('user', $stub);
 
     $this->assertInstanceOf(EntityInterface::class, $created);
-    $this->assertNotEmpty($stub->id, 'entityCreate set the id on the stub.');
+    $this->assertNotEmpty($stub->uid, 'entityCreate populated the entity type id key (uid) on the stub.');
+    $this->assertFalse(property_exists($stub, 'id'), 'entityCreate did not populate a generic "id" property on the stub.');
 
     // Delete via the stub, which triggers the load-by-id branch of
-    // entityDelete().
+    // entityDelete() resolved against the entity type id key.
     $this->core->entityDelete('user', $stub);
 
-    $this->assertNull(User::load((int) $stub->id));
+    $this->assertNull(User::load((int) $stub->uid));
+  }
+
+  /**
+   * Tests 'entityCreate()' auto-expands base fields set on the stub.
+   *
+   * 'name' is a base field on the user entity type. Base fields are not
+   * registered field storage configs, so without auto-detection the field
+   * handler pipeline would skip them and values like entity references on
+   * a base field (e.g. 'commerce_product.variations', 'user.roles') would
+   * reach entity storage in their raw scalar form. With auto-detection,
+   * DefaultHandler wraps the scalar value into the array form expected by
+   * the field API - observable here by inspecting the stub after create.
+   */
+  public function testEntityCreateAutoExpandsBaseFieldsSetOnStub(): void {
+    $stub = (object) [
+      'name' => 'uma',
+      'mail' => 'uma@example.com',
+      'status' => 1,
+    ];
+
+    $this->core->entityCreate('user', $stub);
+
+    $this->assertSame(['uma'], $stub->name, 'base field "name" was routed through the handler pipeline.');
   }
 
   /**


### PR DESCRIPTION
> Iterates on #271 by @chrisolof. Thank you for the contribution!

Closes #270

## Summary

Fixes two bugs in the generic `entityCreate()` / `entityDelete()` pipeline that blocked setting base entity-reference fields on entity stubs (e.g. `commerce_product.variations`, `user.roles`) and caused stub-based round-trips to fail for any entity type whose id key isn't literally `id`.

1. `expandEntityFields()` previously only processed configured fields (`FieldStorageConfig`); base fields were filtered out unless the caller explicitly passed them in `$base_fields`. `entityCreate()` never did, so base entity-reference fields set on the stub reached entity storage in their raw scalar form and failed to resolve targets by label. The method now auto-detects base fields present as properties on the stub (excluding the id and bundle keys, which are system-managed) and routes them through the field-handler pipeline alongside configured fields.

2. `entityCreate()` populated `$entity->id` and `entityDelete()` loaded from `$entity->id`, hardcoding the generic property name. For entity types whose id key isn't `id` (`user` → `uid`, `node` → `nid`, `taxonomy_term` → `tid`, plus most commerce and custom types), this broke stub-based round-trips and was inconsistent with `nodeCreate`/`userCreate`/`termCreate`, which already populate the proper id key. Both methods now resolve the id key via `$definition->getKey('id')` and use it consistently.

**v3.x behaviour change**: `entityCreate()` now populates `$entity->$id_key` (e.g. `$stub->uid` for user entities) instead of `$entity->id`. Consumers that read `$entity->id` after `entityCreate()` must switch to `$entity->$id_key` or read from the returned `EntityInterface`.

## Changes

### `src/Drupal/Driver/Core/Core.php`

- `expandEntityFields()`: merges explicitly passed `$base_fields` with a new auto-detected set before calling `getEntityFieldTypes()`.
- New protected `detectBaseFieldsOnEntity()`: walks `EntityFieldManager::getBaseFieldDefinitions()` and returns the base field names that exist as properties on the stub, excluding the entity type's id key and bundle key.
- `entityCreate()`: looks up the entity type definition once, resolves `$bundle_key` and `$id_key` from it, and populates `$entity->$id_key = $created_entity->id()` after save. The bundle-validation guard and `step_bundle` promotion are unchanged.
- `entityDelete()`: when a stub is passed (rather than a loaded `EntityInterface`), resolves the id key the same way and loads via `$entity->$id_key`.

### `tests/Drupal/Tests/Driver/Kernel/Core/CoreEntityMethodsKernelTest.php`

- `testEntityCreateAndDeleteWithStub`: asserts `$stub->uid` is populated and `$stub->id` is NOT, and uses `$stub->uid` for the round-trip `entityDelete()`.
- New `testEntityCreateAutoExpandsBaseFieldsSetOnStub`: calls `entityCreate('user', $stub)` with a plain scalar `name`, then asserts `$stub->name === ['uma']` — proving `DefaultHandler::expand()` ran on the base field.

## Before / After

```
expandEntityFields(entity_type, entity):

Before:
  base_fields = caller-supplied only
  getEntityFieldTypes(type, base_fields)
    -> returns configured FieldStorageConfig entries
       + any base fields the caller named explicitly

  Stub has $entity->variations = ['sku-1', 'sku-2']
  commerce_product.variations is a BASE entity_reference field
  -> not in caller-supplied base_fields
  -> filtered out in getEntityFieldTypes
  -> EntityReferenceHandler NEVER called
  -> Drupal storage receives ['sku-1', 'sku-2'] (raw labels)
  -> save fails / silently drops

After:
  auto = detectBaseFieldsOnEntity(type, entity)   <-- NEW
       = base fields present on the stub, minus id/bundle keys
  base_fields = unique(caller-supplied + auto)
  getEntityFieldTypes(type, base_fields)
    -> now includes 'variations'
  -> EntityReferenceHandler resolves each label to a target id
  -> storage receives the shape it expects
```

```
entityCreate() / entityDelete() id-key resolution:

Before:                              After:
  $created->save();                    $id_key = $definition->getKey('id');
  $entity->id = $created->id();        ...
                                       $created->save();
                                       $entity->$id_key = $created->id();
  entityDelete():                      entityDelete():
    $storage->load($entity->id)          $storage->load($entity->$id_key)

  user stub:                           user stub:
    { name, mail, status }               { name, mail, status }
  after create: ->id = 42              after create: ->uid = 42
  delete: load(user, 42) via ->id      delete: load(user, 42) via ->uid
  (works only because we set ->id)     (works using the entity's real id key)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Entity create/delete now respect entity-type identifier keys (e.g., uid) instead of assuming a generic id.
  * Base fields set on stubs (including base entity-reference fields and product-variation references) are automatically expanded and routed through the field pipeline.

* **Tests**
  * Added kernel tests validating stub expansion, entity-reference behavior, and commerce product/variation creation.

* **Chores**
  * Added a development dependency to enable commerce-related tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->