### PR TITLE
Fixed 'FileHandler' regression for existing managed file lookup by filename.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+  * Fixed `FileHandler` regression introduced in 2.5.0 where referencing an existing managed file by filename failed with `Failed to open stream: No such file or directory`. The handler now reuses an existing managed file when the value matches a numeric file id or `filename` property, falling through to the v2.5.0 path-on-disk import only when the value resolves to a real file.
+
 ## [2.5.0]
 ### Added
   * [#306](https://github.com/jhedstrom/DrupalDriver/pull/306) Added `TimeHandler` for the `time_field` contrib module.

--- a/src/Drupal/Driver/Fields/Drupal8/FileHandler.php
+++ b/src/Drupal/Driver/Fields/Drupal8/FileHandler.php
@@ -12,32 +12,93 @@ class FileHandler extends AbstractHandler {
    */
   public function expand($values) {
     $return = [];
+
     foreach ((array) $values as $value) {
-      $file_path = is_array($value) ? $value['target_id'] ?? $value[0] : $value;
-      $file_extension = pathinfo($file_path, PATHINFO_EXTENSION);
-      $data = file_get_contents($file_path);
+      $raw = is_array($value) ? $value['target_id'] ?? $value[0] : $value;
+      $display = is_array($value) ? ($value['display'] ?? 1) : 1;
+      $description = is_array($value) ? ($value['description'] ?? '') : '';
 
-      if ($data === FALSE) {
-        throw new \Exception(sprintf('Error reading file %s.', $file_path));
-      }
-
-      /** @var \Drupal\file\FileInterface $file */
-      $file = \Drupal::service('file.repository')
-        ->writeData($data, 'public://' . uniqid() . '.' . $file_extension);
-
-      if ($file === FALSE) {
-        throw new \Exception('Error saving file.');
-      }
-
-      $file->save();
+      $target_id = $this->resolveTargetId($raw);
 
       $return[] = [
-        'target_id' => $file->id(),
-        'display' => is_array($value) ? ($value['display'] ?? 1) : 1,
-        'description' => is_array($value) ? ($value['description'] ?? '') : '',
+        'target_id' => $target_id,
+        'display' => $display,
+        'description' => $description,
       ];
     }
+
     return $return;
+  }
+
+  /**
+   * Resolves a raw value to a managed file id.
+   *
+   * Tries the filesystem first so callers can import a brand-new file by path
+   * (v2.5.0 behavior). Falls back to looking up an existing managed file by
+   * numeric id or filename (v2.4.3 behavior) so suites that pre-create files
+   * via 'managed files' steps keep working.
+   */
+  protected function resolveTargetId($value) {
+    if (is_string($value) && is_file($value)) {
+      return $this->createFileFromPath($value);
+    }
+
+    $existing = $this->loadExistingManagedFile($value);
+    if ($existing !== NULL) {
+      return $existing->id();
+    }
+
+    throw new \Exception(sprintf('Could not resolve file value "%s" as a path on disk or an existing managed file.', is_scalar($value) ? $value : gettype($value)));
+  }
+
+  /**
+   * Reads a file from disk and creates a new managed file entity.
+   */
+  protected function createFileFromPath($path) {
+    $data = file_get_contents($path);
+
+    if ($data === FALSE) {
+      throw new \Exception(sprintf('Error reading file %s.', $path));
+    }
+
+    $extension = pathinfo($path, PATHINFO_EXTENSION);
+
+    /** @var \Drupal\file\FileInterface $file */
+    $file = \Drupal::service('file.repository')
+      ->writeData($data, 'public://' . uniqid() . '.' . $extension);
+
+    if ($file === FALSE) {
+      throw new \Exception('Error saving file.');
+    }
+
+    $file->save();
+
+    return $file->id();
+  }
+
+  /**
+   * Loads an existing managed file by numeric id or filename.
+   *
+   * @return \Drupal\file\FileInterface|null
+   *   The matching file entity, or NULL when no match exists.
+   */
+  protected function loadExistingManagedFile($value) {
+    if (!is_scalar($value)) {
+      return NULL;
+    }
+
+    $storage = \Drupal::entityTypeManager()->getStorage('file');
+
+    if (is_int($value) || (is_string($value) && ctype_digit($value))) {
+      $file = $storage->load((int) $value);
+      if ($file) {
+        return $file;
+      }
+    }
+
+    $files = $storage->loadByProperties(['filename' => $value]);
+
+    return $files ? reset($files) : NULL;
   }
 
 }

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/FileHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/FileHandlerTest.php
@@ -201,7 +201,7 @@ class FileHandlerTest extends TestCase {
    * Creates a file storage stub backed by id and filename indexes.
    *
    * @param array $index
-   *   ['id' => [<id> => <file>], 'filename' => [<name> => <file>]].
+   *   Index keyed by lookup type, e.g. ['id' => [id => file], 'filename' => [name => file]].
    */
   protected function createFileStorage(array $index) {
     return new class($index) {

--- a/tests/Drupal/Tests/Driver/Fields/Drupal8/FileHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Fields/Drupal8/FileHandlerTest.php
@@ -20,15 +20,17 @@ class FileHandlerTest extends TestCase {
   }
 
   /**
-   * Tests that unreadable files throw a descriptive exception.
+   * Tests that unresolved values throw a descriptive exception.
    */
-  public function testExpandThrowsWhenFileCannotBeRead() {
+  public function testExpandThrowsWhenValueCannotBeResolved() {
+    $this->setContainer(NULL, $this->createFileStorage([]));
+
     $handler = $this->createHandler();
 
     $this->expectException(\Exception::class);
-    $this->expectExceptionMessage('Error reading file /tmp/drupal-driver-nonexistent-file.bin.');
+    $this->expectExceptionMessage('Could not resolve file value "/tmp/drupal-driver-nonexistent-file.bin"');
 
-    @$handler->expand(['/tmp/drupal-driver-nonexistent-file.bin']);
+    $handler->expand(['/tmp/drupal-driver-nonexistent-file.bin']);
   }
 
   /**
@@ -36,7 +38,7 @@ class FileHandlerTest extends TestCase {
    */
   public function testExpandHandlesStringValueWithDefaults() {
     $path = $this->createTempFile('png');
-    $this->setFileRepositoryWithReturnId(99);
+    $this->setContainer($this->createFileRepositoryReturning(99), $this->createFileStorage([]));
 
     $handler = $this->createHandler();
 
@@ -52,7 +54,7 @@ class FileHandlerTest extends TestCase {
    */
   public function testExpandHandlesArrayValueWithOverrides() {
     $path = $this->createTempFile('pdf');
-    $this->setFileRepositoryWithReturnId(42);
+    $this->setContainer($this->createFileRepositoryReturning(42), $this->createFileStorage([]));
 
     $handler = $this->createHandler();
 
@@ -66,6 +68,63 @@ class FileHandlerTest extends TestCase {
 
     $this->assertSame([
       ['target_id' => 42, 'display' => 0, 'description' => 'Spec sheet'],
+    ], $result);
+  }
+
+  /**
+   * Tests that an existing managed file is reused when looked up by filename.
+   */
+  public function testExpandReusesExistingManagedFileByFilename() {
+    $existing = $this->createFileEntity(7);
+    $this->setContainer(NULL, $this->createFileStorage([
+      'filename' => ['document.pdf' => $existing],
+    ]));
+
+    $handler = $this->createHandler();
+
+    $result = $handler->expand(['document.pdf']);
+
+    $this->assertSame([
+      ['target_id' => 7, 'display' => 1, 'description' => ''],
+    ], $result);
+  }
+
+  /**
+   * Tests that an existing managed file is reused when looked up by numeric id.
+   */
+  public function testExpandReusesExistingManagedFileByNumericId() {
+    $existing = $this->createFileEntity(11);
+    $this->setContainer(NULL, $this->createFileStorage([
+      'id' => [11 => $existing],
+    ]));
+
+    $handler = $this->createHandler();
+
+    $result = $handler->expand(['11']);
+
+    $this->assertSame([
+      ['target_id' => 11, 'display' => 1, 'description' => ''],
+    ], $result);
+  }
+
+  /**
+   * Tests that on-disk paths win over an entity that shares the filename.
+   */
+  public function testExpandPrefersFilesystemPathOverExistingFilename() {
+    $path = $this->createTempFile('pdf');
+    $existing = $this->createFileEntity(99);
+
+    $this->setContainer(
+      $this->createFileRepositoryReturning(123),
+      $this->createFileStorage(['filename' => [basename($path) => $existing]])
+    );
+
+    $handler = $this->createHandler();
+
+    $result = $handler->expand([$path]);
+
+    $this->assertSame([
+      ['target_id' => 123, 'display' => 1, 'description' => ''],
     ], $result);
   }
 
@@ -87,14 +146,95 @@ class FileHandlerTest extends TestCase {
   }
 
   /**
-   * Registers a mocked file.repository service returning a file with an ID.
+   * Builds a Drupal container with optional file.repository and file storage.
    *
-   * Uses inline anonymous classes because FileInterface and
-   * FileRepositoryInterface ship with the file module rather than drupal/core
-   * and are therefore not guaranteed to be autoloadable in isolation.
+   * Uses inline anonymous classes because FileInterface, FileRepositoryInterface
+   * and the file storage handler ship with the file module rather than
+   * drupal/core and are therefore not guaranteed to be autoloadable in
+   * isolation.
    */
-  protected function setFileRepositoryWithReturnId($file_id) {
-    $file = new class($file_id) {
+  protected function setContainer($file_repository, $file_storage) {
+    $entity_type_manager = new class($file_storage) {
+
+      public function __construct(private $file_storage) {}
+
+      /**
+       * Returns the stub file entity storage.
+       */
+      public function getStorage($entity_type_id) {
+        return $this->file_storage;
+      }
+
+    };
+
+    $container = new ContainerBuilder();
+
+    if ($file_repository !== NULL) {
+      $container->set('file.repository', $file_repository);
+    }
+    $container->set('entity_type.manager', $entity_type_manager);
+
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Creates a file.repository stub that returns a stored file with the given id.
+   */
+  protected function createFileRepositoryReturning($file_id) {
+    $file = $this->createFileEntity($file_id);
+
+    return new class($file) {
+
+      public function __construct(private $file) {}
+
+      /**
+       * Writes data to a destination and returns the stored file entity.
+       */
+      public function writeData($data, $destination) {
+        return $this->file;
+      }
+
+    };
+  }
+
+  /**
+   * Creates a file storage stub backed by id and filename indexes.
+   *
+   * @param array $index
+   *   ['id' => [<id> => <file>], 'filename' => [<name> => <file>]].
+   */
+  protected function createFileStorage(array $index) {
+    return new class($index) {
+
+      public function __construct(private array $index) {}
+
+      /**
+       * Loads a file entity by numeric id.
+       */
+      public function load($id) {
+        return $this->index['id'][$id] ?? NULL;
+      }
+
+      /**
+       * Loads file entities matching the given properties.
+       */
+      public function loadByProperties(array $properties) {
+        $name = $properties['filename'] ?? NULL;
+        if ($name !== NULL && isset($this->index['filename'][$name])) {
+          return [$this->index['filename'][$name]];
+        }
+
+        return [];
+      }
+
+    };
+  }
+
+  /**
+   * Creates a file entity stub with id() and save() methods.
+   */
+  protected function createFileEntity($file_id) {
+    return new class($file_id) {
 
       public function __construct(private $file_id) {}
 
@@ -112,23 +252,6 @@ class FileHandlerTest extends TestCase {
       }
 
     };
-
-    $repository = new class($file) {
-
-      public function __construct(private $file) {}
-
-      /**
-       * Writes data to a destination and returns the stored file entity.
-       */
-      public function writeData($data, $destination) {
-        return $this->file;
-      }
-
-    };
-
-    $container = new ContainerBuilder();
-    $container->set('file.repository', $repository);
-    \Drupal::setContainer($container);
   }
 
 }


### PR DESCRIPTION
## Summary

`FileHandler` in v2.5.0 (commit `951a75b`) was rewritten to always call `file_get_contents()` on the raw value, breaking every test suite that references an existing managed file by filename (e.g. `document.pdf`). Those callers received `Warning: file_get_contents(document.pdf): Failed to open stream: No such file or directory` because the bare filename was treated as a relative filesystem path rather than a reference to a pre-created managed file entity.

This fix restores compatibility with the v2.4.3 pattern while preserving the v2.5.0 ability to import brand-new files from disk. The handler now uses a filesystem-first, entity-fallback resolution order: if the value is a real path on disk it reads and imports the file; otherwise it looks up an existing managed file by numeric id or `filename` property; if neither resolves it throws a descriptive exception.

## Changes

### Source

- `src/Drupal/Driver/Fields/Drupal8/FileHandler.php` - rewrote `expand()` to delegate to a new `resolveTargetId()` helper; extracted `createFileFromPath()` (v2.5.0 import path) and `loadExistingManagedFile()` (v2.4.3 entity-lookup path) as protected helpers.

### Tests

- `tests/Drupal/Tests/Driver/Fields/Drupal8/FileHandlerTest.php` - added tests for lookup-by-filename, lookup-by-numeric-id, filesystem-path-wins-over-shared-filename, and descriptive-exception-on-unresolved-value; refactored container helpers into `setContainer()`, `createFileRepositoryReturning()`, `createFileStorage()`, and `createFileEntity()` to support both `file.repository` and `entity_type.manager`/file-storage stubs.

### Changelog

- `CHANGELOG.md` - added an `[Unreleased]` section with a `Fixed` entry describing the v2.5.0 regression and the resolution strategy.

## Before / After

```
v2.5.0 (broken)
================

 value (any)
     |
     v
 file_get_contents($value)
     |
     +-- FALSE --> Exception "Error reading file X."
     |
     +-- ok  --> writeData() --> save() --> target_id


After this fix (Option C: filesystem-first, entity-fallback)
=============================================================

 value
     |
     v
 is_file($value)?
     |
     +-- YES --> createFileFromPath()
     |               |
     |               +-- read fails  --> Exception
     |               +-- write fails --> Exception
     |               +-- ok          --> target_id (new entity)
     |
     +-- NO  --> loadExistingManagedFile()
                     |
                     +-- ctype_digit? --> storage->load(id)
                     |                       |
                     |                       +-- found --> target_id
                     |                       +-- NULL  --> try filename
                     |
                     +-- storage->loadByProperties(['filename' => value])
                             |
                             +-- found --> target_id (reused entity)
                             |
                             +-- NULL  --> Exception
                                          "Could not resolve file value ..."
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File handler now reuses existing managed files when referenced by filename or numeric ID, instead of failing with an error. File creation from disk paths remains available as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->