### PR TITLE
Fixed 'EntityReferenceHandler::expand()' to preserve extra item properties on associative-array deltas.

### DIFF
--- a/src/Drupal/Driver/Core/Field/EntityReferenceHandler.php
+++ b/src/Drupal/Driver/Core/Field/EntityReferenceHandler.php
@@ -19,30 +19,40 @@ class EntityReferenceHandler extends AbstractHandler {
 
     // User entities return FALSE for getKey('label'), so use 'name' directly.
     $label_key = $entity_type_id !== 'user' ? $entity_definition->getKey('label') : 'name';
+    $main_property = $this->fieldInfo->getMainPropertyName();
 
     // Determine target bundle restrictions.
     $target_bundles = $this->getTargetBundles();
     $target_bundle_key = $target_bundles ? $entity_definition->getKey('bundle') : NULL;
 
-    $ids = [];
+    $resolved = [];
 
     foreach ((array) $values as $value) {
+      // A delta may be a scalar (label or id) OR an associative array carrying
+      // the main property plus additional item columns (e.g. 'display' on file
+      // references or 'target_revision_id' on entity_reference_revisions).
+      // When the main property is present, use its value as the lookup label
+      // and preserve the rest of the array so those extras round-trip through
+      // to storage.
+      $has_extras = is_string($main_property) && is_array($value) && array_key_exists($main_property, $value);
+      $lookup = $has_extras ? $value[$main_property] : $value;
+
       $query = \Drupal::entityQuery($entity_type_id);
       $query->accessCheck(FALSE);
 
       if ($label_key) {
-        $is_numeric_id = is_int($value) || (is_string($value) && ctype_digit($value));
+        $is_numeric_id = is_int($lookup) || (is_string($lookup) && ctype_digit($lookup));
         $or = $query->orConditionGroup();
 
         if ($is_numeric_id) {
-          $or->condition($id_key, (int) $value);
+          $or->condition($id_key, (int) $lookup);
         }
 
-        $or->condition($label_key, $value);
+        $or->condition($label_key, $lookup);
         $query->condition($or);
       }
       else {
-        $query->condition($id_key, $value);
+        $query->condition($id_key, $lookup);
       }
 
       if ($target_bundles && $target_bundle_key) {
@@ -52,13 +62,21 @@ class EntityReferenceHandler extends AbstractHandler {
       $entities = $query->execute();
 
       if (!$entities) {
-        throw new \Exception(sprintf("No entity '%s' of type '%s' exists.", $value, $entity_type_id));
+        throw new \Exception(sprintf("No entity '%s' of type '%s' exists.", $lookup, $entity_type_id));
       }
 
-      $ids[] = array_shift($entities);
+      $resolved_id = array_shift($entities);
+
+      if ($has_extras) {
+        $value[$main_property] = $resolved_id;
+        $resolved[] = $value;
+      }
+      else {
+        $resolved[] = $resolved_id;
+      }
     }
 
-    return $ids;
+    return $resolved;
   }
 
   /**

--- a/tests/Drupal/Tests/Driver/Kernel/Core/Field/EntityReferenceHandlerKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/Field/EntityReferenceHandlerKernelTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\Driver\Kernel\Core\Field;
 
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\user\Entity\User;
@@ -70,6 +72,55 @@ class EntityReferenceHandlerKernelTest extends FieldHandlerKernelTestBase {
     $user->save();
 
     $this->assertFieldRoundTripViaDriver('field_owner', [(int) $user->id()]);
+  }
+
+  /**
+   * Tests round-trip when a delta is an associative array.
+   *
+   * Callers passing the field-item shape used by file / image /
+   * entity_reference_revisions values - e.g. '['target_id' => 'alice',
+   * 'display' => 1]' - previously crashed because the array was handed to
+   * 'query->condition()' directly, producing a SQL parameter-binding error.
+   * The handler should treat the main property value as the lookup label,
+   * resolve it to an id, and preserve the original array shape so any extra
+   * item properties round-trip through to storage.
+   */
+  public function testUserReferenceResolvesAssociativeArrayDelta(): void {
+    $this->attachField('field_owner', 'entity_reference', [
+      'target_type' => 'user',
+    ]);
+
+    User::create(['name' => 'alice'])->save();
+
+    $this->assertFieldRoundTripViaDriver('field_owner', [['target_id' => 'alice']]);
+  }
+
+  /**
+   * Tests round-trip when deltas mix scalar labels and associative arrays.
+   */
+  public function testUserReferenceResolvesMixedScalarAndAssociativeDeltas(): void {
+    // Needs an unlimited-cardinality field to store two deltas; attachField()
+    // always creates a single-value field, so configure the storage inline.
+    FieldStorageConfig::create([
+      'field_name' => 'field_owners',
+      'entity_type' => self::ENTITY_TYPE,
+      'type' => 'entity_reference',
+      'cardinality' => FieldStorageConfig::CARDINALITY_UNLIMITED,
+      'settings' => ['target_type' => 'user'],
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'field_owners',
+      'entity_type' => self::ENTITY_TYPE,
+      'bundle' => self::BUNDLE,
+    ])->save();
+
+    User::create(['name' => 'alice'])->save();
+    User::create(['name' => 'bob'])->save();
+
+    $this->assertFieldRoundTripViaDriver('field_owners', [
+      ['target_id' => 'alice'],
+      'bob',
+    ]);
   }
 
   /**


### PR DESCRIPTION
> Iterates on #252 by @idimopoulos. Thank you for the contribution!

## Summary

`EntityReferenceHandler::expand()` previously crashed with `Calling Drupal\Core\Database\Query\Condition::condition() without an array compatible operator is not supported` whenever a delta was an associative array - the shape callers emit for file fields (`['target_id' => 'alice', 'display' => 1]`), image fields (`target_id` + `alt` + `title`), or `entity_reference_revisions` (`target_id` + `target_revision_id`). The full array was handed to `query->condition()`, which now rejects arrays without an array-compatible operator.

The fix: when a delta is an associative array containing the field's main property, treat that property's value as the lookup label, resolve it to an entity id, and write the resolved id back into the array so the remaining item columns round-trip through to storage. Scalar deltas continue to use the existing numeric-id OR label branch, and entity types that return `FALSE` for `getKey('label')` still fall back to id-only lookup.

Proven via RED -> GREEN kernel tests on a real Drupal kernel: the new tests failed with the exact `InvalidQueryException` above before the fix and pass after.

## Changes

### `src/Drupal/Driver/Core/Field/EntityReferenceHandler.php`

- Resolve the field's main property name via `$this->fieldInfo->getMainPropertyName()`.
- Per delta: if the value is an associative array containing the main property, extract that property's value as the lookup label; otherwise use the scalar value as before.
- Preserve the existing numeric-id OR label lookup branch and the `label_key = FALSE` fallback for scalar values.
- On resolution: if the delta had extras, write the resolved id back into the array at the main property key and keep the other columns; otherwise emit just the resolved id as before.
- Use the lookup label (not the raw array) in the `No entity … exists` exception message.

### `tests/Drupal/Tests/Driver/Kernel/Core/Field/EntityReferenceHandlerKernelTest.php`

- New `testUserReferenceResolvesAssociativeArrayDelta`: attaches an `entity_reference` field targeting user, passes `[['target_id' => 'alice']]` as the delta, asserts the label resolves to the user's uid and round-trips through storage.
- New `testUserReferenceResolvesMixedScalarAndAssociativeDeltas`: configures an unlimited-cardinality `entity_reference` field inline (the shared `attachField()` helper only creates single-value fields), passes `[['target_id' => 'alice'], 'bob']` mixing associative and scalar deltas, asserts both deltas round-trip.
- Both tests failed with `InvalidQueryException: Calling … condition() without an array compatible operator is not supported` on current master before this change and pass after.

## Before / After

```
EntityReferenceHandler::expand() handling one delta:

Before (crashes on associative-array delta):
  $value = ['target_id' => 'alice', 'display' => 1]

  $or->condition($label_key, $value)      <-- $value is an array
                ^^^^^^^^^^^^^^^^^^^^
  Drupal\Core\Database\Query\Condition::condition():
    "without an array compatible operator is not supported"

After (splits main property from extras):
  $value  = ['target_id' => 'alice', 'display' => 1]
  $lookup = 'alice'                        <-- main_property = 'target_id'
  extras  = ['target_id' => <tbd>, 'display' => 1]

  $or->condition($label_key, 'alice')      <-- scalar, works
  $resolved_id = 42

  $value['target_id'] = 42
  -> ['target_id' => 42, 'display' => 1]   <-- extras preserved
```

```
Delta-by-delta shape preservation:

input (list of deltas)                  output
-----------------------------           -----------------------------
'alice'                                 42                        <-- scalar in, scalar out
['target_id' => 'alice']                ['target_id' => 42]       <-- array in, array out
['target_id' => 'alice', 'display' => 1]  ['target_id' => 42, 'display' => 1]
```
