### PR TITLE
Tightened 'DrupalDriverInterface' contract and 'DrupalDriver' visibility.

### DIFF
--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -23,7 +23,7 @@ class DrupalDriver implements DrupalDriverInterface {
   /**
    * Drupal core object.
    */
-  public CoreInterface $core;
+  protected CoreInterface $core;
 
   /**
    * System path to the Drupal installation.
@@ -38,7 +38,7 @@ class DrupalDriver implements DrupalDriverInterface {
   /**
    * Drupal core version.
    */
-  public int $version;
+  protected int $version;
 
   /**
    * Set Drupal root and URI.
@@ -93,34 +93,10 @@ class DrupalDriver implements DrupalDriverInterface {
   }
 
   /**
-   * Determine major Drupal version.
-   *
-   * @return int
-   *   The major Drupal version.
-   *
-   * @throws \Drupal\Driver\Exception\BootstrapException
-   *   Thrown when the Drupal version could not be determined.
-   *
-   * @see drush_drupal_version()
+   * {@inheritdoc}
    */
   public function getDrupalVersion(): int {
     return $this->version;
-  }
-
-  /**
-   * Injects the active Core implementation.
-   *
-   * Consumers override the driver's default Core lookup by passing any
-   * class that implements 'CoreInterface' - the class name and namespace
-   * do not matter. Typically called in a test bootstrap when the project
-   * ships its own Core subclass (e.g. one that registers additional field
-   * handlers in its 'registerDefaultFieldHandlers()' override).
-   *
-   * @param \Drupal\Driver\Core\CoreInterface $core
-   *   The Core instance the driver should delegate to.
-   */
-  public function setCore(CoreInterface $core): void {
-    $this->core = $core;
   }
 
   /**
@@ -155,10 +131,17 @@ class DrupalDriver implements DrupalDriverInterface {
   }
 
   /**
-   * Return current core.
+   * {@inheritdoc}
    */
   public function getCore(): CoreInterface {
     return $this->core;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setCore(CoreInterface $core): void {
+    $this->core = $core;
   }
 
   /**

--- a/src/Drupal/Driver/DrupalDriverInterface.php
+++ b/src/Drupal/Driver/DrupalDriverInterface.php
@@ -17,6 +17,7 @@ use Drupal\Driver\Capability\ModuleCapabilityInterface;
 use Drupal\Driver\Capability\RoleCapabilityInterface;
 use Drupal\Driver\Capability\UserCapabilityInterface;
 use Drupal\Driver\Capability\WatchdogCapabilityInterface;
+use Drupal\Driver\Core\CoreInterface;
 
 /**
  * Contract for the full-featured Drupal driver.
@@ -39,5 +40,37 @@ interface DrupalDriverInterface extends
   RoleCapabilityInterface,
   UserCapabilityInterface,
   WatchdogCapabilityInterface {
+
+  /**
+   * Return current core.
+   */
+  public function getCore(): CoreInterface;
+
+  /**
+   * Injects the active Core implementation.
+   *
+   * Consumers override the driver's default Core lookup by passing any
+   * class that implements 'CoreInterface' - the class name and namespace
+   * do not matter. Typically called in a test bootstrap when the project
+   * ships its own Core subclass (e.g. one that registers additional field
+   * handlers in its 'registerDefaultFieldHandlers()' override).
+   *
+   * @param \Drupal\Driver\Core\CoreInterface $core
+   *   The Core instance the driver should delegate to.
+   */
+  public function setCore(CoreInterface $core): void;
+
+  /**
+   * Returns the major Drupal version detected at construction time.
+   *
+   * The version is captured once when the driver is instantiated; the
+   * detection itself may throw BootstrapException, but this getter does not.
+   *
+   * @return int
+   *   The major Drupal version.
+   *
+   * @see drush_drupal_version()
+   */
+  public function getDrupalVersion(): int;
 
 }

--- a/tests/Drupal/Tests/Driver/Unit/CoreLookupTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/CoreLookupTest.php
@@ -75,7 +75,8 @@ class CoreLookupTest extends TestCase {
     $uri_prop = $reflection->getProperty('uri');
     $uri_prop->setValue($driver, 'default');
 
-    $driver->version = $version;
+    $version_property = $reflection->getProperty('version');
+    $version_property->setValue($driver, $version);
 
     return $driver;
   }

--- a/tests/Drupal/Tests/Driver/Unit/DrupalDriverDelegationTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/DrupalDriverDelegationTest.php
@@ -202,8 +202,10 @@ class DrupalDriverDelegationTest extends TestCase {
     $uri = $reflection->getProperty('uri');
     $uri->setValue($driver, 'default');
 
-    $driver->version = $version;
-    $driver->core = $core;
+    $version_property = $reflection->getProperty('version');
+    $version_property->setValue($driver, $version);
+
+    $driver->setCore($core);
 
     return $driver;
   }


### PR DESCRIPTION
## Summary

Tightens the `DrupalDriverInterface` contract so consumers can type-hint against the interface and call `getCore()`, `setCore()`, and `getDrupalVersion()` without downcasting to the concrete class. Makes `$core` and `$version` on `DrupalDriver` `protected` so subclasses retain access while outside callers are directed through the public API. Corrects the `@throws BootstrapException` annotation on `getDrupalVersion()` - the exception is raised during construction inside `detectMajorVersion()`, not by the getter itself.

## Stack

This PR is **#1 of 4** in a stacked series:

- **PR 1 (this one):** `feature/driver-interface` → `master`
- **PR 2:** `feature/field-classifier` → `feature/driver-interface`
- **PR 3:** `feature/field-coverage` → `feature/field-classifier`
- **PR 4:** `feature/ext-smoke-ci` → `feature/field-coverage`

Merge PRs in order. Each PR's base will rebase to `master` automatically as its predecessor merges.

## Changes

- Declares `getCore()`, `setCore()`, and `getDrupalVersion()` on `DrupalDriverInterface` so the full driver contract is visible at the interface level.
- Makes `$core` and `$version` properties `protected` on `DrupalDriver`; subclasses can read them, but external callers must use the public methods.
- Corrects the `@throws BootstrapException` annotation on `getDrupalVersion()`: the exception originates in `detectMajorVersion()` at construction time, not in the getter. The updated docblock on the interface makes this distinction clear.

## Before / After

```
Before                              After
------                              -----
DrupalDriverInterface               DrupalDriverInterface
  (no getCore / setCore /             + getCore(): CoreInterface
   getDrupalVersion declared)         + setCore(CoreInterface): void
                                      + getDrupalVersion(): int

DrupalDriver                        DrupalDriver
  public $core                        protected $core
  public $version                     protected $version
  getDrupalVersion()                  getDrupalVersion()
    @throws BootstrapException          (no @throws - exception
                                         is raised at construction)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal property encapsulation in the DrupalDriver class
  * Expanded DrupalDriverInterface to include core delegation and version introspection methods

* **Tests**
  * Updated unit tests to align with internal property visibility changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->