### PR TITLE
[#111] Added 'BlockCapabilityInterface' with block placement and content-block methods.

### DIFF
--- a/src/Drupal/Driver/Capability/BlockCapabilityInterface.php
+++ b/src/Drupal/Driver/Capability/BlockCapabilityInterface.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Driver\Capability;
+
+/**
+ * Capability: place blocks and create content blocks.
+ *
+ * Groups the two distinct block operations a driver typically needs during
+ * scenario setup:
+ *
+ *  - Placing a block in a region - the 'block' config entity. Answers what
+ *    a scenario step like "Given the X block is placed in the Y region"
+ *    resolves to internally.
+ *  - Creating a content block - the 'block_content' content entity. The
+ *    reusable block body that would normally be authored through the
+ *    block library UI.
+ *
+ * Block type ('block_content_type') creation is intentionally out of scope.
+ * Like node types and taxonomy vocabularies, it is schema-level setup that
+ * belongs in the test site's configuration, not in a scenario step.
+ */
+interface BlockCapabilityInterface {
+
+  /**
+   * Places a block in a region.
+   *
+   * @param \stdClass $block
+   *   Block placement stub. Properties mirror the 'block' config entity's
+   *   keys: 'id' (machine name of the placement; auto-generated when
+   *   absent), 'plugin' (block plugin id, e.g. 'system_powered_by_block'
+   *   or 'block_content:<uuid>'), 'theme', 'region', 'weight', 'settings',
+   *   'visibility', 'status'.
+   *
+   * @return object
+   *   The saved 'block' config entity. The stub is mutated so that its
+   *   'id' property holds the resolved placement id, matching the
+   *   'nodeCreate'/'termCreate' mutation convention.
+   */
+  public function blockPlace(\stdClass $block): object;
+
+  /**
+   * Removes a placed block.
+   *
+   * @param object $block
+   *   The block placement to delete. May be the stub returned by
+   *   'blockPlace()' (needs an 'id' property) or a loaded 'block' entity.
+   */
+  public function blockDelete(object $block): void;
+
+  /**
+   * Creates a content block.
+   *
+   * @param \stdClass $block_content
+   *   Content block stub. The 'type' property selects the block-content
+   *   bundle; remaining properties map to fields on that bundle ('info',
+   *   'body', custom fields, etc.).
+   *
+   * @return object
+   *   The saved 'block_content' entity.
+   */
+  public function blockContentCreate(\stdClass $block_content): object;
+
+  /**
+   * Deletes a content block.
+   *
+   * @param object $block_content
+   *   The content block to delete. May be the stub returned by
+   *   'blockContentCreate()' or a loaded 'block_content' entity.
+   */
+  public function blockContentDelete(object $block_content): void;
+
+}

--- a/src/Drupal/Driver/Core/Core.php
+++ b/src/Drupal/Driver/Core/Core.php
@@ -732,6 +732,54 @@ class Core implements CoreInterface {
   /**
    * {@inheritdoc}
    */
+  public function blockPlace(\stdClass $block): object {
+    // Generate a placement id when the caller did not supply one, matching
+    // the 'nodeCreate'/'roleCreate' convention of tolerating ID-less stubs.
+    // Block config entities require an id, so we must fill it before save.
+    if (!isset($block->id) || $block->id === '') {
+      $block->id = strtolower($this->random->name(8, TRUE));
+    }
+
+    $placement = \Drupal::entityTypeManager()->getStorage('block')->create((array) $block);
+    $placement->save();
+
+    return $placement;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockDelete(object $block): void {
+    if (!$block instanceof EntityInterface) {
+      if (!isset($block->id) || !is_string($block->id)) {
+        throw new \InvalidArgumentException('Cannot delete a block placement from a stub without a string "id" property.');
+      }
+
+      $block = \Drupal::entityTypeManager()->getStorage('block')->load($block->id);
+    }
+
+    if ($block instanceof EntityInterface) {
+      $block->delete();
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockContentCreate(\stdClass $block_content): object {
+    return $this->entityCreate('block_content', $block_content);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockContentDelete(object $block_content): void {
+    $this->entityDelete('block_content', $block_content);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getModuleList(): array {
     return array_keys(\Drupal::moduleHandler()->getModuleList());
   }

--- a/src/Drupal/Driver/Core/CoreInterface.php
+++ b/src/Drupal/Driver/Core/CoreInterface.php
@@ -6,6 +6,7 @@ namespace Drupal\Driver\Core;
 
 use Drupal\Component\Utility\Random;
 use Drupal\Driver\Capability\AuthenticationCapabilityInterface;
+use Drupal\Driver\Capability\BlockCapabilityInterface;
 use Drupal\Driver\Capability\CacheCapabilityInterface;
 use Drupal\Driver\Capability\ConfigCapabilityInterface;
 use Drupal\Driver\Capability\ContentCapabilityInterface;
@@ -28,6 +29,7 @@ use Drupal\Driver\Core\Field\FieldHandlerInterface;
  */
 interface CoreInterface extends
   AuthenticationCapabilityInterface,
+  BlockCapabilityInterface,
   CacheCapabilityInterface,
   ConfigCapabilityInterface,
   ContentCapabilityInterface,

--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -275,6 +275,34 @@ class DrupalDriver implements DrupalDriverInterface {
   /**
    * {@inheritdoc}
    */
+  public function blockPlace(\stdClass $block): object {
+    return $this->getCore()->blockPlace($block);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockDelete(object $block): void {
+    $this->getCore()->blockDelete($block);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockContentCreate(\stdClass $block_content): object {
+    return $this->getCore()->blockContentCreate($block_content);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockContentDelete(object $block_content): void {
+    $this->getCore()->blockContentDelete($block_content);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function cronRun(): bool {
     return $this->getCore()->cronRun();
   }

--- a/src/Drupal/Driver/DrupalDriverInterface.php
+++ b/src/Drupal/Driver/DrupalDriverInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Driver;
 
 use Drupal\Driver\Capability\AuthenticationCapabilityInterface;
+use Drupal\Driver\Capability\BlockCapabilityInterface;
 use Drupal\Driver\Capability\CacheCapabilityInterface;
 use Drupal\Driver\Capability\ConfigCapabilityInterface;
 use Drupal\Driver\Capability\ContentCapabilityInterface;
@@ -26,6 +27,7 @@ interface DrupalDriverInterface extends
   DriverInterface,
   SubDriverFinderInterface,
   AuthenticationCapabilityInterface,
+  BlockCapabilityInterface,
   CacheCapabilityInterface,
   ConfigCapabilityInterface,
   ContentCapabilityInterface,

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreBlockMethodsKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreBlockMethodsKernelTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\Driver\Kernel\Core;
+
+use Drupal\block\Entity\Block;
+use Drupal\block_content\Entity\BlockContent;
+use Drupal\block_content\Entity\BlockContentType;
+use Drupal\Driver\Core\Core;
+use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Kernel tests for the block capability methods on Core.
+ *
+ * Covers all four methods of 'BlockCapabilityInterface':
+ *  - 'blockPlace()' / 'blockDelete()' round-trip a 'block' config entity
+ *    (placement in a region of a theme).
+ *  - 'blockContentCreate()' / 'blockContentDelete()' round-trip a
+ *    'block_content' content entity (the reusable block body).
+ *
+ * @group core
+ * @group block
+ */
+#[Group('core')]
+#[Group('block')]
+class CoreBlockMethodsKernelTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   *
+   * @var array<string>
+   */
+  protected static $modules = ['system', 'user', 'block', 'block_content', 'filter', 'text'];
+
+  /**
+   * The Core driver under test.
+   */
+  protected Core $core;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('block_content');
+    $this->installConfig(['system', 'filter', 'block_content']);
+    \Drupal::service('theme_installer')->install(['stark']);
+    $this->core = new Core($this->root);
+  }
+
+  /**
+   * Tests that 'blockPlace()' creates a placement in the given region.
+   */
+  public function testBlockPlaceAndDeleteRoundTrip(): void {
+    $stub = (object) [
+      'id' => 'test_powered_by',
+      'plugin' => 'system_powered_by_block',
+      'theme' => 'stark',
+      'region' => 'content',
+      'weight' => 0,
+      'settings' => ['label' => 'Powered by', 'label_display' => 'visible'],
+    ];
+
+    $placement = $this->core->blockPlace($stub);
+
+    $this->assertInstanceOf(Block::class, $placement);
+
+    $reloaded = Block::load('test_powered_by');
+    $this->assertInstanceOf(Block::class, $reloaded);
+    $this->assertSame('content', $reloaded->getRegion());
+    $this->assertSame('stark', $reloaded->getTheme());
+    $this->assertSame('system_powered_by_block', $reloaded->getPluginId());
+
+    $this->core->blockDelete($stub);
+    $this->assertNull(Block::load('test_powered_by'));
+  }
+
+  /**
+   * Tests that 'blockPlace()' auto-generates an id when the stub omits it.
+   */
+  public function testBlockPlaceGeneratesIdWhenAbsent(): void {
+    $stub = (object) [
+      'plugin' => 'system_powered_by_block',
+      'theme' => 'stark',
+      'region' => 'footer',
+    ];
+
+    $placement = $this->core->blockPlace($stub);
+
+    $this->assertInstanceOf(Block::class, $placement);
+    $this->assertNotEmpty($placement->id(), 'blockPlace populated an id on the saved placement.');
+    $this->assertNotNull(Block::load($placement->id()));
+  }
+
+  /**
+   * Tests that 'blockDelete()' accepts a loaded entity as well as a stub.
+   */
+  public function testBlockDeleteAcceptsLoadedEntity(): void {
+    $stub = (object) [
+      'id' => 'test_via_entity',
+      'plugin' => 'system_powered_by_block',
+      'theme' => 'stark',
+      'region' => 'content',
+    ];
+    $this->core->blockPlace($stub);
+
+    $loaded = Block::load('test_via_entity');
+    $this->assertInstanceOf(Block::class, $loaded);
+
+    $this->core->blockDelete($loaded);
+    $this->assertNull(Block::load('test_via_entity'));
+  }
+
+  /**
+   * Tests that 'blockDelete()' fails loudly when the stub has no id.
+   */
+  public function testBlockDeleteRequiresIdOnStub(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/id/');
+
+    $this->core->blockDelete((object) ['plugin' => 'system_powered_by_block']);
+  }
+
+  /**
+   * Tests that 'blockContentCreate()' creates a content-block entity.
+   */
+  public function testBlockContentCreateAndDeleteRoundTrip(): void {
+    BlockContentType::create(['id' => 'basic', 'label' => 'Basic'])->save();
+
+    $stub = (object) [
+      'type' => 'basic',
+      'info' => 'driver-test content block',
+      'reusable' => TRUE,
+    ];
+
+    $created = $this->core->blockContentCreate($stub);
+
+    $this->assertInstanceOf(BlockContent::class, $created);
+    $this->assertNotEmpty($stub->id, 'blockContentCreate populated the id key on the stub.');
+    $this->assertSame('driver-test content block', $created->label());
+
+    $this->core->blockContentDelete($stub);
+    $this->assertNull(BlockContent::load((int) $stub->id));
+  }
+
+}

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreBlockMethodsKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreBlockMethodsKernelTest.php
@@ -32,7 +32,7 @@ class CoreBlockMethodsKernelTest extends KernelTestBase {
    *
    * @var array<string>
    */
-  protected static $modules = ['system', 'user', 'block', 'block_content', 'filter', 'text'];
+  protected static $modules = ['system', 'user', 'block', 'block_content'];
 
   /**
    * The Core driver under test.
@@ -46,7 +46,12 @@ class CoreBlockMethodsKernelTest extends KernelTestBase {
     parent::setUp();
     $this->installEntitySchema('user');
     $this->installEntitySchema('block_content');
-    $this->installConfig(['system', 'filter', 'block_content']);
+    // Only 'system' config is installed. Installing 'block_content' config
+    // on Drupal 10 / Drupal 11-lowest pulls in
+    // 'field.storage.block_content.body', whose schema references the 'text'
+    // module - unnecessary surface for this test, which creates its own
+    // body-less 'block_content_type' inline.
+    $this->installConfig(['system']);
     \Drupal::service('theme_installer')->install(['stark']);
     $this->core = new Core($this->root);
   }

--- a/tests/Drupal/Tests/Driver/Unit/DrupalDriverDelegationTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/DrupalDriverDelegationTest.php
@@ -172,6 +172,10 @@ class DrupalDriverDelegationTest extends TestCase {
     yield 'configSet' => ['configSet', ['system.site', 'name', 'v'], 'configSet'];
     yield 'entityCreate' => ['entityCreate', ['node', $entity], 'entityCreate'];
     yield 'entityDelete' => ['entityDelete', ['node', $entity], 'entityDelete'];
+    yield 'blockPlace' => ['blockPlace', [new \stdClass()], 'blockPlace'];
+    yield 'blockDelete' => ['blockDelete', [new \stdClass()], 'blockDelete'];
+    yield 'blockContentCreate' => ['blockContentCreate', [new \stdClass()], 'blockContentCreate'];
+    yield 'blockContentDelete' => ['blockContentDelete', [new \stdClass()], 'blockContentDelete'];
     yield 'mailStartCollecting' => ['mailStartCollecting', [], 'mailStartCollecting'];
     yield 'mailStopCollecting' => ['mailStopCollecting', [], 'mailStopCollecting'];
     yield 'mailGet' => ['mailGet', [], 'mailGet'];


### PR DESCRIPTION
Closes #111

## Summary

Adds a dedicated `BlockCapabilityInterface` covering both block operations the driver needs during scenario setup: placing a block in a region (`block` config entity) and creating a content block (`block_content` content entity). The 2016 PR (#112) shipped D7-only and was never ported; v3 gets a D10/D11-shaped API that mirrors the capability layout the rest of the driver follows.

Placement goes through a named method rather than being wedged into `entityCreate`: config entities don't have field storage, so their setup rituals (id generation, plugin/theme/region wiring) are type-specific and belong in a typed method alongside `roleCreate` and `languageCreate`. Content-block creation also gets a typed method even though it could flow through `entityCreate('block_content', $stub)` - keeping all block ops under one interface reads cleaner than splitting them across `Block` and `Content`, and matches how `UserCapabilityInterface` already groups user-related operations.

Block-type (`block_content_type`) creation is intentionally out of scope. Like node types and taxonomy vocabularies, it is schema-level setup that belongs in the test site's configuration, not in a scenario step.

## Changes

### New capability interface

- `src/Drupal/Driver/Capability/BlockCapabilityInterface.php`: declares `blockPlace(\stdClass $block): object`, `blockDelete(object $block): void`, `blockContentCreate(\stdClass $block_content): object`, `blockContentDelete(object $block_content): void`. Docblock spells out the three-concern split (placement / content / type) and why only two of the three ship.

### Composite interfaces

- `src/Drupal/Driver/Core/CoreInterface.php`: extends `BlockCapabilityInterface` alongside the existing capabilities.
- `src/Drupal/Driver/DrupalDriverInterface.php`: same.

### Core implementation

- `src/Drupal/Driver/Core/Core.php`:
  - `blockPlace()`: generates a random id when the stub omits one (matches the `roleCreate` DX), hands the stub to the `block` storage, saves, returns the saved placement.
  - `blockDelete()`: accepts either a stub with an `id` property or a loaded entity; fails loudly via `InvalidArgumentException` when the stub has no id, so consumers do not silently no-op.
  - `blockContentCreate()` / `blockContentDelete()`: thin delegates to `entityCreate('block_content', ...)` / `entityDelete('block_content', ...)`. `block_content` is a fieldable content entity, so the generic field-expansion path is exactly what we want.

### Driver delegation

- `src/Drupal/Driver/DrupalDriver.php`: four new one-liners forwarding to `$this->getCore()`.

### Tests

- `tests/Drupal/Tests/Driver/Kernel/Core/CoreBlockMethodsKernelTest.php` (new): five kernel tests covering placement round-trip, id auto-generation, delete-by-loaded-entity, delete-stub-without-id validation, and content-block round-trip against a real `block_content_type`.
- `tests/Drupal/Tests/Driver/Unit/DrupalDriverDelegationTest.php`: four new data-provider rows for the four new methods.

## Before / After

```
Before                                         After
──────                                         ─────

  DrupalDriver capabilities                    DrupalDriver capabilities
  ┌─────────────────────────────┐              ┌─────────────────────────────┐
  │ Authentication              │              │ Authentication              │
  │ Cache                       │              │ Block           ◄── NEW     │
  │ Config                      │              │ Cache                       │
  │ Content                     │              │ Config                      │
  │ Cron                        │              │ Content                     │
  │ Field                       │              │ Cron                        │
  │ Language                    │              │ Field                       │
  │ Mail                        │              │ Language                    │
  │ Module                      │              │ Mail                        │
  │ Role                        │              │ Module                      │
  │ User                        │              │ Role                        │
  │ Watchdog                    │              │ User                        │
  └─────────────────────────────┘              │ Watchdog                    │
                                               └─────────────────────────────┘

  Block placement:                             BlockCapabilityInterface:
  (not supported in v3.x)                      ┌────────────────────────────────┐
                                               │ blockPlace()                   │
  D7 PR #112 used db_update('block')           │ blockDelete()                  │
  - never ported to D10/D11.                   │ blockContentCreate()           │
                                               │ blockContentDelete()           │
                                               └────────────────────────────────┘
                                                         │
                                                         ▼
                                               ┌────────────────────────────────┐
                                               │ block         config entity    │
                                               │ block_content content entity   │
                                               └────────────────────────────────┘
```

Local verification: 305 / 305 tests pass, lint clean.
