### PR TITLE
Bundle fields not accounted if they are created through hook_entity_bundle_field_info()

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -431,7 +431,19 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
    */
   public function isBaseField($entity_type, $field_name) {
     $base_fields = $this->getEntityFieldManager()->getBaseFieldDefinitions($entity_type);
-    return isset($base_fields[$field_name]);
+    if (isset($base_fields[$field_name])) {
+      return TRUE;
+    }
+    // Also check bundle-specific fields (hook_entity_bundle_field_info).
+    // These are computed/custom-storage fields not in FieldStorageConfig.
+    $bundle_info = \Drupal::service('entity_type.bundle.info')->getBundleInfo($entity_type);
+    foreach (array_keys($bundle_info) as $bundle) {
+      $field_definitions = $this->getEntityFieldManager()->getFieldDefinitions($entity_type, $bundle);
+      if (isset($field_definitions[$field_name])) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
   /**

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -434,8 +434,14 @@ class Drupal8 extends AbstractCore implements CoreAuthenticationInterface {
     if (isset($base_fields[$field_name])) {
       return TRUE;
     }
-    // Also check bundle-specific fields (hook_entity_bundle_field_info).
-    // These are computed/custom-storage fields not in FieldStorageConfig.
+    // Configurable fields are handled by isField(); exclude them here.
+    if ($this->isField($entity_type, $field_name)) {
+      return FALSE;
+    }
+    // Also check bundle-specific computed/custom-storage fields defined via
+    // hook_entity_bundle_field_info(). These don't appear in getBaseFieldDefinitions()
+    // and are not FieldStorageConfig instances, so they fall through both isField()
+    // and the base-field check above.
     $bundle_info = \Drupal::service('entity_type.bundle.info')->getBundleInfo($entity_type);
     foreach (array_keys($bundle_info) as $bundle) {
       $field_definitions = $this->getEntityFieldManager()->getFieldDefinitions($entity_type, $bundle);

--- a/tests/Drupal/Tests/Driver/Drupal8FieldMethodsTest.php
+++ b/tests/Drupal/Tests/Driver/Drupal8FieldMethodsTest.php
@@ -18,10 +18,13 @@ namespace Drupal\field\Entity {
 namespace Drupal\Tests\Driver {
 
   use Drupal\Core\Entity\EntityFieldManagerInterface;
+  use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
   use Drupal\Core\Field\BaseFieldDefinition;
+  use Drupal\Core\Field\FieldDefinitionInterface;
   use Drupal\Driver\Cores\Drupal8;
   use Drupal\field\Entity\FieldStorageConfig;
   use PHPUnit\Framework\TestCase;
+  use Symfony\Component\DependencyInjection\ContainerInterface;
 
   /**
    * Tests for Drupal8 field methods: isBaseField(), isField(), getEntityFieldTypes().
@@ -46,12 +49,14 @@ namespace Drupal\Tests\Driver {
     /**
      * Data provider for testIsBaseField().
      */
-    public function dataProviderIsBaseField() {
+    public static function dataProviderIsBaseField() {
       return [
         'non-computed base field' => ['title', TRUE],
         'computed base field' => ['moderation_state', TRUE],
         'configurable field' => ['field_tags', FALSE],
         'unknown field' => ['nonexistent', FALSE],
+        'bundle computed field' => ['uri', TRUE],
+        'unknown bundle field' => ['nonexistent_bundle_field', FALSE],
       ];
     }
 
@@ -73,7 +78,7 @@ namespace Drupal\Tests\Driver {
     /**
      * Data provider for testIsField().
      */
-    public function dataProviderIsField() {
+    public static function dataProviderIsField() {
       return [
         'configurable field' => ['field_tags', TRUE],
         'non-computed base field' => ['title', FALSE],
@@ -109,7 +114,7 @@ namespace Drupal\Tests\Driver {
     /**
      * Data provider for testGetEntityFieldTypes().
      */
-    public function dataProviderGetEntityFieldTypes() {
+    public static function dataProviderGetEntityFieldTypes() {
       return [
         'no base fields requested' => [
         [],
@@ -135,7 +140,15 @@ namespace Drupal\Tests\Driver {
     }
 
     /**
-     * Creates a TestDrupal8Core with mocked entity field manager.
+     * Resets the Drupal container after each test.
+     */
+    protected function tearDown(): void {
+      parent::tearDown();
+      \Drupal::unsetContainer();
+    }
+
+    /**
+     * Creates a TestDrupal8Core with mocked entity field manager and container.
      *
      * @return \Drupal\Tests\Driver\TestDrupal8Core
      *   The test core instance.
@@ -152,9 +165,14 @@ namespace Drupal\Tests\Driver {
       // Configurable field — use stub that passes instanceof FieldStorageConfig.
       $field_tags = new FieldStorageConfig('entity_reference');
 
+      // Bundle computed field: present in a specific bundle, not in base fields
+      // or field storage definitions (no FieldStorageConfig).
+      $uri_field = $this->createMock(FieldDefinitionInterface::class);
+      $uri_field->method('getType')->willReturn('uri');
+
       $entity_field_manager = $this->createMock(EntityFieldManagerInterface::class);
 
-      // getFieldStorageDefinitions: returns non-computed base fields + configurable fields.
+      // getFieldStorageDefinitions: non-computed base fields + configurable fields.
       $entity_field_manager->method('getFieldStorageDefinitions')
         ->with('node')
         ->willReturn([
@@ -162,13 +180,36 @@ namespace Drupal\Tests\Driver {
           'field_tags' => $field_tags,
         ]);
 
-      // getBaseFieldDefinitions: returns ALL base fields (computed + non-computed).
+      // getBaseFieldDefinitions: ALL base fields (computed + non-computed).
       $entity_field_manager->method('getBaseFieldDefinitions')
         ->with('node')
         ->willReturn([
           'title' => $title_field,
           'moderation_state' => $moderation_state_field,
         ]);
+
+      // getFieldDefinitions: bundle-specific fields per bundle. 'uri' exists only
+      // on 'solution'; 'field_tags' appears on 'article' as a configurable field.
+      $entity_field_manager->method('getFieldDefinitions')
+        ->willReturnMap([
+          ['node', 'article', ['title' => $title_field, 'field_tags' => $field_tags]],
+          ['node', 'solution', ['title' => $title_field, 'uri' => $uri_field]],
+        ]);
+
+      // Set up the Drupal container so isBaseField() can resolve entity_type.bundle.info.
+      $bundle_info_service = $this->createMock(EntityTypeBundleInfoInterface::class);
+      $bundle_info_service->method('getBundleInfo')
+        ->with('node')
+        ->willReturn([
+          'article' => ['label' => 'Article'],
+          'solution' => ['label' => 'Solution'],
+        ]);
+
+      $container = $this->createMock(ContainerInterface::class);
+      $container->method('get')
+        ->with('entity_type.bundle.info')
+        ->willReturn($bundle_info_service);
+      \Drupal::setContainer($container);
 
       $core = new TestDrupal8Core(__DIR__, 'default');
       $core->setEntityFieldManager($entity_field_manager);


### PR DESCRIPTION
So the Drupal8 driver seems to have been expanded in https://github.com/jhedstrom/DrupalDriver/commit/71a97a34bb35fedc53f84ebd20b45074127ada8c as far as I can track down, but it seems to be missing the bundle fields that are created through `hook_entity_bundle_field_info` _and_ are computed.

**Disclaimer**
I am not really good with Unit tests and I have to sum up my day to go to the DDD the upcoming days so the test was LLM assisted. Feel free to disregard.

