### PR TITLE
[#124] Added 'BooleanHandler' accepting field labels and canonical yes/no forms.

### DIFF
--- a/src/Drupal/Driver/Core/Field/BooleanHandler.php
+++ b/src/Drupal/Driver/Core/Field/BooleanHandler.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Driver\Core\Field;
+
+/**
+ * Field handler for the 'boolean' field type.
+ *
+ * Scenarios authored against a BDD driver read naturally when boolean columns
+ * carry human words ('Yes', 'Published') rather than the raw 1/0 the Drupal
+ * field API stores. This handler resolves an incoming value in two stages:
+ *
+ *  1. The field's own 'on_label' / 'off_label' settings, compared
+ *     case-insensitively. These are the labels the site builder configured;
+ *     they already reflect the site's active language, so translated sites
+ *     get translation matching for free.
+ *  2. A canonical allow-list via 'filter_var(FILTER_VALIDATE_BOOLEAN)':
+ *     '1', 'true', 'on', 'yes' map to 1; '0', 'false', 'off', 'no', '' map
+ *     to 0. Case-insensitive.
+ *
+ * A value that matches neither throws a descriptive 'RuntimeException' listing
+ * both the field-specific labels and the canonical set, so scenario authors
+ * get an actionable error instead of a silent coercion to FALSE.
+ *
+ * Subclasses in a 'Core{N}\Field\' tree can override 'resolveBoolean()' to
+ * extend the mapping (e.g. site-specific synonyms) without reimplementing the
+ * per-delta loop.
+ */
+class BooleanHandler extends AbstractHandler {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function expand(mixed $values): array {
+    $settings = $this->fieldConfig->getSettings();
+    $on_label = (string) ($settings['on_label'] ?? '');
+    $off_label = (string) ($settings['off_label'] ?? '');
+
+    $resolved = [];
+
+    foreach ((array) $values as $value) {
+      $resolved[] = $this->resolveBoolean((string) $value, $on_label, $off_label);
+    }
+
+    return $resolved;
+  }
+
+  /**
+   * Maps a raw value to 1 (true) or 0 (false).
+   *
+   * @param string $value
+   *   The value to resolve.
+   * @param string $on_label
+   *   The field's configured on-state label, or '' if none.
+   * @param string $off_label
+   *   The field's configured off-state label, or '' if none.
+   *
+   * @return int
+   *   1 or 0.
+   *
+   * @throws \RuntimeException
+   *   When the value matches neither the field labels nor a canonical form.
+   */
+  protected function resolveBoolean(string $value, string $on_label, string $off_label): int {
+    if ($on_label !== '' && strcasecmp($value, $on_label) === 0) {
+      return 1;
+    }
+
+    if ($off_label !== '' && strcasecmp($value, $off_label) === 0) {
+      return 0;
+    }
+
+    $canonical = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+    if ($canonical === NULL) {
+      throw new \RuntimeException(sprintf(
+        'Cannot convert "%s" to a boolean. Accepted values: on label "%s", off label "%s", or any of 1/0, true/false, yes/no, on/off (case-insensitive).',
+        $value,
+        $on_label,
+        $off_label,
+      ));
+    }
+
+    return $canonical ? 1 : 0;
+  }
+
+}

--- a/tests/Drupal/Tests/Driver/Kernel/Core/Field/BooleanHandlerKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/Field/BooleanHandlerKernelTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\Driver\Kernel\Core\Field;
+
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Kernel round-trip test for BooleanHandler via the Core driver.
+ *
+ * Asserts that scenarios can populate boolean fields with human-readable
+ * words ('Yes', 'Published') instead of 1/0, and that unrecognised values
+ * raise a clear error rather than silently coercing to FALSE.
+ *
+ * @group fields
+ */
+#[Group('fields')]
+class BooleanHandlerKernelTest extends FieldHandlerKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   *
+   * @var array<string>
+   */
+  protected static $modules = [
+    ...self::BASE_MODULES,
+  ];
+
+  /**
+   * Tests canonical 'Yes' resolves to 1 and round-trips via storage.
+   */
+  public function testCanonicalYesRoundTrip(): void {
+    $this->attachField('field_flag', 'boolean');
+    $this->assertFieldRoundTripViaDriver('field_flag', ['Yes']);
+  }
+
+  /**
+   * Tests canonical 'no' resolves to 0 and round-trips via storage.
+   */
+  public function testCanonicalNoRoundTrip(): void {
+    $this->attachField('field_flag', 'boolean');
+    $this->assertFieldRoundTripViaDriver('field_flag', ['no']);
+  }
+
+  /**
+   * Tests the field's configured on_label takes priority over canonical forms.
+   *
+   * Site builders often customise the labels (e.g. 'Published'/'Draft' on a
+   * publishing workflow field). Scenarios should be able to use those exact
+   * words without the handler second-guessing them.
+   */
+  public function testFieldOnLabelResolvesToTrue(): void {
+    $this->attachField('field_flag', 'boolean', [], [
+      'on_label' => 'Published',
+      'off_label' => 'Draft',
+    ]);
+
+    $this->assertFieldRoundTripViaDriver('field_flag', ['Published']);
+  }
+
+  /**
+   * Tests the field's configured off_label resolves to 0.
+   */
+  public function testFieldOffLabelResolvesToFalse(): void {
+    $this->attachField('field_flag', 'boolean', [], [
+      'on_label' => 'Published',
+      'off_label' => 'Draft',
+    ]);
+
+    $this->assertFieldRoundTripViaDriver('field_flag', ['Draft']);
+  }
+
+  /**
+   * Tests an unrecognised value raises a descriptive exception.
+   */
+  public function testUnrecognisedValueThrows(): void {
+    $this->attachField('field_flag', 'boolean');
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessageMatches('/Cannot convert "maybe" to a boolean/');
+
+    $this->assertFieldRoundTripViaDriver('field_flag', ['maybe']);
+  }
+
+}


