### PR TITLE
[#202] Allowed explicit id and label on 'roleCreate()'.

### DIFF
--- a/src/Drupal/Driver/Capability/RoleCapabilityInterface.php
+++ b/src/Drupal/Driver/Capability/RoleCapabilityInterface.php
@@ -14,11 +14,18 @@ interface RoleCapabilityInterface {
    *
    * @param array<string> $permissions
    *   Permission machine names or labels.
+   * @param string|null $id
+   *   Optional role machine name. If omitted, a random lowercase id is
+   *   generated. Callers that need to reference the role by a known name
+   *   (e.g. in assertions against a configuration form) should pass this.
+   * @param string|null $label
+   *   Optional human-readable role label. Defaults to the id when omitted;
+   *   falls back to a random string only when both this and $id are NULL.
    *
    * @return string
    *   The created role's machine name.
    */
-  public function roleCreate(array $permissions): string;
+  public function roleCreate(array $permissions, ?string $id = NULL, ?string $label = NULL): string;
 
   /**
    * Deletes a role.

--- a/src/Drupal/Driver/Core/Core.php
+++ b/src/Drupal/Driver/Core/Core.php
@@ -404,16 +404,16 @@ class Core implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function roleCreate(array $permissions): string {
-    $rid = strtolower($this->random->name(8, TRUE));
-    $label = trim($this->random->name(8, TRUE));
+  public function roleCreate(array $permissions, ?string $id = NULL, ?string $label = NULL): string {
+    $rid = $id ?? strtolower($this->random->name(8, TRUE));
+    $role_label = $label ?? ($id ?? trim($this->random->name(8, TRUE)));
 
     $this->convertPermissions($permissions);
     $this->checkPermissions($permissions);
 
     $role = \Drupal::entityTypeManager()->getStorage('user_role')->create([
       'id' => $rid,
-      'label' => $label,
+      'label' => $role_label,
     ]);
     $role->save();
 

--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -357,8 +357,8 @@ class DrupalDriver implements DrupalDriverInterface {
   /**
    * {@inheritdoc}
    */
-  public function roleCreate(array $permissions): string {
-    return $this->getCore()->roleCreate($permissions);
+  public function roleCreate(array $permissions, ?string $id = NULL, ?string $label = NULL): string {
+    return $this->getCore()->roleCreate($permissions, $id, $label);
   }
 
   /**

--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -213,12 +213,12 @@ class DrushDriver implements DrushDriverInterface {
   /**
    * {@inheritdoc}
    */
-  public function roleCreate(array $permissions): string {
+  public function roleCreate(array $permissions, ?string $id = NULL, ?string $label = NULL): string {
     $random = $this->getRandom();
-    $rid = strtolower($random->name(8, TRUE));
-    $label = trim($random->name(8, TRUE));
+    $rid = $id ?? strtolower($random->name(8, TRUE));
+    $role_label = $label ?? ($id ?? trim($random->name(8, TRUE)));
 
-    $this->drush('role:create', [$rid, sprintf('"%s"', $label)], []);
+    $this->drush('role:create', [$rid, sprintf('"%s"', $role_label)], []);
 
     foreach ($permissions as $permission) {
       $this->drush('role:perm:add', [$rid, sprintf('"%s"', $permission)], []);

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreUserMethodsKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreUserMethodsKernelTest.php
@@ -132,4 +132,33 @@ class CoreUserMethodsKernelTest extends KernelTestBase {
     $this->core->roleCreate(['definitely not a real permission']);
   }
 
+  /**
+   * Tests 'roleCreate()' honours explicit id and label arguments.
+   *
+   * Without this path, scenarios that need to assert against a role by name
+   * (e.g. verifying it appears in a permissions admin form) have to scrape the
+   * random id out of the return value - which makes the assertion opaque.
+   */
+  public function testRoleCreateAcceptsExplicitIdAndLabel(): void {
+    $role_id = $this->core->roleCreate(['access user profiles'], 'editor', 'Editor');
+
+    $this->assertSame('editor', $role_id);
+    $role = Role::load('editor');
+    $this->assertInstanceOf(Role::class, $role);
+    $this->assertSame('Editor', $role->label());
+    $this->assertTrue($role->hasPermission('access user profiles'));
+  }
+
+  /**
+   * Tests 'roleCreate()' falls back to the id as label when only id is given.
+   */
+  public function testRoleCreateFallsBackToIdAsLabel(): void {
+    $role_id = $this->core->roleCreate([], 'content_editor');
+
+    $this->assertSame('content_editor', $role_id);
+    $role = Role::load('content_editor');
+    $this->assertInstanceOf(Role::class, $role);
+    $this->assertSame('content_editor', $role->label());
+  }
+
 }

--- a/tests/Drupal/Tests/Driver/Unit/Core/CoreFieldHandlerLookupTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/CoreFieldHandlerLookupTest.php
@@ -232,7 +232,7 @@ class Core99TestCore extends Core {
   /**
    * {@inheritdoc}
    */
-  public function roleCreate(array $permissions): string {
+  public function roleCreate(array $permissions, ?string $id = NULL, ?string $label = NULL): string {
     return '';
   }
 

--- a/tests/Drupal/Tests/Driver/Unit/DrupalDriverDelegationTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/DrupalDriverDelegationTest.php
@@ -170,6 +170,7 @@ class DrupalDriverDelegationTest extends TestCase {
     yield 'termCreate' => ['termCreate', [$term], 'termCreate'];
     yield 'termDelete' => ['termDelete', [$term], 'termDelete'];
     yield 'roleCreate' => ['roleCreate', [['admin']], 'roleCreate'];
+    yield 'roleCreate named' => ['roleCreate', [['admin'], 'editor', 'Editor'], 'roleCreate'];
     yield 'roleDelete' => ['roleDelete', ['editor'], 'roleDelete'];
     yield 'fieldExists' => ['fieldExists', ['node', 'title'], 'fieldExists'];
     yield 'fieldIsBase' => ['fieldIsBase', ['node', 'title'], 'fieldIsBase'];

--- a/tests/Drupal/Tests/Driver/Unit/DrushDriverMethodsTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/DrushDriverMethodsTest.php
@@ -382,6 +382,8 @@ class DrushDriverMethodsTest extends TestCase {
     yield 'configSet' => ['configSet', ['system.site', 'name', 'v'], 'config:set'];
     yield 'roleCreate no permissions' => ['roleCreate', [[]], 'role:create'];
     yield 'roleCreate with permissions' => ['roleCreate', [['access content']], 'role:create'];
+    yield 'roleCreate with explicit id' => ['roleCreate', [[], 'editor'], 'role:create'];
+    yield 'roleCreate with id and label' => ['roleCreate', [['access content'], 'editor', 'Editor'], 'role:create'];
     yield 'roleDelete' => ['roleDelete', ['editor'], 'role:delete'];
   }
 


### PR DESCRIPTION
## Summary

`roleCreate()` previously always generated a random machine id and label, which forced scenarios that assert against a role by name (for example, verifying a role shows up on a permissions admin form) to scrape the id out of the return value. This PR adds optional `$id` and `$label` parameters so callers can name roles explicitly while keeping full backward compatibility: calling with just `$permissions` still yields a random id + label as before.

Issue #202 has been open since 2018. The label fallback follows the principle that when only `$id` is given, the id also serves as the human-readable label - matching what a Drupal site builder would do by hand.

## Changes

### `src/Drupal/Driver/Capability/RoleCapabilityInterface.php`

Extended `roleCreate()` signature to `roleCreate(array $permissions, ?string $id = NULL, ?string $label = NULL): string` with documentation explaining the fallback chain.

### `src/Drupal/Driver/Core/Core.php`

`Core::roleCreate()` now uses `$id` when provided (else generates a random lowercase id via `$this->random->name(8, TRUE)`) and uses `$label` when provided (else falls back to `$id` when that is given, otherwise a random label). Same permission-validation and `user_role_grant_permissions()` flow as before.

### `src/Drupal/Driver/DrushDriver.php`

`DrushDriver::roleCreate()` mirrors the same fallback logic and forwards the resolved `$rid` + `$label` to the `drush role:create` command.

### `src/Drupal/Driver/DrupalDriver.php`

Pass-through delegation updated to forward the new parameters to the core.

### Test-stub classes and tests

- `tests/Drupal/Tests/Driver/Unit/Core/CoreFieldHandlerLookupTest.php`: stub signature updated to match the interface.
- `tests/Drupal/Tests/Driver/Unit/DrushDriverMethodsTest.php`: added two data-provider cases covering the explicit-id path and the explicit-id+label path.
- `tests/Drupal/Tests/Driver/Unit/DrupalDriverDelegationTest.php`: added a named-role data-provider case to prove the pass-through forwards both optional parameters.
- `tests/Drupal/Tests/Driver/Kernel/Core/CoreUserMethodsKernelTest.php`: two new kernel tests - `testRoleCreateAcceptsExplicitIdAndLabel` (asserts id + label + permission round-trip via a real user_role entity) and `testRoleCreateFallsBackToIdAsLabel` (asserts id-only path uses id as label).

## Before / After

```
roleCreate() argument shape:

Before:
  roleCreate(array $permissions): string
    -> always random id + random label

After:
  roleCreate(array $permissions,
             ?string $id = NULL,
             ?string $label = NULL): string

  $id === NULL  + $label === NULL  -> random id + random label   (backward compatible)
  $id === 'x'   + $label === NULL  -> id 'x', label 'x'          (id doubles as label)
  $id === 'x'   + $label === 'Y'   -> id 'x', label 'Y'
  $id === NULL  + $label === 'Y'   -> random id, label 'Y'       (rare but valid)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced role creation to accept optional identifiers and labels. Users can now provide explicit role IDs and human-readable labels when creating roles, with automatic generation as fallback when omitted.

* **Tests**
  * Added test coverage for role creation with explicit identifiers and labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->