### PR TITLE
[#118] Improved error messages for unknown entity types, bundles, and vocabularies.

### DIFF
--- a/src/Drupal/Driver/Core/Core.php
+++ b/src/Drupal/Driver/Core/Core.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Drupal\Driver\Core;
 
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Component\Utility\Random;
 use Drupal\Core\DrupalKernel;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Driver\Core\Field\DefaultHandler;
 use Drupal\Driver\Core\Field\FieldHandlerInterface;
 use Drupal\Driver\Exception\BootstrapException;
@@ -15,8 +18,8 @@ use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\mailsystem\MailsystemManager;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\taxonomy\TermInterface;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
@@ -181,7 +184,7 @@ class Core implements CoreInterface {
    *   Base field names whose corresponding property is set on the stub.
    */
   protected function detectBaseFieldsOnEntity(string $entity_type, \stdClass $entity): array {
-    $definition = \Drupal::entityTypeManager()->getDefinition($entity_type);
+    $definition = $this->loadEntityTypeDefinition($entity_type);
     $skip = array_filter([$definition->getKey('id'), $definition->getKey('bundle')]);
 
     $detected = [];
@@ -197,6 +200,33 @@ class Core implements CoreInterface {
     }
 
     return $detected;
+  }
+
+  /**
+   * Resolves an entity type definition, rethrowing with an actionable message.
+   *
+   * Drupal's EntityTypeManager throws 'PluginNotFoundException' with text like
+   * "The 'xyz' plugin does not exist." That is technically correct but leaks
+   * plugin-system vocabulary into what a scenario author experiences as a
+   * driver-level error. Wrapping it lets us produce a message that names
+   * what actually went wrong: the entity type argument they passed.
+   *
+   * @param string $entity_type
+   *   Entity type id to load.
+   *
+   * @return \Drupal\Core\Entity\EntityTypeInterface
+   *   The resolved definition.
+   *
+   * @throws \InvalidArgumentException
+   *   If the entity type id is not registered.
+   */
+  protected function loadEntityTypeDefinition(string $entity_type): EntityTypeInterface {
+    try {
+      return \Drupal::entityTypeManager()->getDefinition($entity_type);
+    }
+    catch (PluginNotFoundException $e) {
+      throw new \InvalidArgumentException(sprintf('Unknown entity type "%s".', $entity_type), 0, $e);
+    }
   }
 
   /**
@@ -594,18 +624,29 @@ class Core implements CoreInterface {
    * {@inheritdoc}
    */
   public function termCreate(\stdClass $term): \stdClass {
+    if (empty($term->vocabulary_machine_name)) {
+      throw new \InvalidArgumentException("Cannot create term because it is missing the required property 'vocabulary_machine_name'.");
+    }
+
+    if (Vocabulary::load($term->vocabulary_machine_name) === NULL) {
+      throw new \InvalidArgumentException(sprintf("Cannot create term because vocabulary '%s' does not exist.", $term->vocabulary_machine_name));
+    }
+
     $term->vid = $term->vocabulary_machine_name;
 
     if (!empty($term->parent)) {
+      $parent_name = $term->parent;
       $parent_terms = \Drupal::entityQuery('taxonomy_term')
         ->accessCheck(FALSE)
-        ->condition('name', $term->parent)
+        ->condition('name', $parent_name)
         ->condition('vid', $term->vocabulary_machine_name)
         ->execute();
 
-      if (!empty($parent_terms)) {
-        $term->parent = reset($parent_terms);
+      if (empty($parent_terms)) {
+        throw new \InvalidArgumentException(sprintf("Cannot create term because parent term '%s' does not exist in vocabulary '%s'.", $parent_name, $term->vocabulary_machine_name));
       }
+
+      $term->parent = reset($parent_terms);
     }
 
     $this->expandEntityFields('taxonomy_term', $term);
@@ -785,7 +826,7 @@ class Core implements CoreInterface {
       throw new \InvalidArgumentException('You must specify an entity type to create an entity.');
     }
 
-    $definition = \Drupal::entityTypeManager()->getDefinition($entity_type);
+    $definition = $this->loadEntityTypeDefinition($entity_type);
     $bundle_key = $definition->getKey('bundle');
     $id_key = $definition->getKey('id');
 
@@ -801,7 +842,7 @@ class Core implements CoreInterface {
       $bundles = $bundle_info->getBundleInfo($entity_type);
 
       if (!in_array($entity->$bundle_key, array_keys($bundles))) {
-        throw new \Exception(sprintf("Cannot create entity because provided bundle '%s' does not exist.", $entity->$bundle_key));
+        throw new \InvalidArgumentException(sprintf("Cannot create entity because provided bundle '%s' does not exist.", $entity->$bundle_key));
       }
     }
 
@@ -822,7 +863,7 @@ class Core implements CoreInterface {
    */
   public function entityDelete(string $entity_type, object $entity): void {
     if (!$entity instanceof EntityInterface) {
-      $id_key = \Drupal::entityTypeManager()->getDefinition($entity_type)->getKey('id');
+      $id_key = $this->loadEntityTypeDefinition($entity_type)->getKey('id');
 
       // Fail loudly if the stub does not carry the resolved id key. Without
       // this guard a missing property would silently call storage->load(NULL)

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreEntityMethodsKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreEntityMethodsKernelTest.php
@@ -196,6 +196,31 @@ class CoreEntityMethodsKernelTest extends KernelTestBase {
   }
 
   /**
+   * Tests 'entityCreate()' rejects an unknown entity type with a clear message.
+   *
+   * Drupal's 'EntityTypeManager::getDefinition()' raises a
+   * 'PluginNotFoundException' with plugin-system vocabulary that does not
+   * describe what a scenario author actually did wrong. The driver wraps it
+   * as an 'InvalidArgumentException' that names the offending entity type.
+   */
+  public function testEntityCreateRejectsUnknownEntityType(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/Unknown entity type "nonexistent_type"/');
+
+    $this->core->entityCreate('nonexistent_type', (object) ['name' => 'foo']);
+  }
+
+  /**
+   * Tests 'entityDelete()' rejects an unknown entity type with a clear message.
+   */
+  public function testEntityDeleteRejectsUnknownEntityType(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/Unknown entity type "nonexistent_type"/');
+
+    $this->core->entityDelete('nonexistent_type', (object) ['id' => 1]);
+  }
+
+  /**
    * Tests that 'entityCreate()' rejects an unknown bundle for a bundled type.
    *
    * 'entity_test' has a 'type' bundle key but no bundles registered unless

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreTermMethodsKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreTermMethodsKernelTest.php
@@ -87,4 +87,45 @@ class CoreTermMethodsKernelTest extends KernelTestBase {
     $this->assertFalse($this->core->termDelete($missing));
   }
 
+  /**
+   * Tests that termCreate rejects a stub missing 'vocabulary_machine_name'.
+   */
+  public function testTermCreateRejectsMissingVocabularyProperty(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches("/missing the required property 'vocabulary_machine_name'/");
+
+    $this->core->termCreate((object) ['name' => 'Orphan']);
+  }
+
+  /**
+   * Tests that termCreate rejects an unknown vocabulary.
+   */
+  public function testTermCreateRejectsUnknownVocabulary(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches("/vocabulary 'ghosts' does not exist/");
+
+    $this->core->termCreate((object) [
+      'vocabulary_machine_name' => 'ghosts',
+      'name' => 'Casper',
+    ]);
+  }
+
+  /**
+   * Tests that termCreate rejects a parent term that does not exist.
+   *
+   * Previously a non-matching parent was silently left as the raw name string,
+   * which produced an opaque downstream error from Term::create. Now it fails
+   * loudly with a message that names the missing parent.
+   */
+  public function testTermCreateRejectsUnknownParent(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches("/parent term 'Missing' does not exist in vocabulary 'tags'/");
+
+    $this->core->termCreate((object) [
+      'vocabulary_machine_name' => 'tags',
+      'name' => 'Orphaned',
+      'parent' => 'Missing',
+    ]);
+  }
+
 }


### PR DESCRIPTION
Closes #118

## Summary

Scenarios that passed an unknown entity type, bundle, vocabulary, or parent term got opaque low-level errors ("The 'fake' plugin does not exist", stdClass-to-string coercion, undefined property warnings) rather than driver-level messages that name what the scenario author actually got wrong. This PR tightens the error-handling seams so every unknown-input path produces an `InvalidArgumentException` with a message that quotes the offending value and points at the validated concept.

## Changes

### `src/Drupal/Driver/Core/Core.php`

- New `protected loadEntityTypeDefinition()`: wraps `\Drupal::entityTypeManager()->getDefinition()` and catches `PluginNotFoundException`, re-throwing as `InvalidArgumentException('Unknown entity type "X".')`. Plugin-system vocabulary no longer leaks into driver-level errors.
- `entityCreate()` and `entityDelete()` now route their entity-type resolution through `loadEntityTypeDefinition()`, so a bad `$entity_type` argument fails loudly at the top of the method with an actionable message. The existing unknown-bundle check now throws `InvalidArgumentException` for consistency.
- `termCreate()` gained three explicit validations:
  - `vocabulary_machine_name` missing or empty - throws naming the missing property.
  - Vocabulary does not exist - throws naming the vocabulary id.
  - Parent term name supplied but not resolvable in that vocabulary - throws naming the missing parent and the vocabulary. Previously the parent string was silently left in place, producing an opaque downstream error from `Term::create`.
- `detectBaseFieldsOnEntity()` also routes through the wrapper so an unknown entity type fails the same way as `entityCreate()`.

### `tests/Drupal/Tests/Driver/Kernel/Core/CoreEntityMethodsKernelTest.php`

- `testEntityCreateRejectsUnknownEntityType`: asserts `InvalidArgumentException` with message matching `Unknown entity type "nonexistent_type"`.
- `testEntityDeleteRejectsUnknownEntityType`: same on the delete path.

### `tests/Drupal/Tests/Driver/Kernel/Core/CoreTermMethodsKernelTest.php`

- `testTermCreateRejectsMissingVocabularyProperty`: stub without `vocabulary_machine_name` fails with the missing-property message.
- `testTermCreateRejectsUnknownVocabulary`: stub referencing a vocabulary id that is not registered fails with the vocabulary-not-found message.
- `testTermCreateRejectsUnknownParent`: stub with a parent name that does not resolve in the vocabulary fails with the parent-not-found message, instead of silently passing a name string down into Term::create.

## Before / After

```
Error surface for bad inputs:

Before:
  entityCreate('fake_type', ...)
    -> PluginNotFoundException: The 'fake_type' plugin does not exist.
  entityDelete('fake_type', $stub)
    -> PluginNotFoundException: The 'fake_type' plugin does not exist.
  termCreate(stub without vocabulary_machine_name)
    -> undefined property warning, then save fails obscurely
  termCreate(stub referencing a fake vocabulary)
    -> Term::create proceeds, save fails with a foreign-key-ish error
  termCreate(stub with parent 'Missing')
    -> silently leaves parent as the string 'Missing', Term::create
       fails with a type error deep in the stack

After:
  entityCreate('fake_type', ...)
    -> InvalidArgumentException: Unknown entity type "fake_type".
  entityDelete('fake_type', stub)
    -> InvalidArgumentException: Unknown entity type "fake_type".
  termCreate(stub without vocabulary_machine_name)
    -> InvalidArgumentException: Cannot create term because it is missing
       the required property 'vocabulary_machine_name'.
  termCreate(stub referencing a fake vocabulary)
    -> InvalidArgumentException: Cannot create term because vocabulary
       'fake' does not exist.
  termCreate(stub with parent 'Missing', vocabulary_machine_name 'tags')
    -> InvalidArgumentException: Cannot create term because parent term
       'Missing' does not exist in vocabulary 'tags'.
```
