### PR TITLE
Added 'DrupalExtension' downstream smoke check job to CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,15 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 env:
   CI_COVERAGE_THRESHOLD: '95'
+  # DrupalExtension repo/ref used by the 'extension' job to verify that the
+  # downstream consumer still works against this DrupalDriver HEAD. Override
+  # DRUPALEXTENSION_REF to target a branch with pending API compatibility changes.
+  DRUPALEXTENSION_REPO: jhedstrom/drupalextension
+  DRUPALEXTENSION_REF: feature/drupal-driver-3x
 
 jobs:
   lint:
@@ -194,3 +200,61 @@ jobs:
           path: .logs
           include-hidden-files: true
           if-no-files-found: ignore
+
+  extension:
+    name: DrupalExtension smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout DrupalDriver
+        uses: actions/checkout@v6
+        with:
+          path: drupaldriver
+
+      - name: Checkout DrupalExtension
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.DRUPALEXTENSION_REPO }}
+          ref: ${{ env.DRUPALEXTENSION_REF }}
+          path: drupalextension
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v5
+        with:
+          path: /tmp/composer-cache
+          key: extension-${{ runner.os }}-${{ hashFiles('drupalextension/composer.json') }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: gd, pdo_sqlite
+          coverage: pcov
+
+      - name: Add path repository for DrupalDriver
+        working-directory: drupalextension
+        run: composer config repositories.drupaldriver path ../drupaldriver
+
+      - name: Require local DrupalDriver
+        working-directory: drupalextension
+        run: composer require --no-interaction --no-update 'drupal/drupal-driver:*'
+
+      - name: Install DrupalExtension dependencies
+        working-directory: drupalextension
+        run: composer update --no-interaction --no-progress --with-all-dependencies
+
+      - name: Verify DrupalDriver resolved to the local path copy
+        working-directory: drupalextension
+        run: composer show drupal/drupal-driver
+
+      # BrowserKitFactoryTest mocks getCwd() to '/var/www/html/build' and calls
+      # DrupalFinder on it. Symlink that path to the DrupalExtension checkout
+      # so DrupalFinder locates 'build/web/core' via composer.json scaffolding.
+      - name: Symlink expected Drupal root for BrowserKitFactoryTest
+        run: sudo ln -sfn "${GITHUB_WORKSPACE}/drupalextension" /var/www/html/build
+
+      - name: Run DrupalExtension PHPUnit
+        working-directory: drupalextension
+        run: vendor/bin/phpunit


### PR DESCRIPTION
## Summary

Adds an `extension` job to the CI workflow that runs `jhedstrom/drupalextension`'s own PHPUnit suite against the current DrupalDriver HEAD on every PR and push to `master`. The job checks out DrupalExtension at a configurable ref, injects the local DrupalDriver source via a Composer path repository, then runs the consumer's tests - failing the build if any break. This catches driver regressions that would otherwise only surface after the downstream consumer picks up a release. Two prerequisite steps are included: `pcov` coverage is enabled (DrupalExtension's `phpunit.xml` has `failOnWarning` and would fail on a missing-coverage-driver warning), and a symlink at `/var/www/html/build` is created for `BrowserKitFactoryTest`, which hardcodes that path when calling DrupalFinder.

## Stack

This PR is **#4 of 4** in a stacked series:

- **PR 1:** `feature/driver-interface` -> `master` (#358)
- **PR 2:** `feature/field-classifier` -> `feature/driver-interface` (#359)
- **PR 3:** `feature/field-coverage` -> `feature/field-classifier` (#360)
- **PR 4 (this one):** `feature/ext-smoke-ci` -> `feature/field-coverage`

Merge LAST. Depends on #360 - without the field-handler fixes in that PR, DrupalExtension's PHPUnit fails because `text_long`/`text`/`file` regressions break consumer tests.

## Changes

- New `extension` job that checks out DrupalExtension and installs it with the local DrupalDriver injected via a Composer path repository
- `pcov` coverage driver enabled in PHP setup so DrupalExtension's `failOnWarning` does not abort the run
- Symlink step creating `/var/www/html/build` -> `drupalextension` checkout for `BrowserKitFactoryTest`
- `DRUPALEXTENSION_REPO` / `DRUPALEXTENSION_REF` env vars at the top of the workflow file make the consumer target fully configurable without a code change
- `workflow_dispatch:` trigger added so the job can be manually re-run against a different consumer ref

## Before / After

```
Before:  lint  |  tests (PHP 8.2/8.3/8.4 x Drupal 10/11)
After:   lint  |  tests (PHP 8.2/8.3/8.4 x Drupal 10/11)  |  extension (smoke)
```