### PR DESCRIPTION
Closes #124

## Summary

Scenarios populating `boolean` fields previously had to use raw `1`/`0`, which reads poorly in BDD tables. This PR adds a `BooleanHandler` that accepts human-readable values in two resolution stages: first the field's own `on_label` / `off_label` settings (case-insensitive) so site-specific labels like `Published`/`Draft` work verbatim, then a canonical allow-list via `filter_var(FILTER_VALIDATE_BOOLEAN)` which recognises `1/0`, `true/false`, `yes/no`, `on/off` (case-insensitive). Anything else throws a descriptive `RuntimeException` listing both the field labels and the canonical set, so scenario authors get an actionable error instead of a silent coercion to `FALSE`.

Translation handling is free: `on_label` / `off_label` are already stored in the site's active language, so a German site with labels `Ja`/`Nein` matches `Ja`/`Nein` verbatim and still falls back to canonical English `yes`/`no`.

Subclasses in a `Core{N}\Field\` tree can override `resolveBoolean()` to extend the mapping (e.g. site-specific synonyms) without reimplementing the per-delta loop.

## Changes

### `src/Drupal/Driver/Core/Field/BooleanHandler.php` (new)

- `expand()` reads `on_label` and `off_label` off the FieldConfig settings and maps each delta via `resolveBoolean()`.
- `resolveBoolean()` tries a case-insensitive match against the two labels first, then delegates to `filter_var(..., FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)`. A null return from filter_var triggers a `RuntimeException` with the full accepted-values list in the message.

### `tests/Drupal/Tests/Driver/Kernel/Core/Field/BooleanHandlerKernelTest.php` (new)

Five kernel round-trip tests exercising the handler end-to-end against a real Drupal kernel:

- `testCanonicalYesRoundTrip`: `'Yes'` resolves to `1` and round-trips through storage.
- `testCanonicalNoRoundTrip`: `'no'` resolves to `0`.
- `testFieldOnLabelResolvesToTrue`: attaches a field with `on_label = 'Published'`, passes `'Published'`, asserts round-trip.
- `testFieldOffLabelResolvesToFalse`: same with `off_label = 'Draft'`.
- `testUnrecognisedValueThrows`: passes `'maybe'`, expects `RuntimeException` matching the descriptive message.

## Before / After

```
Handler resolution for a value in a scenario table:

Before (no BooleanHandler):
  | promote |
  | 1       |
    -> DefaultHandler wraps to [1] -> stored as TRUE
  | Yes     |
    -> DefaultHandler wraps to ['Yes'] -> Drupal coerces to TRUE but the
       scenario reads oddly against the native 1/0 expectation

After:
  | promote |
  | Yes     |  -> filter_var -> 1 -> stored as TRUE
  | no      |  -> filter_var -> 0 -> stored as FALSE
  | true    |  -> filter_var -> 1
  | off     |  -> filter_var -> 0

  For a field with on_label='Published', off_label='Draft':
  | Published |  -> field label match -> 1
  | Draft     |  -> field label match -> 0
  | yes       |  -> still works via canonical fallback -> 1

  | maybe     |  -> RuntimeException with accepted-values list
```
