### PR TITLE
[#362] Replaced 'stdClass' entity stubs with typed 'EntityStub' class.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   # downstream consumer still works against this DrupalDriver HEAD. Override
   # DRUPALEXTENSION_REF to target a branch with pending API compatibility changes.
   DRUPALEXTENSION_REPO: jhedstrom/drupalextension
-  DRUPALEXTENSION_REF: feature/drupal-driver-3x
+  DRUPALEXTENSION_REF: feature/337-entity-stub
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   # downstream consumer still works against this DrupalDriver HEAD. Override
   # DRUPALEXTENSION_REF to target a branch with pending API compatibility changes.
   DRUPALEXTENSION_REPO: jhedstrom/drupalextension
-  DRUPALEXTENSION_REF: feature/337-entity-stub
+  DRUPALEXTENSION_REF: main
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,11 @@ jobs:
       - name: Checkout DrupalDriver
         uses: actions/checkout@v6
         with:
+          # Check out the branch by name (not the merge SHA) so the path
+          # repo composer adds below presents the package as
+          # 'dev-<branch>', matching the dev-branch constraint that the
+          # downstream DrupalExtension branch pins for this PR.
+          ref: ${{ github.head_ref || github.ref_name }}
           path: drupaldriver
 
       - name: Checkout DrupalExtension
@@ -236,14 +241,6 @@ jobs:
       - name: Add path repository for DrupalDriver
         working-directory: drupalextension
         run: composer config repositories.drupaldriver path ../drupaldriver
-
-      - name: Allow dev stability for the local DrupalDriver path repo
-        working-directory: drupalextension
-        run: composer config minimum-stability dev
-
-      - name: Require local DrupalDriver
-        working-directory: drupalextension
-        run: composer require --no-interaction --no-update 'drupal/drupal-driver:*@dev'
 
       - name: Install DrupalExtension dependencies
         working-directory: drupalextension

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,9 +237,13 @@ jobs:
         working-directory: drupalextension
         run: composer config repositories.drupaldriver path ../drupaldriver
 
+      - name: Allow dev stability for the local DrupalDriver path repo
+        working-directory: drupalextension
+        run: composer config minimum-stability dev
+
       - name: Require local DrupalDriver
         working-directory: drupalextension
-        run: composer require --no-interaction --no-update 'drupal/drupal-driver:*'
+        run: composer require --no-interaction --no-update 'drupal/drupal-driver:*@dev'
 
       - name: Install DrupalExtension dependencies
         working-directory: drupalextension

--- a/src/Drupal/Driver/Capability/AuthenticationCapabilityInterface.php
+++ b/src/Drupal/Driver/Capability/AuthenticationCapabilityInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\Driver\Capability;
 
+use Drupal\Driver\Entity\EntityStubInterface;
+
 /**
  * Capability: authenticate users on the backend.
  */
@@ -12,10 +14,11 @@ interface AuthenticationCapabilityInterface {
   /**
    * Logs a user in.
    *
-   * @param \stdClass $user
-   *   The user to log in.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The user stub. Either the saved-entity slot or a 'uid' value must be
+   *   populated so the driver can resolve the account.
    */
-  public function login(\stdClass $user): void;
+  public function login(EntityStubInterface $stub): void;
 
   /**
    * Logs the current user out.

--- a/src/Drupal/Driver/Capability/BlockCapabilityInterface.php
+++ b/src/Drupal/Driver/Capability/BlockCapabilityInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\Driver\Capability;
 
+use Drupal\Driver\Entity\EntityStubInterface;
+
 /**
  * Capability: place blocks and create content blocks.
  *
@@ -26,49 +28,50 @@ interface BlockCapabilityInterface {
   /**
    * Places a block in a region.
    *
-   * @param \stdClass $block
-   *   Block placement stub. Properties mirror the 'block' config entity's
-   *   keys: 'id' (machine name of the placement; auto-generated when
-   *   absent), 'plugin' (block plugin id, e.g. 'system_powered_by_block'
-   *   or 'block_content:<uuid>'), 'theme', 'region', 'weight', 'settings',
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   Block placement stub. Values mirror the 'block' config entity's keys:
+   *   'id' (machine name of the placement; auto-generated when absent),
+   *   'plugin' (block plugin id, e.g. 'system_powered_by_block' or
+   *   'block_content:<uuid>'), 'theme', 'region', 'weight', 'settings',
    *   'visibility', 'status'.
    *
-   * @return object
-   *   The saved 'block' config entity. The stub is mutated so that its
-   *   'id' property holds the resolved placement id, matching the
-   *   'nodeCreate'/'termCreate' mutation convention.
+   * @return \Drupal\Driver\Entity\EntityStubInterface
+   *   The same stub, now flagged as saved with the placement attached. The
+   *   resolved id is also written back onto the stub's values bag under
+   *   the 'id' key.
    */
-  public function blockPlace(\stdClass $block): object;
+  public function blockPlace(EntityStubInterface $stub): EntityStubInterface;
 
   /**
    * Removes a placed block.
    *
-   * @param object $block
-   *   The block placement to delete. May be the stub returned by
-   *   'blockPlace()' (needs an 'id' property) or a loaded 'block' entity.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The stub returned by 'blockPlace()', or one that carries an 'id'
+   *   value resolving to an existing block placement.
    */
-  public function blockDelete(object $block): void;
+  public function blockDelete(EntityStubInterface $stub): void;
 
   /**
    * Creates a content block.
    *
-   * @param \stdClass $block_content
-   *   Content block stub. The 'type' property selects the block-content
-   *   bundle; remaining properties map to fields on that bundle ('info',
-   *   'body', custom fields, etc.).
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   Content block stub. The 'bundle' property selects the block-content
+   *   bundle; values map to fields on that bundle ('info', 'body', custom
+   *   fields, etc.).
    *
-   * @return object
-   *   The saved 'block_content' entity.
+   * @return \Drupal\Driver\Entity\EntityStubInterface
+   *   The same stub, now flagged as saved with the saved 'block_content'
+   *   entity attached.
    */
-  public function blockContentCreate(\stdClass $block_content): object;
+  public function blockContentCreate(EntityStubInterface $stub): EntityStubInterface;
 
   /**
    * Deletes a content block.
    *
-   * @param object $block_content
-   *   The content block to delete. May be the stub returned by
-   *   'blockContentCreate()' or a loaded 'block_content' entity.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The stub returned by 'blockContentCreate()', or one that carries
+   *   the entity type's id key resolving to an existing content block.
    */
-  public function blockContentDelete(object $block_content): void;
+  public function blockContentDelete(EntityStubInterface $stub): void;
 
 }

--- a/src/Drupal/Driver/Capability/ContentCapabilityInterface.php
+++ b/src/Drupal/Driver/Capability/ContentCapabilityInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\Driver\Capability;
 
+use Drupal\Driver\Entity\EntityStubInterface;
+
 /**
  * Capability: create and delete content (nodes, terms, generic entities).
  */
@@ -12,65 +14,65 @@ interface ContentCapabilityInterface {
   /**
    * Creates a node.
    *
-   * @param \stdClass $node
-   *   The node stub.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The node stub. The bundle property selects the node type.
    *
-   * @return object
-   *   The created node, with its identifier populated.
+   * @return \Drupal\Driver\Entity\EntityStubInterface
+   *   The same stub, now flagged as saved with the created node attached.
    */
-  public function nodeCreate(\stdClass $node): object;
+  public function nodeCreate(EntityStubInterface $stub): EntityStubInterface;
 
   /**
    * Deletes a node.
    *
-   * @param object $node
-   *   The node to delete.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The stub returned from a previous 'nodeCreate()' call, or one that
+   *   carries a 'nid' value resolving to an existing node.
    */
-  public function nodeDelete(object $node): void;
+  public function nodeDelete(EntityStubInterface $stub): void;
 
   /**
    * Creates a taxonomy term.
    *
-   * @param \stdClass $term
-   *   The term stub.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The term stub. The bundle property selects the vocabulary.
    *
-   * @return object
-   *   The created term, with its identifier populated.
+   * @return \Drupal\Driver\Entity\EntityStubInterface
+   *   The same stub, now flagged as saved with the created term attached.
    */
-  public function termCreate(\stdClass $term): object;
+  public function termCreate(EntityStubInterface $stub): EntityStubInterface;
 
   /**
    * Deletes a taxonomy term.
    *
-   * @param object $term
-   *   The term stub or loaded term entity to delete.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The stub returned from a previous 'termCreate()' call, or one that
+   *   carries a 'tid' value resolving to an existing term.
    *
    * @return bool
    *   TRUE when the term was deleted.
    */
-  public function termDelete(object $term): bool;
+  public function termDelete(EntityStubInterface $stub): bool;
 
   /**
-   * Creates an entity of a given type.
+   * Creates an entity of any type.
    *
-   * @param string $entity_type
-   *   The entity type ID.
-   * @param \stdClass $entity
-   *   The entity stub.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The entity stub. The 'entity_type' property selects the storage and
+   *   the 'bundle' property selects the bundle.
    *
-   * @return object
-   *   The created entity.
+   * @return \Drupal\Driver\Entity\EntityStubInterface
+   *   The same stub, now flagged as saved with the created entity attached.
    */
-  public function entityCreate(string $entity_type, \stdClass $entity): object;
+  public function entityCreate(EntityStubInterface $stub): EntityStubInterface;
 
   /**
-   * Deletes an entity of a given type.
+   * Deletes an entity of any type.
    *
-   * @param string $entity_type
-   *   The entity type ID.
-   * @param object $entity
-   *   The entity stub or loaded entity to delete.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The stub returned from a previous 'entityCreate()' call, or one that
+   *   carries the entity type's id key resolving to an existing entity.
    */
-  public function entityDelete(string $entity_type, object $entity): void;
+  public function entityDelete(EntityStubInterface $stub): void;
 
 }

--- a/src/Drupal/Driver/Capability/ContentCapabilityInterface.php
+++ b/src/Drupal/Driver/Capability/ContentCapabilityInterface.php
@@ -58,8 +58,9 @@ interface ContentCapabilityInterface {
    * Creates an entity of any type.
    *
    * @param \Drupal\Driver\Entity\EntityStubInterface $stub
-   *   The entity stub. The 'entity_type' property selects the storage and
-   *   the 'bundle' property selects the bundle.
+   *   The entity stub. Its typed entity type (via 'getEntityType()') selects
+   *   the storage, and its typed bundle (via 'getBundle()') selects the
+   *   bundle. The values bag carries base properties and field values.
    *
    * @return \Drupal\Driver\Entity\EntityStubInterface
    *   The same stub, now flagged as saved with the created entity attached.

--- a/src/Drupal/Driver/Capability/LanguageCapabilityInterface.php
+++ b/src/Drupal/Driver/Capability/LanguageCapabilityInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\Driver\Capability;
 
+use Drupal\Driver\Entity\EntityStubInterface;
+
 /**
  * Capability: create and delete languages.
  */
@@ -12,20 +14,20 @@ interface LanguageCapabilityInterface {
   /**
    * Creates a language.
    *
-   * @param \stdClass $language
-   *   Object with at least a `langcode` property.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   Language stub. Must carry a 'langcode' value.
    *
-   * @return \stdClass|false
-   *   The language object, or FALSE if the language already exists.
+   * @return \Drupal\Driver\Entity\EntityStubInterface|false
+   *   The saved stub, or FALSE if the language already exists.
    */
-  public function languageCreate(\stdClass $language): \stdClass|false;
+  public function languageCreate(EntityStubInterface $stub): EntityStubInterface|false;
 
   /**
    * Deletes a language.
    *
-   * @param \stdClass $language
-   *   Object with at least a `langcode` property.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   Language stub. Must carry a 'langcode' value.
    */
-  public function languageDelete(\stdClass $language): void;
+  public function languageDelete(EntityStubInterface $stub): void;
 
 }

--- a/src/Drupal/Driver/Capability/UserCapabilityInterface.php
+++ b/src/Drupal/Driver/Capability/UserCapabilityInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\Driver\Capability;
 
+use Drupal\Driver\Entity\EntityStubInterface;
+
 /**
  * Capability: create, delete, and assign roles to users.
  */
@@ -12,27 +14,29 @@ interface UserCapabilityInterface {
   /**
    * Creates a user.
    *
-   * @param \stdClass $user
-   *   The user to create.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The user stub. The driver writes the resolved 'uid' back onto the
+   *   stub and marks it saved with the created account.
    */
-  public function userCreate(\stdClass $user): void;
+  public function userCreate(EntityStubInterface $stub): void;
 
   /**
    * Deletes a user.
    *
-   * @param \stdClass $user
-   *   The user to delete.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The stub returned from a previous 'userCreate()' call, or one that
+   *   carries a 'uid' value resolving to an existing user.
    */
-  public function userDelete(\stdClass $user): void;
+  public function userDelete(EntityStubInterface $stub): void;
 
   /**
    * Adds a role to a user.
    *
-   * @param \stdClass $user
-   *   The user to grant the role to.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The user stub.
    * @param string $role
    *   The role machine name or label.
    */
-  public function userAddRole(\stdClass $user, string $role): void;
+  public function userAddRole(EntityStubInterface $stub, string $role): void;
 
 }

--- a/src/Drupal/Driver/Core/Core.php
+++ b/src/Drupal/Driver/Core/Core.php
@@ -915,7 +915,7 @@ class Core implements CoreInterface {
    * {@inheritdoc}
    */
   public function languageCreate(EntityStubInterface $stub): EntityStubInterface|false {
-    $langcode = $stub->getValue('langcode');
+    $langcode = $this->resolveLangcode($stub);
 
     // Enable a language only if it has not been enabled already.
     if (ConfigurableLanguage::load($langcode)) {
@@ -933,8 +933,32 @@ class Core implements CoreInterface {
    * {@inheritdoc}
    */
   public function languageDelete(EntityStubInterface $stub): void {
-    $configurable_language = ConfigurableLanguage::load($stub->getValue('langcode'));
+    $langcode = $this->resolveLangcode($stub);
+    $configurable_language = ConfigurableLanguage::load($langcode);
+
+    if (!$configurable_language instanceof ConfigurableLanguage) {
+      throw new \InvalidArgumentException(sprintf('Cannot delete language "%s" because it does not exist.', $langcode));
+    }
+
     $configurable_language->delete();
+  }
+
+  /**
+   * Returns a non-empty langcode string from the stub or throws.
+   *
+   * Centralises the input validation so 'languageCreate()' and
+   * 'languageDelete()' fail loudly with the same message rather than
+   * passing 'NULL'/'""' through to Drupal's storage layer where they would
+   * surface as opaque storage errors.
+   */
+  protected function resolveLangcode(EntityStubInterface $stub): string {
+    $langcode = $stub->getValue('langcode');
+
+    if (!is_string($langcode) || $langcode === '') {
+      throw new \InvalidArgumentException('Cannot operate on a language without a non-empty "langcode" value.');
+    }
+
+    return $langcode;
   }
 
   /**
@@ -1028,7 +1052,9 @@ class Core implements CoreInterface {
 
       // Fail loudly if the stub does not carry the resolved id key. Without
       // this guard a missing property would silently call storage->load(NULL)
-      // - the delete would appear to succeed while doing nothing.
+      // - 'hasValue()' is intentionally not enough here because a stored NULL
+      // would still pass the "is set" check while triggering a Drupal
+      // assertion error inside 'EntityStorageBase::load()'.
       if (!is_string($id_key) || !$stub->hasValue($id_key)) {
         throw new \InvalidArgumentException(sprintf(
           'Cannot delete an entity of type "%s" from a stub without the id key "%s" set.',
@@ -1037,7 +1063,17 @@ class Core implements CoreInterface {
         ));
       }
 
-      $entity = \Drupal::entityTypeManager()->getStorage($entity_type)->load($stub->getValue($id_key));
+      $id = $stub->getValue($id_key);
+
+      if ((!is_int($id) && !is_string($id)) || $id === '') {
+        throw new \InvalidArgumentException(sprintf(
+          'Cannot delete an entity of type "%s" from a stub with an empty id key "%s".',
+          $entity_type,
+          $id_key,
+        ));
+      }
+
+      $entity = \Drupal::entityTypeManager()->getStorage($entity_type)->load($id);
     }
 
     if ($entity instanceof EntityInterface) {

--- a/src/Drupal/Driver/Core/Core.php
+++ b/src/Drupal/Driver/Core/Core.php
@@ -14,6 +14,7 @@ use Drupal\Driver\Core\Field\DefaultHandler;
 use Drupal\Driver\Core\Field\FieldClassifier;
 use Drupal\Driver\Core\Field\FieldClassifierInterface;
 use Drupal\Driver\Core\Field\FieldHandlerInterface;
+use Drupal\Driver\Entity\EntityStubInterface;
 use Drupal\Driver\Exception\BootstrapException;
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\mailsystem\MailsystemManager;
@@ -209,8 +210,8 @@ class Core implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function getFieldHandler(object $entity, string $entity_type, string $field_name): FieldHandlerInterface {
-    $bundle = $this->resolveBundleFromEntity($entity_type, $entity);
+  public function getFieldHandler(EntityStubInterface $stub, string $entity_type, string $field_name): FieldHandlerInterface {
+    $bundle = $this->resolveBundle($stub);
     $field_types = $this->getEntityFieldTypes($entity_type, $bundle);
 
     if (!isset($field_types[$field_name])) {
@@ -219,18 +220,17 @@ class Core implements CoreInterface {
 
     $class = $this->fieldHandlers[$field_types[$field_name]] ?? DefaultHandler::class;
 
-    return new $class($entity, $entity_type, $field_name);
+    return new $class($stub, $entity_type, $field_name);
   }
 
   /**
-   * Expands properties on the given entity object to the expected structure.
+   * Expands values on the given stub through the field-handler pipeline.
    *
-   * @param string $entity_type
-   *   The entity type ID.
-   * @param \stdClass $entity
-   *   Entity object.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   Stub whose values bag will be mutated in place.
    */
-  protected function expandEntityFields(string $entity_type, \stdClass $entity): void {
+  protected function expandEntityFields(EntityStubInterface $stub): void {
+    $entity_type = $stub->getEntityType();
     $definition = $this->loadEntityTypeDefinition($entity_type);
 
     // The id key and bundle key identify the record itself and must not pass
@@ -241,7 +241,7 @@ class Core implements CoreInterface {
     // subsequent bundle lookup for the same stub.
     $skip = array_filter([$definition->getKey('id'), $definition->getKey('bundle')]);
 
-    $bundle = $this->resolveBundleFromEntity($entity_type, $entity);
+    $bundle = $this->resolveBundle($stub);
     $field_types = $this->getEntityFieldTypes($entity_type, $bundle);
 
     foreach (array_keys($field_types) as $field_name) {
@@ -249,41 +249,41 @@ class Core implements CoreInterface {
         continue;
       }
 
-      if (isset($entity->$field_name)) {
-        $entity->$field_name = $this->getFieldHandler($entity, $entity_type, $field_name)
-          ->expand($entity->$field_name);
+      if (!$stub->hasValue($field_name)) {
+        continue;
       }
+
+      $expanded = $this->getFieldHandler($stub, $entity_type, $field_name)
+        ->expand($stub->getValue($field_name));
+      $stub->setValue($field_name, $expanded);
     }
   }
 
   /**
    * Resolves the bundle for an entity stub.
    *
-   * Consults the entity type's bundle key first, then 'step_bundle', then
-   * falls back to the entity type id (single-bundle entities like 'user'
-   * use the type id as their bundle).
+   * Consults the entity type's bundle key in the values bag first, then the
+   * typed 'bundle' constructor argument, then falls back to the entity type
+   * id (single-bundle entities like 'user' use the type id as their bundle).
    *
-   * @param string $entity_type
-   *   The entity type ID.
-   * @param object $entity
-   *   Entity stub.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The stub.
    *
    * @return string
    *   Bundle name. Never empty.
    */
-  protected function resolveBundleFromEntity(string $entity_type, object $entity): string {
-    $definition = $this->loadEntityTypeDefinition($entity_type);
-    $bundle_key = $definition->getKey('bundle');
+  protected function resolveBundle(EntityStubInterface $stub): string {
+    $bundle_key = $this->loadEntityTypeDefinition($stub->getEntityType())->getKey('bundle');
 
-    if ($bundle_key && !empty($entity->$bundle_key)) {
-      return (string) $entity->$bundle_key;
+    if ($bundle_key && $stub->hasValue($bundle_key) && !empty($stub->getValue($bundle_key))) {
+      return (string) $stub->getValue($bundle_key);
     }
 
-    if (isset($entity->step_bundle) && $entity->step_bundle !== '') {
-      return (string) $entity->step_bundle;
+    if ($stub->getBundle() !== NULL && $stub->getBundle() !== '') {
+      return $stub->getBundle();
     }
 
-    return $entity_type;
+    return $stub->getEntityType();
   }
 
   /**
@@ -361,10 +361,10 @@ class Core implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function nodeCreate(\stdClass $node): object {
-    // Throw an exception if the node type is missing or does not exist.
-    /** @var \stdClass $node */
-    if (!isset($node->type) || !$node->type) {
+  public function nodeCreate(EntityStubInterface $stub): EntityStubInterface {
+    $type = $stub->getBundle() ?? $stub->getValue('type');
+
+    if (empty($type)) {
       throw new \Exception("Cannot create content because it is missing the required property 'type'.");
     }
 
@@ -372,34 +372,47 @@ class Core implements CoreInterface {
     $bundle_info = \Drupal::service('entity_type.bundle.info');
     $bundles = $bundle_info->getBundleInfo('node');
 
-    if (!in_array($node->type, array_keys($bundles))) {
-      throw new \Exception(sprintf('Cannot create content because provided content type %s does not exist.', $node->type));
+    if (!in_array($type, array_keys($bundles))) {
+      throw new \Exception(sprintf('Cannot create content because provided content type %s does not exist.', $type));
+    }
+
+    // 'Node::create()' reads the bundle from the 'type' values key, so make
+    // sure it carries the resolved bundle even when the caller only set it
+    // through the typed 'bundle' constructor argument.
+    if (!$stub->hasValue('type')) {
+      $stub->setValue('type', $type);
     }
 
     // If 'author' is set, remap it to 'uid'.
-    if (isset($node->author)) {
+    if ($stub->hasValue('author')) {
       /** @var \Drupal\user\Entity\User|null $user */
-      $user = user_load_by_name($node->author);
+      $user = user_load_by_name($stub->getValue('author'));
 
       if ($user) {
-        $node->uid = $user->id();
+        $stub->setValue('uid', $user->id());
       }
     }
 
-    $this->expandEntityFields('node', $node);
-    $entity = Node::create((array) $node);
+    $this->expandEntityFields($stub);
+    $entity = Node::create($stub->getValues());
     $entity->save();
 
-    $node->nid = $entity->id();
+    $stub->setValue('nid', $entity->id());
+    $stub->markSaved($entity);
 
-    return $node;
+    return $stub;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function nodeDelete(object $node): void {
-    $node = $node instanceof NodeInterface ? $node : Node::load($node->nid);
+  public function nodeDelete(EntityStubInterface $stub): void {
+    $node = $stub->isSaved() ? $stub->getSavedEntity() : NULL;
+
+    if (!$node instanceof NodeInterface) {
+      $node = Node::load($stub->getValue('nid'));
+    }
+
     if ($node instanceof NodeInterface) {
       $node->delete();
     }
@@ -501,18 +514,19 @@ class Core implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function userCreate(\stdClass $user): void {
+  public function userCreate(EntityStubInterface $stub): void {
     // Default status to TRUE if not explicitly creating a blocked user.
-    if (!isset($user->status)) {
-      $user->status = 1;
+    if (!$stub->hasValue('status')) {
+      $stub->setValue('status', 1);
     }
 
-    $this->expandEntityFields('user', $user);
-    $account = \Drupal::entityTypeManager()->getStorage('user')->create((array) $user);
+    $this->expandEntityFields($stub);
+    $account = \Drupal::entityTypeManager()->getStorage('user')->create($stub->getValues());
     $account->save();
 
-    // Store UID.
-    $user->uid = $account->id();
+    // Store UID and the saved account.
+    $stub->setValue('uid', $account->id());
+    $stub->markSaved($account);
   }
 
   /**
@@ -621,8 +635,8 @@ class Core implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function userDelete(\stdClass $user): void {
-    user_cancel([], $user->uid, 'user_cancel_delete');
+  public function userDelete(EntityStubInterface $stub): void {
+    user_cancel([], $this->resolveUid($stub), 'user_cancel_delete');
     // user_cancel() schedules the deletion via batch; drive the batch to
     // completion so callers see synchronous deletion.
     $this->processBatch();
@@ -631,7 +645,7 @@ class Core implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function userAddRole(\stdClass $user, string $role): void {
+  public function userAddRole(EntityStubInterface $stub, string $role): void {
     // Allow both machine and human role names.
     $query = \Drupal::entityQuery('user_role');
     $conditions = $query->orConditionGroup()
@@ -643,9 +657,20 @@ class Core implements CoreInterface {
       throw new \RuntimeException(sprintf('No role "%s" exists.', $role));
     }
 
-    $account = User::load($user->uid);
+    $account = User::load($this->resolveUid($stub));
     $account->addRole(reset($rids));
     $account->save();
+  }
+
+  /**
+   * Resolves the user id from a stub.
+   *
+   * Prefers the saved-entity slot - that is the only authoritative source
+   * after 'userCreate()' - then falls back to a 'uid' value the caller may
+   * have populated manually.
+   */
+  protected function resolveUid(EntityStubInterface $stub): int|string|null {
+    return $stub->getId() ?? $stub->getValue('uid');
   }
 
   /**
@@ -707,46 +732,53 @@ class Core implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function termCreate(\stdClass $term): \stdClass {
-    if (empty($term->vocabulary_machine_name)) {
+  public function termCreate(EntityStubInterface $stub): EntityStubInterface {
+    $vocabulary = $stub->getBundle() ?? $stub->getValue('vocabulary_machine_name');
+
+    if (empty($vocabulary)) {
       throw new \InvalidArgumentException("Cannot create term because it is missing the required property 'vocabulary_machine_name'.");
     }
 
-    if (Vocabulary::load($term->vocabulary_machine_name) === NULL) {
-      throw new \InvalidArgumentException(sprintf("Cannot create term because vocabulary '%s' does not exist.", $term->vocabulary_machine_name));
+    if (Vocabulary::load($vocabulary) === NULL) {
+      throw new \InvalidArgumentException(sprintf("Cannot create term because vocabulary '%s' does not exist.", $vocabulary));
     }
 
-    $term->vid = $term->vocabulary_machine_name;
+    $stub->setValue('vid', $vocabulary);
 
-    if (!empty($term->parent)) {
-      $parent_name = $term->parent;
+    if ($stub->hasValue('parent') && !empty($stub->getValue('parent'))) {
+      $parent_name = $stub->getValue('parent');
       $parent_terms = \Drupal::entityQuery('taxonomy_term')
         ->accessCheck(FALSE)
         ->condition('name', $parent_name)
-        ->condition('vid', $term->vocabulary_machine_name)
+        ->condition('vid', $vocabulary)
         ->execute();
 
       if (empty($parent_terms)) {
-        throw new \InvalidArgumentException(sprintf("Cannot create term because parent term '%s' does not exist in vocabulary '%s'.", $parent_name, $term->vocabulary_machine_name));
+        throw new \InvalidArgumentException(sprintf("Cannot create term because parent term '%s' does not exist in vocabulary '%s'.", $parent_name, $vocabulary));
       }
 
-      $term->parent = reset($parent_terms);
+      $stub->setValue('parent', reset($parent_terms));
     }
 
-    $this->expandEntityFields('taxonomy_term', $term);
-    $entity = Term::create((array) $term);
+    $this->expandEntityFields($stub);
+    $entity = Term::create($stub->getValues());
     $entity->save();
 
-    $term->tid = $entity->id();
+    $stub->setValue('tid', $entity->id());
+    $stub->markSaved($entity);
 
-    return $term;
+    return $stub;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function termDelete(object $term): bool {
-    $term = $term instanceof TermInterface ? $term : Term::load($term->tid);
+  public function termDelete(EntityStubInterface $stub): bool {
+    $term = $stub->isSaved() ? $stub->getSavedEntity() : NULL;
+
+    if (!$term instanceof TermInterface) {
+      $term = Term::load($stub->getValue('tid'));
+    }
 
     if (!$term instanceof TermInterface) {
       return FALSE;
@@ -760,49 +792,54 @@ class Core implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function blockPlace(\stdClass $block): object {
+  public function blockPlace(EntityStubInterface $stub): EntityStubInterface {
     // Generate a placement id when the caller did not supply one, matching
     // the 'nodeCreate'/'roleCreate' convention of tolerating ID-less stubs.
     // Block config entities require an id, so we must fill it before save.
-    if (!isset($block->id) || $block->id === '') {
-      $block->id = strtolower($this->random->name(8, TRUE));
+    if (!$stub->hasValue('id') || $stub->getValue('id') === '') {
+      $stub->setValue('id', strtolower($this->random->name(8, TRUE)));
     }
 
-    $placement = \Drupal::entityTypeManager()->getStorage('block')->create((array) $block);
+    $placement = \Drupal::entityTypeManager()->getStorage('block')->create($stub->getValues());
     $placement->save();
+    $stub->markSaved($placement);
 
-    return $placement;
+    return $stub;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function blockDelete(object $block): void {
-    if (!$block instanceof EntityInterface) {
-      if (!isset($block->id) || !is_string($block->id)) {
+  public function blockDelete(EntityStubInterface $stub): void {
+    $entity = $stub->isSaved() ? $stub->getSavedEntity() : NULL;
+
+    if (!$entity instanceof EntityInterface) {
+      $id = $stub->getValue('id');
+
+      if (!is_string($id) || $id === '') {
         throw new \InvalidArgumentException('Cannot delete a block placement from a stub without a string "id" property.');
       }
 
-      $block = \Drupal::entityTypeManager()->getStorage('block')->load($block->id);
+      $entity = \Drupal::entityTypeManager()->getStorage('block')->load($id);
     }
 
-    if ($block instanceof EntityInterface) {
-      $block->delete();
+    if ($entity instanceof EntityInterface) {
+      $entity->delete();
     }
   }
 
   /**
    * {@inheritdoc}
    */
-  public function blockContentCreate(\stdClass $block_content): object {
-    return $this->entityCreate('block_content', $block_content);
+  public function blockContentCreate(EntityStubInterface $stub): EntityStubInterface {
+    return $this->entityCreate($stub);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function blockContentDelete(object $block_content): void {
-    $this->entityDelete('block_content', $block_content);
+  public function blockContentDelete(EntityStubInterface $stub): void {
+    $this->entityDelete($stub);
   }
 
   /**
@@ -877,22 +914,26 @@ class Core implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function languageCreate(\stdClass $language): \stdClass|false {
+  public function languageCreate(EntityStubInterface $stub): EntityStubInterface|false {
+    $langcode = $stub->getValue('langcode');
+
     // Enable a language only if it has not been enabled already.
-    if (ConfigurableLanguage::load($language->langcode)) {
+    if (ConfigurableLanguage::load($langcode)) {
       return FALSE;
     }
 
-    ConfigurableLanguage::createFromLangcode($language->langcode)->save();
+    $entity = ConfigurableLanguage::createFromLangcode($langcode);
+    $entity->save();
+    $stub->markSaved($entity);
 
-    return $language;
+    return $stub;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function languageDelete(\stdClass $language): void {
-    $configurable_language = ConfigurableLanguage::load($language->langcode);
+  public function languageDelete(EntityStubInterface $stub): void {
+    $configurable_language = ConfigurableLanguage::load($stub->getValue('langcode'));
     $configurable_language->delete();
   }
 
@@ -934,7 +975,9 @@ class Core implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function entityCreate(string $entity_type, \stdClass $entity): EntityInterface {
+  public function entityCreate(EntityStubInterface $stub): EntityStubInterface {
+    $entity_type = $stub->getEntityType();
+
     if ($entity_type === '') {
       throw new \InvalidArgumentException('You must specify an entity type to create an entity.');
     }
@@ -943,45 +986,50 @@ class Core implements CoreInterface {
     $bundle_key = $definition->getKey('bundle');
     $id_key = $definition->getKey('id');
 
-    // If the bundle field is empty, put the inferred bundle value in it.
-    if (!isset($entity->$bundle_key) && isset($entity->step_bundle)) {
-      $entity->$bundle_key = $entity->step_bundle;
+    // Sync the typed bundle property into the values bag so
+    // storage->create() picks it up under the entity type's own bundle key.
+    if ($bundle_key && !$stub->hasValue($bundle_key) && $stub->getBundle() !== NULL) {
+      $stub->setValue($bundle_key, $stub->getBundle());
     }
 
     // Throw an exception if a bundle is specified but does not exist.
-    if (isset($entity->$bundle_key) && ($entity->$bundle_key !== NULL)) {
+    if ($bundle_key && $stub->hasValue($bundle_key) && $stub->getValue($bundle_key) !== NULL) {
       /** @var \Drupal\Core\Entity\EntityTypeBundleInfo $bundle_info */
       $bundle_info = \Drupal::service('entity_type.bundle.info');
       $bundles = $bundle_info->getBundleInfo($entity_type);
 
-      if (!in_array($entity->$bundle_key, array_keys($bundles))) {
-        throw new \InvalidArgumentException(sprintf("Cannot create entity because provided bundle '%s' does not exist.", $entity->$bundle_key));
+      if (!in_array($stub->getValue($bundle_key), array_keys($bundles))) {
+        throw new \InvalidArgumentException(sprintf("Cannot create entity because provided bundle '%s' does not exist.", $stub->getValue($bundle_key)));
       }
     }
 
-    $this->expandEntityFields($entity_type, $entity);
-    $created_entity = \Drupal::entityTypeManager()->getStorage($entity_type)->create((array) $entity);
+    $this->expandEntityFields($stub);
+    $created_entity = \Drupal::entityTypeManager()->getStorage($entity_type)->create($stub->getValues());
     $created_entity->save();
 
     // Mutate the stub under the entity type's own id key ('uid' for user,
     // 'nid' for node, 'tid' for term, 'id' for entity_test and others), so
     // callers can round-trip it back through entityDelete().
-    $entity->$id_key = $created_entity->id();
+    $stub->setValue($id_key, $created_entity->id());
+    $stub->markSaved($created_entity);
 
-    return $created_entity;
+    return $stub;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function entityDelete(string $entity_type, object $entity): void {
+  public function entityDelete(EntityStubInterface $stub): void {
+    $entity_type = $stub->getEntityType();
+    $entity = $stub->isSaved() ? $stub->getSavedEntity() : NULL;
+
     if (!$entity instanceof EntityInterface) {
       $id_key = $this->loadEntityTypeDefinition($entity_type)->getKey('id');
 
       // Fail loudly if the stub does not carry the resolved id key. Without
       // this guard a missing property would silently call storage->load(NULL)
       // - the delete would appear to succeed while doing nothing.
-      if (!is_string($id_key) || !isset($entity->$id_key)) {
+      if (!is_string($id_key) || !$stub->hasValue($id_key)) {
         throw new \InvalidArgumentException(sprintf(
           'Cannot delete an entity of type "%s" from a stub without the id key "%s" set.',
           $entity_type,
@@ -989,7 +1037,7 @@ class Core implements CoreInterface {
         ));
       }
 
-      $entity = \Drupal::entityTypeManager()->getStorage($entity_type)->load($entity->$id_key);
+      $entity = \Drupal::entityTypeManager()->getStorage($entity_type)->load($stub->getValue($id_key));
     }
 
     if ($entity instanceof EntityInterface) {
@@ -1128,8 +1176,8 @@ class Core implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function login(\stdClass $user): void {
-    $account = User::load($user->uid);
+  public function login(EntityStubInterface $stub): void {
+    $account = User::load($this->resolveUid($stub));
     \Drupal::service('account_switcher')->switchTo($account);
   }
 

--- a/src/Drupal/Driver/Core/CoreInterface.php
+++ b/src/Drupal/Driver/Core/CoreInterface.php
@@ -19,6 +19,7 @@ use Drupal\Driver\Capability\UserCapabilityInterface;
 use Drupal\Driver\Capability\WatchdogCapabilityInterface;
 use Drupal\Driver\Core\Field\FieldClassifierInterface;
 use Drupal\Driver\Core\Field\FieldHandlerInterface;
+use Drupal\Driver\Entity\EntityStubInterface;
 
 /**
  * Contract for a Drupal-backed core implementation.
@@ -83,10 +84,10 @@ interface CoreInterface extends
   public function processBatch(): void;
 
   /**
-   * Returns a field handler for the given entity/field.
+   * Returns a field handler for the given stub/field.
    *
-   * @param object $entity
-   *   The entity being processed.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The entity stub providing the bundle context.
    * @param string $entity_type
    *   The entity type ID.
    * @param string $field_name
@@ -95,7 +96,7 @@ interface CoreInterface extends
    * @return \Drupal\Driver\Core\Field\FieldHandlerInterface
    *   The matching field handler.
    */
-  public function getFieldHandler(object $entity, string $entity_type, string $field_name): FieldHandlerInterface;
+  public function getFieldHandler(EntityStubInterface $stub, string $entity_type, string $field_name): FieldHandlerInterface;
 
   /**
    * Registers a field handler class for a field type.

--- a/src/Drupal/Driver/Core/Field/AbstractHandler.php
+++ b/src/Drupal/Driver/Core/Field/AbstractHandler.php
@@ -6,6 +6,7 @@ namespace Drupal\Driver\Core\Field;
 
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Driver\Entity\EntityStubInterface;
 
 /**
  * Base class for field handlers.
@@ -24,8 +25,8 @@ abstract class AbstractHandler implements FieldHandlerInterface {
   /**
    * Constructs an AbstractHandler object.
    *
-   * @param \StdClass $entity
-   *   The simulated entity object containing field information.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The simulated entity stub providing the bundle context.
    * @param string $entity_type
    *   The entity type.
    * @param string $field_name
@@ -34,7 +35,7 @@ abstract class AbstractHandler implements FieldHandlerInterface {
    * @throws \Exception
    *   Thrown when the given field name does not exist on the entity.
    */
-  public function __construct(\StdClass $entity, string $entity_type, string $field_name) {
+  public function __construct(EntityStubInterface $stub, string $entity_type, string $field_name) {
     if ($entity_type === '') {
       throw new \InvalidArgumentException('You must specify an entity type in order to parse entity fields.');
     }
@@ -43,10 +44,17 @@ abstract class AbstractHandler implements FieldHandlerInterface {
     $entity_field_manager = \Drupal::service('entity_field.manager');
     $storage_definitions = $entity_field_manager->getFieldStorageDefinitions($entity_type);
 
-    // Resolve the bundle: explicit bundle key > step_bundle > entity type
-    // (single-bundle entities like 'user' use the entity type as bundle).
+    // Resolve the bundle: bundle key value > typed bundle > entity type
+    // (single-bundle entities like 'user' use the entity type as the bundle).
     $bundle_key = \Drupal::entityTypeManager()->getDefinition($entity_type)->getKey('bundle');
-    $bundle = empty($entity->$bundle_key) ? ($entity->step_bundle ?? $entity_type) : $entity->$bundle_key;
+    $bundle = $entity_type;
+
+    if ($bundle_key && !empty($stub->getValue($bundle_key))) {
+      $bundle = (string) $stub->getValue($bundle_key);
+    }
+    elseif ($stub->getBundle() !== NULL && $stub->getBundle() !== '') {
+      $bundle = $stub->getBundle();
+    }
 
     $field_definitions = $entity_field_manager->getFieldDefinitions($entity_type, $bundle);
 

--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -8,6 +8,7 @@ use Drupal\Component\Utility\Random;
 use Drupal\Driver\Capability\AuthenticationCapabilityInterface;
 use Drupal\Driver\Core\Core;
 use Drupal\Driver\Core\CoreInterface;
+use Drupal\Driver\Entity\EntityStubInterface;
 use Drupal\Driver\Exception\BootstrapException;
 
 /**
@@ -159,11 +160,11 @@ class DrupalDriver implements DrupalDriverInterface {
   /**
    * {@inheritdoc}
    */
-  public function login(\stdClass $user): void {
+  public function login(EntityStubInterface $stub): void {
     $auth = $this->getAuthCore();
 
     if ($auth instanceof AuthenticationCapabilityInterface) {
-      $auth->login($user);
+      $auth->login($stub);
     }
   }
 
@@ -216,71 +217,71 @@ class DrupalDriver implements DrupalDriverInterface {
   /**
    * {@inheritdoc}
    */
-  public function nodeCreate(\stdClass $node): object {
-    return $this->getCore()->nodeCreate($node);
+  public function nodeCreate(EntityStubInterface $stub): EntityStubInterface {
+    return $this->getCore()->nodeCreate($stub);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function nodeDelete(object $node): void {
-    $this->getCore()->nodeDelete($node);
+  public function nodeDelete(EntityStubInterface $stub): void {
+    $this->getCore()->nodeDelete($stub);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function termCreate(\stdClass $term): object {
-    return $this->getCore()->termCreate($term);
+  public function termCreate(EntityStubInterface $stub): EntityStubInterface {
+    return $this->getCore()->termCreate($stub);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function termDelete(object $term): bool {
-    return $this->getCore()->termDelete($term);
+  public function termDelete(EntityStubInterface $stub): bool {
+    return $this->getCore()->termDelete($stub);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function entityCreate(string $entity_type, \stdClass $entity): object {
-    return $this->getCore()->entityCreate($entity_type, $entity);
+  public function entityCreate(EntityStubInterface $stub): EntityStubInterface {
+    return $this->getCore()->entityCreate($stub);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function entityDelete(string $entity_type, object $entity): void {
-    $this->getCore()->entityDelete($entity_type, $entity);
+  public function entityDelete(EntityStubInterface $stub): void {
+    $this->getCore()->entityDelete($stub);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function blockPlace(\stdClass $block): object {
-    return $this->getCore()->blockPlace($block);
+  public function blockPlace(EntityStubInterface $stub): EntityStubInterface {
+    return $this->getCore()->blockPlace($stub);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function blockDelete(object $block): void {
-    $this->getCore()->blockDelete($block);
+  public function blockDelete(EntityStubInterface $stub): void {
+    $this->getCore()->blockDelete($stub);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function blockContentCreate(\stdClass $block_content): object {
-    return $this->getCore()->blockContentCreate($block_content);
+  public function blockContentCreate(EntityStubInterface $stub): EntityStubInterface {
+    return $this->getCore()->blockContentCreate($stub);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function blockContentDelete(object $block_content): void {
-    $this->getCore()->blockContentDelete($block_content);
+  public function blockContentDelete(EntityStubInterface $stub): void {
+    $this->getCore()->blockContentDelete($stub);
   }
 
   /**
@@ -293,15 +294,15 @@ class DrupalDriver implements DrupalDriverInterface {
   /**
    * {@inheritdoc}
    */
-  public function languageCreate(\stdClass $language): \stdClass|false {
-    return $this->getCore()->languageCreate($language);
+  public function languageCreate(EntityStubInterface $stub): EntityStubInterface|false {
+    return $this->getCore()->languageCreate($stub);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function languageDelete(\stdClass $language): void {
-    $this->getCore()->languageDelete($language);
+  public function languageDelete(EntityStubInterface $stub): void {
+    $this->getCore()->languageDelete($stub);
   }
 
   /**
@@ -370,22 +371,22 @@ class DrupalDriver implements DrupalDriverInterface {
   /**
    * {@inheritdoc}
    */
-  public function userCreate(\stdClass $user): void {
-    $this->getCore()->userCreate($user);
+  public function userCreate(EntityStubInterface $stub): void {
+    $this->getCore()->userCreate($stub);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function userDelete(\stdClass $user): void {
-    $this->getCore()->userDelete($user);
+  public function userDelete(EntityStubInterface $stub): void {
+    $this->getCore()->userDelete($stub);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function userAddRole(\stdClass $user, string $role): void {
-    $this->getCore()->userAddRole($user, $role);
+  public function userAddRole(EntityStubInterface $stub, string $role): void {
+    $this->getCore()->userAddRole($stub, $role);
   }
 
   /**

--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Drupal\Driver;
 
 use Drupal\Component\Utility\Random;
+use Drupal\Driver\Entity\EntityStubInterface;
 use Drupal\Driver\Exception\BootstrapException;
-
 use Symfony\Component\Process\Process;
 
 /**
@@ -237,34 +237,36 @@ class DrushDriver implements DrushDriverInterface {
   /**
    * {@inheritdoc}
    */
-  public function userCreate(\stdClass $user): void {
-    $arguments = [sprintf('"%s"', $user->name)];
+  public function userCreate(EntityStubInterface $stub): void {
+    $arguments = [sprintf('"%s"', $stub->getValue('name'))];
     $options = [
-      'password' => $user->pass,
-      'mail' => $user->mail,
+      'password' => $stub->getValue('pass'),
+      'mail' => $stub->getValue('mail'),
     ];
 
     $result = $this->drush('user-create', $arguments, $options);
     $uid = $this->parseUserId($result);
 
     if ($uid) {
-      $user->uid = $uid;
+      $stub->setValue('uid', $uid);
     }
 
-    if (!isset($user->roles) || !is_array($user->roles)) {
+    $roles = $stub->getValue('roles');
+
+    if (!is_array($roles)) {
       return;
     }
 
-    foreach ($user->roles as $role) {
-      $this->userAddRole($user, $role);
+    foreach ($roles as $role) {
+      $this->userAddRole($stub, $role);
     }
   }
 
   /**
    * {@inheritdoc}
    */
-  public function userDelete(\stdClass $user): void {
-    $arguments = [sprintf('"%s"', $user->name)];
+  public function userDelete(EntityStubInterface $stub): void {
+    $arguments = [sprintf('"%s"', $stub->getValue('name'))];
     $options = [
       'yes' => NULL,
       'delete-content' => NULL,
@@ -275,10 +277,10 @@ class DrushDriver implements DrushDriverInterface {
   /**
    * {@inheritdoc}
    */
-  public function userAddRole(\stdClass $user, string $role): void {
+  public function userAddRole(EntityStubInterface $stub, string $role): void {
     $arguments = [
       sprintf('"%s"', $role),
-      sprintf('"%s"', $user->name),
+      sprintf('"%s"', $stub->getValue('name')),
     ];
     $this->drush('user-add-role', $arguments);
   }

--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -238,10 +238,10 @@ class DrushDriver implements DrushDriverInterface {
    * {@inheritdoc}
    */
   public function userCreate(EntityStubInterface $stub): void {
-    $arguments = [sprintf('"%s"', $stub->getValue('name'))];
+    $arguments = [escapeshellarg((string) $stub->getValue('name'))];
     $options = [
-      'password' => $stub->getValue('pass'),
-      'mail' => $stub->getValue('mail'),
+      'password' => escapeshellarg((string) $stub->getValue('pass')),
+      'mail' => escapeshellarg((string) $stub->getValue('mail')),
     ];
 
     $result = $this->drush('user-create', $arguments, $options);
@@ -266,7 +266,7 @@ class DrushDriver implements DrushDriverInterface {
    * {@inheritdoc}
    */
   public function userDelete(EntityStubInterface $stub): void {
-    $arguments = [sprintf('"%s"', $stub->getValue('name'))];
+    $arguments = [escapeshellarg((string) $stub->getValue('name'))];
     $options = [
       'yes' => NULL,
       'delete-content' => NULL,
@@ -279,8 +279,8 @@ class DrushDriver implements DrushDriverInterface {
    */
   public function userAddRole(EntityStubInterface $stub, string $role): void {
     $arguments = [
-      sprintf('"%s"', $role),
-      sprintf('"%s"', $stub->getValue('name')),
+      escapeshellarg($role),
+      escapeshellarg((string) $stub->getValue('name')),
     ];
     $this->drush('user-add-role', $arguments);
   }

--- a/src/Drupal/Driver/Entity/EntityStub.php
+++ b/src/Drupal/Driver/Entity/EntityStub.php
@@ -76,7 +76,7 @@ final class EntityStub implements EntityStubInterface {
    * {@inheritdoc}
    */
   public function getValue(string $key, mixed $default = NULL): mixed {
-    return $this->values[$key] ?? $default;
+    return array_key_exists($key, $this->values) ? $this->values[$key] : $default;
   }
 
   /**

--- a/src/Drupal/Driver/Entity/EntityStub.php
+++ b/src/Drupal/Driver/Entity/EntityStub.php
@@ -18,12 +18,12 @@ final class EntityStub implements EntityStubInterface {
   /**
    * The saved Drupal entity object. NULL until the driver populates it.
    */
-  private ?object $entity = NULL;
+  protected ?object $entity = NULL;
 
   /**
    * The bundle key for this entity type ('type', 'vid', 'bundle', etc.).
    */
-  private string $bundleKey = self::DEFAULT_BUNDLE_KEY;
+  protected string $bundleKey = self::DEFAULT_BUNDLE_KEY;
 
   /**
    * Set up the stub.
@@ -36,9 +36,9 @@ final class EntityStub implements EntityStubInterface {
    *   Flat map of base properties and field values, keyed by name.
    */
   public function __construct(
-    private readonly string $entityType,
-    private readonly ?string $bundle = NULL,
-    private array $values = [],
+    protected readonly string $entityType,
+    protected readonly ?string $bundle = NULL,
+    protected array $values = [],
   ) {
   }
 

--- a/src/Drupal/Driver/Entity/EntityStub.php
+++ b/src/Drupal/Driver/Entity/EntityStub.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Driver\Entity;
+
+/**
+ * Typed envelope for creating, tracking, and cleaning up a Drupal entity.
+ *
+ * Replaces the historical 'stdClass' that flowed between the extension's
+ * Gherkin parser and the driver's create methods. Mirrors Drupal Core's own
+ * 'Entity::create($type, $values)' shape - one final class, no subclasses,
+ * with the entity type and bundle pinned at construction time and a
+ * mutable values bag plus a saved-entity slot.
+ */
+final class EntityStub implements EntityStubInterface {
+
+  /**
+   * The saved Drupal entity object. NULL until the driver populates it.
+   */
+  private ?object $entity = NULL;
+
+  /**
+   * The bundle key for this entity type ('type', 'vid', 'bundle', etc.).
+   */
+  private string $bundleKey = self::DEFAULT_BUNDLE_KEY;
+
+  /**
+   * Set up the stub.
+   *
+   * @param string $entityType
+   *   The entity type ID (e.g. 'node', 'taxonomy_term', 'user').
+   * @param string|null $bundle
+   *   The bundle ID (e.g. 'article'). NULL for entity types without bundles.
+   * @param array<string, mixed> $values
+   *   Flat map of base properties and field values, keyed by name.
+   */
+  public function __construct(
+    private readonly string $entityType,
+    private readonly ?string $bundle = NULL,
+    private array $values = [],
+  ) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityType(): string {
+    return $this->entityType;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBundle(): ?string {
+    return $this->bundle;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBundleKey(): string {
+    return $this->bundleKey;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setBundleKey(string $bundle_key): self {
+    $this->bundleKey = $bundle_key;
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue(string $key, mixed $default = NULL): mixed {
+    return $this->values[$key] ?? $default;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setValue(string $key, mixed $value): self {
+    $this->values[$key] = $value;
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function hasValue(string $key): bool {
+    return array_key_exists($key, $this->values);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function removeValue(string $key): self {
+    unset($this->values[$key]);
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValues(): array {
+    return $this->values;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setValues(array $values): self {
+    $this->values = $values;
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isSaved(): bool {
+    return $this->entity !== NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function markSaved(object $entity): self {
+    $this->entity = $entity;
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSavedEntity(): object {
+    if ($this->entity === NULL) {
+      throw new \LogicException(sprintf('EntityStub for "%s" has not been saved yet.', $this->entityType));
+    }
+
+    return $this->entity;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getId(): int|string|null {
+    if ($this->entity === NULL) {
+      return NULL;
+    }
+
+    return method_exists($this->entity, 'id') ? $this->entity->id() : NULL;
+  }
+
+}

--- a/src/Drupal/Driver/Entity/EntityStubInterface.php
+++ b/src/Drupal/Driver/Entity/EntityStubInterface.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Driver\Entity;
+
+/**
+ * Contract for the typed envelope used during entity create/cleanup flows.
+ *
+ * Holds the desired-state values before save, the saved Drupal entity once
+ * the driver populates it, and the bundle context the field-handler
+ * pipeline needs for storage resolution.
+ */
+interface EntityStubInterface {
+
+  /**
+   * Default bundle key for entity types that do not declare one.
+   *
+   * Drupal Core's most common bundle key is 'type' (used by 'node',
+   * 'block_content', 'entity_test', and others), so it is the fallback when
+   * the caller has not specified a bundle key.
+   */
+  public const string DEFAULT_BUNDLE_KEY = 'type';
+
+  /**
+   * Returns the entity type ID (e.g. 'node', 'taxonomy_term', 'user').
+   */
+  public function getEntityType(): string;
+
+  /**
+   * Returns the bundle ID, or NULL for entity types without bundles.
+   */
+  public function getBundle(): ?string;
+
+  /**
+   * Returns the bundle key for this stub's entity type.
+   */
+  public function getBundleKey(): string;
+
+  /**
+   * Sets the bundle key for this stub's entity type.
+   *
+   * Callers that bootstrap a stub before the driver has a chance to consult
+   * Drupal's entity type definitions can override the default here. The
+   * driver itself sets this from the entity type's declared bundle key
+   * before storage operations run.
+   */
+  public function setBundleKey(string $bundle_key): self;
+
+  /**
+   * Returns a single value, or the supplied default when absent.
+   *
+   * @param string $key
+   *   The value name.
+   * @param mixed $default
+   *   Returned when the key is not in the bag.
+   *
+   * @return mixed
+   *   The stored value or the default.
+   */
+  public function getValue(string $key, mixed $default = NULL): mixed;
+
+  /**
+   * Sets a single value.
+   *
+   * @param string $key
+   *   The value name.
+   * @param mixed $value
+   *   The value to store.
+   */
+  public function setValue(string $key, mixed $value): self;
+
+  /**
+   * Returns TRUE when a key is set, even if its value is NULL.
+   */
+  public function hasValue(string $key): bool;
+
+  /**
+   * Removes a single value from the bag.
+   */
+  public function removeValue(string $key): self;
+
+  /**
+   * Returns the entire values bag.
+   *
+   * @return array<string, mixed>
+   *   Stored values keyed by name.
+   */
+  public function getValues(): array;
+
+  /**
+   * Replaces the entire values bag.
+   *
+   * @param array<string, mixed> $values
+   *   Replacement values keyed by name.
+   */
+  public function setValues(array $values): self;
+
+  /**
+   * Returns TRUE once the driver has called 'markSaved()'.
+   */
+  public function isSaved(): bool;
+
+  /**
+   * Records the saved Drupal entity object on the stub.
+   *
+   * @param object $entity
+   *   The Drupal entity that was just persisted.
+   */
+  public function markSaved(object $entity): self;
+
+  /**
+   * Returns the saved Drupal entity object.
+   *
+   * @return object
+   *   The entity supplied to 'markSaved()'.
+   *
+   * @throws \LogicException
+   *   When 'markSaved()' has not yet been called.
+   */
+  public function getSavedEntity(): object;
+
+  /**
+   * Returns the saved entity's id, or NULL when the stub is unsaved.
+   *
+   * @return int|string|null
+   *   The id resolved by the saved entity, or NULL.
+   */
+  public function getId(): int|string|null;
+
+}

--- a/src/Drupal/Driver/Entity/EntityStubInterface.php
+++ b/src/Drupal/Driver/Entity/EntityStubInterface.php
@@ -20,7 +20,7 @@ interface EntityStubInterface {
    * 'block_content', 'entity_test', and others), so it is the fallback when
    * the caller has not specified a bundle key.
    */
-  public const string DEFAULT_BUNDLE_KEY = 'type';
+  public const DEFAULT_BUNDLE_KEY = 'type';
 
   /**
    * Returns the entity type ID (e.g. 'node', 'taxonomy_term', 'user').

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreAuthenticationMethodsKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreAuthenticationMethodsKernelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\Driver\Kernel\Core;
 
 use Drupal\Driver\Core\Core;
+use Drupal\Driver\Entity\EntityStub;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\user\Entity\User;
 use PHPUnit\Framework\Attributes\Group;
@@ -58,7 +59,7 @@ class CoreAuthenticationMethodsKernelTest extends KernelTestBase {
     ]);
     $account->save();
 
-    $user_stub = (object) ['uid' => $account->id()];
+    $user_stub = new EntityStub('user', NULL, ['uid' => $account->id()]);
     $this->core->login($user_stub);
 
     $this->assertSame((int) $account->id(), (int) \Drupal::currentUser()->id());
@@ -77,7 +78,7 @@ class CoreAuthenticationMethodsKernelTest extends KernelTestBase {
     ]);
     $account->save();
 
-    $this->core->login((object) ['uid' => $account->id()]);
+    $this->core->login(new EntityStub('user', NULL, ['uid' => $account->id()]));
     $this->core->logout();
 
     $this->assertSame($original_uid, (int) \Drupal::currentUser()->id());

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreBlockMethodsKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreBlockMethodsKernelTest.php
@@ -8,6 +8,7 @@ use Drupal\block\Entity\Block;
 use Drupal\block_content\Entity\BlockContent;
 use Drupal\block_content\Entity\BlockContentType;
 use Drupal\Driver\Core\Core;
+use Drupal\Driver\Entity\EntityStub;
 use Drupal\KernelTests\KernelTestBase;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -60,18 +61,20 @@ class CoreBlockMethodsKernelTest extends KernelTestBase {
    * Tests that 'blockPlace()' creates a placement in the given region.
    */
   public function testBlockPlaceAndDeleteRoundTrip(): void {
-    $stub = (object) [
+    $stub = new EntityStub('block', NULL, [
       'id' => 'test_powered_by',
       'plugin' => 'system_powered_by_block',
       'theme' => 'stark',
       'region' => 'content',
       'weight' => 0,
       'settings' => ['label' => 'Powered by', 'label_display' => 'visible'],
-    ];
+    ]);
 
-    $placement = $this->core->blockPlace($stub);
+    $result = $this->core->blockPlace($stub);
 
-    $this->assertInstanceOf(Block::class, $placement);
+    $this->assertSame($stub, $result);
+    $this->assertTrue($result->isSaved());
+    $this->assertInstanceOf(Block::class, $result->getSavedEntity());
 
     $reloaded = Block::load('test_powered_by');
     $this->assertInstanceOf(Block::class, $reloaded);
@@ -79,7 +82,7 @@ class CoreBlockMethodsKernelTest extends KernelTestBase {
     $this->assertSame('stark', $reloaded->getTheme());
     $this->assertSame('system_powered_by_block', $reloaded->getPluginId());
 
-    $this->core->blockDelete($stub);
+    $this->core->blockDelete($result);
     $this->assertNull(Block::load('test_powered_by'));
   }
 
@@ -87,35 +90,35 @@ class CoreBlockMethodsKernelTest extends KernelTestBase {
    * Tests that 'blockPlace()' auto-generates an id when the stub omits it.
    */
   public function testBlockPlaceGeneratesIdWhenAbsent(): void {
-    $stub = (object) [
+    $stub = new EntityStub('block', NULL, [
       'plugin' => 'system_powered_by_block',
       'theme' => 'stark',
       'region' => 'footer',
-    ];
+    ]);
 
-    $placement = $this->core->blockPlace($stub);
+    $result = $this->core->blockPlace($stub);
 
+    $this->assertTrue($result->isSaved());
+    $placement = $result->getSavedEntity();
     $this->assertInstanceOf(Block::class, $placement);
     $this->assertNotEmpty($placement->id(), 'blockPlace populated an id on the saved placement.');
     $this->assertNotNull(Block::load($placement->id()));
   }
 
   /**
-   * Tests that 'blockDelete()' accepts a loaded entity as well as a stub.
+   * Tests that 'blockDelete()' uses the saved-entity slot when present.
    */
-  public function testBlockDeleteAcceptsLoadedEntity(): void {
-    $stub = (object) [
+  public function testBlockDeleteUsesSavedEntity(): void {
+    $stub = new EntityStub('block', NULL, [
       'id' => 'test_via_entity',
       'plugin' => 'system_powered_by_block',
       'theme' => 'stark',
       'region' => 'content',
-    ];
+    ]);
     $this->core->blockPlace($stub);
 
-    $loaded = Block::load('test_via_entity');
-    $this->assertInstanceOf(Block::class, $loaded);
-
-    $this->core->blockDelete($loaded);
+    $this->assertNotNull(Block::load('test_via_entity'));
+    $this->core->blockDelete($stub);
     $this->assertNull(Block::load('test_via_entity'));
   }
 
@@ -126,7 +129,7 @@ class CoreBlockMethodsKernelTest extends KernelTestBase {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessageMatches('/id/');
 
-    $this->core->blockDelete((object) ['plugin' => 'system_powered_by_block']);
+    $this->core->blockDelete(new EntityStub('block', NULL, ['plugin' => 'system_powered_by_block']));
   }
 
   /**
@@ -135,20 +138,21 @@ class CoreBlockMethodsKernelTest extends KernelTestBase {
   public function testBlockContentCreateAndDeleteRoundTrip(): void {
     BlockContentType::create(['id' => 'basic', 'label' => 'Basic'])->save();
 
-    $stub = (object) [
-      'type' => 'basic',
+    $stub = new EntityStub('block_content', 'basic', [
       'info' => 'driver-test content block',
       'reusable' => TRUE,
-    ];
+    ]);
 
     $created = $this->core->blockContentCreate($stub);
 
-    $this->assertInstanceOf(BlockContent::class, $created);
-    $this->assertNotEmpty($stub->id, 'blockContentCreate populated the id key on the stub.');
-    $this->assertSame('driver-test content block', $created->label());
+    $this->assertSame($stub, $created);
+    $this->assertTrue($created->isSaved());
+    $this->assertInstanceOf(BlockContent::class, $created->getSavedEntity());
+    $this->assertNotEmpty($stub->getValue('id'), 'blockContentCreate populated the id key on the stub.');
+    $this->assertSame('driver-test content block', $created->getSavedEntity()->label());
 
     $this->core->blockContentDelete($stub);
-    $this->assertNull(BlockContent::load((int) $stub->id));
+    $this->assertNull(BlockContent::load((int) $stub->getValue('id')));
   }
 
 }

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreEntityCreateCommerceKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreEntityCreateCommerceKernelTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\Driver\Kernel\Core;
 use Drupal\commerce_product\Entity\Product;
 use Drupal\commerce_store\Entity\Store;
 use Drupal\Driver\Core\Core;
+use Drupal\Driver\Entity\EntityStub;
 use Drupal\KernelTests\KernelTestBase;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -96,36 +97,34 @@ class CoreEntityCreateCommerceKernelTest extends KernelTestBase {
    * Tests 'entityCreate()' resolves 'commerce_product.variations'.
    */
   public function testEntityCreateExpandsProductVariationsBaseField(): void {
-    $variation_stub = (object) [
-      'type' => 'default',
+    $variation_stub = new EntityStub('commerce_product_variation', 'default', [
       'sku' => 'SKU-001',
       'title' => 'Test variation',
-    ];
-    $this->core->entityCreate('commerce_product_variation', $variation_stub);
+    ]);
+    $this->core->entityCreate($variation_stub);
 
     $this->assertNotEmpty(
-      $variation_stub->variation_id,
+      $variation_stub->getValue('variation_id'),
       'entityCreate populated commerce_product_variation.variation_id on the stub.',
     );
 
-    $product_stub = (object) [
-      'type' => 'default',
+    $product_stub = new EntityStub('commerce_product', 'default', [
       'title' => 'Test product',
-      'variations' => [$variation_stub->variation_id],
-    ];
-    $this->core->entityCreate('commerce_product', $product_stub);
+      'variations' => [$variation_stub->getValue('variation_id')],
+    ]);
+    $this->core->entityCreate($product_stub);
 
     $this->assertNotEmpty(
-      $product_stub->product_id,
+      $product_stub->getValue('product_id'),
       'entityCreate populated commerce_product.product_id on the stub.',
     );
 
-    $product = Product::load((int) $product_stub->product_id);
+    $product = Product::load((int) $product_stub->getValue('product_id'));
     $this->assertInstanceOf(Product::class, $product);
 
     $variation_ids = array_map(intval(...), $product->getVariationIds());
     $this->assertContains(
-      (int) $variation_stub->variation_id,
+      (int) $variation_stub->getValue('variation_id'),
       $variation_ids,
       'product.variations base entity_reference resolved to the variation id.',
     );

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreEntityCreateModerationStateKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreEntityCreateModerationStateKernelTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\Driver\Kernel\Core;
 use Drupal\content_moderation\Entity\ContentModerationState;
 use Drupal\content_moderation\Plugin\WorkflowType\ContentModeration;
 use Drupal\Driver\Core\Core;
+use Drupal\Driver\Entity\EntityStub;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
@@ -95,17 +96,16 @@ class CoreEntityCreateModerationStateKernelTest extends KernelTestBase {
    * Tests that 'moderation_state' on a stub is captured at save.
    */
   public function testEntityCreatePassesModerationStateThrough(): void {
-    $stub = (object) [
-      'type' => 'article',
+    $stub = new EntityStub('node', 'article', [
       'title' => 'Draft article',
       'moderation_state' => 'draft',
-    ];
+    ]);
 
-    $this->core->entityCreate('node', $stub);
+    $this->core->entityCreate($stub);
 
-    $this->assertNotEmpty($stub->nid, 'entityCreate populated node nid on the stub.');
+    $this->assertNotEmpty($stub->getValue('nid'), 'entityCreate populated node nid on the stub.');
 
-    $node = Node::load((int) $stub->nid);
+    $node = Node::load((int) $stub->getValue('nid'));
     $this->assertInstanceOf(Node::class, $node);
 
     $revision_id = $node->getRevisionId();

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreEntityMethodsKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreEntityMethodsKernelTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\Driver\Kernel\Core;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Driver\Core\Core;
+use Drupal\Driver\Entity\EntityStub;
 use Drupal\entity_test\EntityTestHelper;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\user\Entity\Role;
@@ -59,23 +60,25 @@ class CoreEntityMethodsKernelTest extends KernelTestBase {
    * termDelete (tid).
    */
   public function testEntityCreateAndDeleteWithStub(): void {
-    $stub = (object) [
+    $stub = new EntityStub('user', NULL, [
       'name' => 'zoe',
       'mail' => 'zoe@example.com',
       'status' => 1,
-    ];
+    ]);
 
-    $created = $this->core->entityCreate('user', $stub);
+    $created = $this->core->entityCreate($stub);
 
-    $this->assertInstanceOf(EntityInterface::class, $created);
-    $this->assertNotEmpty($stub->uid, 'entityCreate populated the entity type id key (uid) on the stub.');
-    $this->assertFalse(property_exists($stub, 'id'), 'entityCreate did not populate a generic "id" property on the stub.');
+    $this->assertSame($stub, $created, 'entityCreate returns the same stub.');
+    $this->assertTrue($created->isSaved(), 'entityCreate marks the stub saved.');
+    $this->assertInstanceOf(EntityInterface::class, $created->getSavedEntity());
+    $this->assertNotEmpty($stub->getValue('uid'), 'entityCreate populated the entity type id key (uid) on the stub.');
+    $this->assertFalse($stub->hasValue('id'), 'entityCreate did not populate a generic "id" value on the stub.');
 
     // Delete via the stub, which triggers the load-by-id branch of
     // entityDelete() resolved against the entity type id key.
-    $this->core->entityDelete('user', $stub);
+    $this->core->entityDelete($stub);
 
-    $this->assertNull(User::load((int) $stub->uid));
+    $this->assertNull(User::load((int) $stub->getValue('uid')));
   }
 
   /**
@@ -90,15 +93,15 @@ class CoreEntityMethodsKernelTest extends KernelTestBase {
    * the field API - observable here by inspecting the stub after create.
    */
   public function testEntityCreateAutoExpandsBaseFieldsSetOnStub(): void {
-    $stub = (object) [
+    $stub = new EntityStub('user', NULL, [
       'name' => 'uma',
       'mail' => 'uma@example.com',
       'status' => 1,
-    ];
+    ]);
 
-    $this->core->entityCreate('user', $stub);
+    $this->core->entityCreate($stub);
 
-    $this->assertSame(['uma'], $stub->name, 'base field "name" was routed through the handler pipeline.');
+    $this->assertSame(['uma'], $stub->getValue('name'), 'base field "name" was routed through the handler pipeline.');
   }
 
   /**
@@ -108,7 +111,7 @@ class CoreEntityMethodsKernelTest extends KernelTestBase {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessageMatches('/stub without the id key "uid" set/');
 
-    $this->core->entityDelete('user', (object) ['name' => 'missing-uid']);
+    $this->core->entityDelete(new EntityStub('user', NULL, ['name' => 'missing-uid']));
   }
 
   /**
@@ -126,24 +129,24 @@ class CoreEntityMethodsKernelTest extends KernelTestBase {
   public function testEntityCreateExpandsBaseEntityReferenceFieldOnStub(): void {
     Role::create(['id' => 'editor', 'label' => 'Editor'])->save();
 
-    $stub = (object) [
+    $stub = new EntityStub('user', NULL, [
       'name' => 'vic',
       'mail' => 'vic@example.com',
       'status' => 1,
       'roles' => ['editor'],
-    ];
+    ]);
 
-    $this->core->entityCreate('user', $stub);
+    $this->core->entityCreate($stub);
 
-    $account = User::load((int) $stub->uid);
+    $account = User::load((int) $stub->getValue('uid'));
     $this->assertInstanceOf(User::class, $account);
     $this->assertContains('editor', $account->getRoles(), 'entityCreate routed user.roles through EntityReferenceHandler for base-field expansion.');
   }
 
   /**
-   * Tests 'entityDelete()' when given an already-loaded entity.
+   * Tests 'entityDelete()' uses the saved-entity slot when present.
    */
-  public function testEntityDeleteWithLoadedEntity(): void {
+  public function testEntityDeleteUsesSavedEntity(): void {
     $entity = User::create([
       'name' => 'taylor',
       'mail' => 'taylor@example.com',
@@ -151,18 +154,19 @@ class CoreEntityMethodsKernelTest extends KernelTestBase {
     ]);
     $entity->save();
 
-    $this->core->entityDelete('user', $entity);
+    $stub = (new EntityStub('user'))->markSaved($entity);
+    $this->core->entityDelete($stub);
 
     $this->assertNull(User::load((int) $entity->id()));
   }
 
   /**
-   * Tests 'entityCreate()' maps 'step_bundle' onto the real bundle key.
+   * Tests 'entityCreate()' promotes the typed bundle onto the bundle key.
    *
-   * 'entity_test' has a 'type' bundle key, so the stub's 'step_bundle'
-   * should be promoted to 'type' before the entity is saved.
+   * 'entity_test' has a 'type' bundle key, so the typed 'bundle' constructor
+   * argument should be promoted to 'type' before the entity is saved.
    */
-  public function testEntityCreateMapsStepBundle(): void {
+  public function testEntityCreatePromotesTypedBundle(): void {
     // Feature-detect the helper the same way the field-handler base does:
     // Drupal 11.2+ ships EntityTestHelper; older cores only expose the
     // procedural helper.
@@ -173,14 +177,11 @@ class CoreEntityMethodsKernelTest extends KernelTestBase {
       entity_test_create_bundle('custom_bundle');
     }
 
-    $stub = (object) [
-      'name' => 'sam',
-      'step_bundle' => 'custom_bundle',
-    ];
-    $created = $this->core->entityCreate('entity_test', $stub);
+    $stub = new EntityStub('entity_test', 'custom_bundle', ['name' => 'sam']);
+    $created = $this->core->entityCreate($stub);
 
-    $this->assertSame('custom_bundle', $stub->type, 'step_bundle was promoted to the bundle key.');
-    $this->assertSame('custom_bundle', $created->bundle());
+    $this->assertSame('custom_bundle', $stub->getValue('type'), 'typed bundle was promoted to the bundle key.');
+    $this->assertSame('custom_bundle', $created->getSavedEntity()->bundle());
   }
 
   /**
@@ -195,7 +196,7 @@ class CoreEntityMethodsKernelTest extends KernelTestBase {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessageMatches('/Unknown entity type "nonexistent_type"/');
 
-    $this->core->entityCreate('nonexistent_type', (object) ['name' => 'foo']);
+    $this->core->entityCreate(new EntityStub('nonexistent_type', NULL, ['name' => 'foo']));
   }
 
   /**
@@ -205,7 +206,7 @@ class CoreEntityMethodsKernelTest extends KernelTestBase {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessageMatches('/Unknown entity type "nonexistent_type"/');
 
-    $this->core->entityDelete('nonexistent_type', (object) ['id' => 1]);
+    $this->core->entityDelete(new EntityStub('nonexistent_type', NULL, ['id' => 1]));
   }
 
   /**
@@ -215,15 +216,12 @@ class CoreEntityMethodsKernelTest extends KernelTestBase {
    * explicitly created; any supplied bundle therefore triggers the guard.
    */
   public function testEntityCreateRejectsUnknownBundle(): void {
-    $stub = (object) [
-      'type' => 'not_a_real_bundle',
-      'name' => 'orphan',
-    ];
+    $stub = new EntityStub('entity_test', 'not_a_real_bundle', ['name' => 'orphan']);
 
     $this->expectException(\Exception::class);
     $this->expectExceptionMessageMatches("/Cannot create entity because provided bundle 'not_a_real_bundle' does not exist/");
 
-    $this->core->entityCreate('entity_test', $stub);
+    $this->core->entityCreate($stub);
   }
 
 }

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreNodeMethodsKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreNodeMethodsKernelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\Driver\Kernel\Core;
 
 use Drupal\Driver\Core\Core;
+use Drupal\Driver\Entity\EntityStub;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
@@ -65,22 +66,23 @@ class CoreNodeMethodsKernelTest extends KernelTestBase {
     $author = User::create(['name' => 'article_author', 'status' => 1]);
     $author->save();
 
-    $node_data = (object) [
-      'type' => 'article',
+    $stub = new EntityStub('node', 'article', [
       'title' => 'Hello world',
       'author' => 'article_author',
-    ];
+    ]);
 
-    $result = $this->core->nodeCreate($node_data);
+    $result = $this->core->nodeCreate($stub);
 
-    $this->assertNotEmpty($result->nid, 'nodeCreate populated nid.');
-    $node = Node::load($result->nid);
+    $this->assertSame($stub, $result, 'nodeCreate returns the same stub.');
+    $this->assertNotEmpty($result->getValue('nid'), 'nodeCreate populated nid.');
+    $this->assertTrue($result->isSaved(), 'nodeCreate marked the stub saved.');
+    $node = Node::load($result->getValue('nid'));
     $this->assertInstanceOf(Node::class, $node);
     $this->assertSame('Hello world', $node->getTitle());
     $this->assertSame((int) $author->id(), (int) $node->getOwnerId(), 'author mapped to uid.');
 
     $this->core->nodeDelete($result);
-    $this->assertNull(Node::load($result->nid));
+    $this->assertNull(Node::load($result->getValue('nid')));
   }
 
   /**
@@ -90,7 +92,7 @@ class CoreNodeMethodsKernelTest extends KernelTestBase {
     $this->expectException(\Exception::class);
     $this->expectExceptionMessage('Cannot create content because provided content type bogus does not exist.');
 
-    $this->core->nodeCreate((object) ['type' => 'bogus', 'title' => 'Nope']);
+    $this->core->nodeCreate(new EntityStub('node', 'bogus', ['title' => 'Nope']));
   }
 
   /**
@@ -100,7 +102,7 @@ class CoreNodeMethodsKernelTest extends KernelTestBase {
     $this->expectException(\Exception::class);
     $this->expectExceptionMessage("Cannot create content because it is missing the required property 'type'.");
 
-    $this->core->nodeCreate((object) ['title' => 'Nope']);
+    $this->core->nodeCreate(new EntityStub('node', NULL, ['title' => 'Nope']));
   }
 
 }

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreSystemMethodsKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreSystemMethodsKernelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\Driver\Kernel\Core;
 
 use Drupal\Driver\Core\Core;
+use Drupal\Driver\Entity\EntityStub;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\user\Entity\User;
@@ -87,11 +88,14 @@ class CoreSystemMethodsKernelTest extends KernelTestBase {
   public function testLanguageLifecycle(): void {
     $this->assertNull(ConfigurableLanguage::load('fr'));
 
-    $result = $this->core->languageCreate((object) ['langcode' => 'fr']);
+    $stub = new EntityStub('language', NULL, ['langcode' => 'fr']);
+    $result = $this->core->languageCreate($stub);
     $this->assertNotFalse($result, 'languageCreate returned the stub for a new language.');
+    $this->assertSame($stub, $result);
+    $this->assertTrue($result->isSaved());
     $this->assertInstanceOf(ConfigurableLanguage::class, ConfigurableLanguage::load('fr'));
 
-    $this->core->languageDelete((object) ['langcode' => 'fr']);
+    $this->core->languageDelete($stub);
     $this->assertNull(ConfigurableLanguage::load('fr'));
   }
 
@@ -99,9 +103,9 @@ class CoreSystemMethodsKernelTest extends KernelTestBase {
    * Tests that languageCreate returns FALSE when the language already exists.
    */
   public function testLanguageCreateReturnsFalseWhenLanguageExists(): void {
-    $this->core->languageCreate((object) ['langcode' => 'fr']);
+    $this->core->languageCreate(new EntityStub('language', NULL, ['langcode' => 'fr']));
 
-    $second = $this->core->languageCreate((object) ['langcode' => 'fr']);
+    $second = $this->core->languageCreate(new EntityStub('language', NULL, ['langcode' => 'fr']));
 
     $this->assertFalse($second);
   }
@@ -115,7 +119,7 @@ class CoreSystemMethodsKernelTest extends KernelTestBase {
 
     $before_uid = \Drupal::currentUser()->id();
 
-    $this->core->login((object) ['uid' => $alice->id()]);
+    $this->core->login(new EntityStub('user', NULL, ['uid' => $alice->id()]));
     $this->assertSame((int) $alice->id(), (int) \Drupal::currentUser()->id(), 'login switched to alice.');
 
     $this->core->logout();

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreTermMethodsKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreTermMethodsKernelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\Driver\Kernel\Core;
 
 use Drupal\Driver\Core\Core;
+use Drupal\Driver\Entity\EntityStub;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\taxonomy\Entity\Vocabulary;
@@ -61,40 +62,41 @@ class CoreTermMethodsKernelTest extends KernelTestBase {
     $parent = Term::create(['name' => 'Frameworks', 'vid' => 'tags']);
     $parent->save();
 
-    $child_stub = (object) [
-      'vocabulary_machine_name' => 'tags',
+    $child_stub = new EntityStub('taxonomy_term', 'tags', [
       'name' => 'Drupal',
       'parent' => 'Frameworks',
-    ];
+    ]);
     $result = $this->core->termCreate($child_stub);
 
-    $this->assertNotEmpty($result->tid);
-    $child = Term::load($result->tid);
+    $this->assertSame($child_stub, $result);
+    $this->assertNotEmpty($result->getValue('tid'));
+    $this->assertTrue($result->isSaved());
+    $child = Term::load($result->getValue('tid'));
     $this->assertInstanceOf(Term::class, $child);
     $this->assertSame('Drupal', $child->getName());
     $this->assertSame((int) $parent->id(), (int) $child->get('parent')->target_id, 'parent name was resolved to tid.');
 
     $this->assertTrue($this->core->termDelete($result));
-    $this->assertNull(Term::load($result->tid));
+    $this->assertNull(Term::load($result->getValue('tid')));
   }
 
   /**
    * Tests that termDelete returns FALSE for a non-existent term.
    */
   public function testTermDeleteReturnsFalseForMissingTerm(): void {
-    $missing = (object) ['tid' => 99999];
+    $missing = new EntityStub('taxonomy_term', 'tags', ['tid' => 99999]);
 
     $this->assertFalse($this->core->termDelete($missing));
   }
 
   /**
-   * Tests that termCreate rejects a stub missing 'vocabulary_machine_name'.
+   * Tests that termCreate rejects a stub missing the vocabulary.
    */
   public function testTermCreateRejectsMissingVocabularyProperty(): void {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessageMatches("/missing the required property 'vocabulary_machine_name'/");
 
-    $this->core->termCreate((object) ['name' => 'Orphan']);
+    $this->core->termCreate(new EntityStub('taxonomy_term', NULL, ['name' => 'Orphan']));
   }
 
   /**
@@ -104,10 +106,9 @@ class CoreTermMethodsKernelTest extends KernelTestBase {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessageMatches("/vocabulary 'ghosts' does not exist/");
 
-    $this->core->termCreate((object) [
-      'vocabulary_machine_name' => 'ghosts',
+    $this->core->termCreate(new EntityStub('taxonomy_term', 'ghosts', [
       'name' => 'Casper',
-    ]);
+    ]));
   }
 
   /**
@@ -121,11 +122,10 @@ class CoreTermMethodsKernelTest extends KernelTestBase {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessageMatches("/parent term 'Missing' does not exist in vocabulary 'tags'/");
 
-    $this->core->termCreate((object) [
-      'vocabulary_machine_name' => 'tags',
+    $this->core->termCreate(new EntityStub('taxonomy_term', 'tags', [
       'name' => 'Orphaned',
       'parent' => 'Missing',
-    ]);
+    ]));
   }
 
 }

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreUserMethodsKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreUserMethodsKernelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\Driver\Kernel\Core;
 
 use Drupal\Driver\Core\Core;
+use Drupal\Driver\Entity\EntityStub;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
@@ -69,15 +70,16 @@ class CoreUserMethodsKernelTest extends KernelTestBase {
    */
   public function testUserLifecycle(): void {
     // 1. userCreate assigns a UID and persists the account.
-    $user_data = (object) [
+    $user_stub = new EntityStub('user', NULL, [
       'name' => 'alice',
       'mail' => 'alice@example.com',
       'pass' => 'correcthorsebatterystaple',
-    ];
-    $this->core->userCreate($user_data);
+    ]);
+    $this->core->userCreate($user_stub);
 
-    $this->assertNotEmpty($user_data->uid, 'userCreate populated uid.');
-    $account = User::load($user_data->uid);
+    $this->assertNotEmpty($user_stub->getValue('uid'), 'userCreate populated uid.');
+    $this->assertTrue($user_stub->isSaved(), 'userCreate marked the stub saved.');
+    $account = User::load($user_stub->getValue('uid'));
     $this->assertInstanceOf(User::class, $account);
     $this->assertSame('alice', $account->getAccountName());
     $this->assertSame(1, (int) $account->get('status')->value);
@@ -93,13 +95,13 @@ class CoreUserMethodsKernelTest extends KernelTestBase {
     $this->assertTrue($role->hasPermission($permission));
 
     // 3. userAddRole attaches the role to the user.
-    $this->core->userAddRole($user_data, $role_id);
-    $account = User::load($user_data->uid);
+    $this->core->userAddRole($user_stub, $role_id);
+    $account = User::load($user_stub->getValue('uid'));
     $this->assertContains($role_id, $account->getRoles());
 
     // 4. userDelete removes the user (processes the batch synchronously).
-    $this->core->userDelete($user_data);
-    $this->assertNull(\Drupal::entityTypeManager()->getStorage('user')->loadUnchanged($user_data->uid));
+    $this->core->userDelete($user_stub);
+    $this->assertNull(\Drupal::entityTypeManager()->getStorage('user')->loadUnchanged($user_stub->getValue('uid')));
 
     // 5. roleDelete removes the role.
     $this->core->roleDelete($role_id);
@@ -110,13 +112,17 @@ class CoreUserMethodsKernelTest extends KernelTestBase {
    * Tests that 'userAddRole()' throws when the role name is unknown.
    */
   public function testUserAddRoleThrowsOnUnknownRole(): void {
-    $user = (object) ['name' => 'ghost', 'mail' => 'ghost@example.com', 'pass' => 'pw'];
-    $this->core->userCreate($user);
+    $stub = new EntityStub('user', NULL, [
+      'name' => 'ghost',
+      'mail' => 'ghost@example.com',
+      'pass' => 'pw',
+    ]);
+    $this->core->userCreate($stub);
 
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessageMatches('/No role "nonexistent-role" exists/');
 
-    $this->core->userAddRole($user, 'nonexistent-role');
+    $this->core->userAddRole($stub, 'nonexistent-role');
   }
 
   /**

--- a/tests/Drupal/Tests/Driver/Kernel/Core/Field/AbstractHandlerFieldNotFoundKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/Field/AbstractHandlerFieldNotFoundKernelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\Driver\Kernel\Core\Field;
 
 use Drupal\Driver\Core\Field\DefaultHandler;
+use Drupal\Driver\Entity\EntityStub;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -35,7 +36,7 @@ class AbstractHandlerFieldNotFoundKernelTest extends FieldHandlerKernelTestBase 
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessageMatches('/does not exist on entity type "entity_test"/');
 
-    new DefaultHandler((object) [], self::ENTITY_TYPE, 'field_does_not_exist');
+    new DefaultHandler(new EntityStub(self::ENTITY_TYPE), self::ENTITY_TYPE, 'field_does_not_exist');
   }
 
 }

--- a/tests/Drupal/Tests/Driver/Kernel/Core/Field/CustomCoreKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/Field/CustomCoreKernelTest.php
@@ -8,6 +8,7 @@ use ConsumerProject\Driver\ConsumerCore;
 use ConsumerProject\Driver\Field\StringLongHandler as ConsumerStringLongHandler;
 use ConsumerProject\Driver\Field\TextLongHandler as ConsumerTextLongHandler;
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Driver\Entity\EntityStub;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -66,19 +67,19 @@ class CustomCoreKernelTest extends FieldHandlerKernelTestBase {
   public function testConsumerCoreOverridesLibraryHandler(): void {
     $this->attachField('field_body', 'text_long');
 
-    $stub = (object) [
-      'type' => self::BUNDLE,
+    $stub = new EntityStub(self::ENTITY_TYPE, self::BUNDLE, [
       'name' => 'test entity',
       'field_body' => [
         ['value' => 'raw input', 'format' => 'plain_text'],
       ],
-    ];
+    ]);
 
-    $this->core->entityCreate(self::ENTITY_TYPE, $stub);
+    $this->core->entityCreate($stub);
 
-    $this->assertSame(ConsumerTextLongHandler::MARKER, $stub->field_body[0]['value'], 'Consumer handler did not transform the field value during expand().');
+    $field_body = $stub->getValue('field_body');
+    $this->assertSame(ConsumerTextLongHandler::MARKER, $field_body[0]['value'], 'Consumer handler did not transform the field value during expand().');
 
-    $reloaded = \Drupal::entityTypeManager()->getStorage(self::ENTITY_TYPE)->loadUnchanged($stub->id);
+    $reloaded = \Drupal::entityTypeManager()->getStorage(self::ENTITY_TYPE)->loadUnchanged($stub->getValue('id'));
     $this->assertInstanceOf(ContentEntityInterface::class, $reloaded);
     $this->assertSame(ConsumerTextLongHandler::MARKER, $reloaded->get('field_body')->getValue()[0]['value'], 'Storage did not receive the consumer handler output.');
   }
@@ -95,17 +96,17 @@ class CustomCoreKernelTest extends FieldHandlerKernelTestBase {
   public function testConsumerCoreAddsHandlerForNewFieldType(): void {
     $this->attachField('field_summary', 'string_long');
 
-    $stub = (object) [
-      'type' => self::BUNDLE,
+    $stub = new EntityStub(self::ENTITY_TYPE, self::BUNDLE, [
       'name' => 'test entity',
       'field_summary' => [['value' => 'raw input']],
-    ];
+    ]);
 
-    $this->core->entityCreate(self::ENTITY_TYPE, $stub);
+    $this->core->entityCreate($stub);
 
-    $this->assertSame(ConsumerStringLongHandler::MARKER, $stub->field_summary[0]['value'], 'Consumer handler did not transform the field value during expand().');
+    $field_summary = $stub->getValue('field_summary');
+    $this->assertSame(ConsumerStringLongHandler::MARKER, $field_summary[0]['value'], 'Consumer handler did not transform the field value during expand().');
 
-    $reloaded = \Drupal::entityTypeManager()->getStorage(self::ENTITY_TYPE)->loadUnchanged($stub->id);
+    $reloaded = \Drupal::entityTypeManager()->getStorage(self::ENTITY_TYPE)->loadUnchanged($stub->getValue('id'));
     $this->assertInstanceOf(ContentEntityInterface::class, $reloaded);
     $this->assertSame(ConsumerStringLongHandler::MARKER, $reloaded->get('field_summary')->getValue()[0]['value'], 'Storage did not receive the consumer handler output.');
   }

--- a/tests/Drupal/Tests/Driver/Kernel/Core/Field/DatetimeHandlerKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/Field/DatetimeHandlerKernelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\Driver\Kernel\Core\Field;
 
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItem;
+use Drupal\Driver\Entity\EntityStub;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -58,16 +59,15 @@ class DatetimeHandlerKernelTest extends FieldHandlerKernelTestBase {
       'datetime_type' => DateTimeItem::DATETIME_TYPE_DATETIME,
     ]);
 
-    $stub = (object) [
-      'type' => self::BUNDLE,
+    $stub = new EntityStub(self::ENTITY_TYPE, self::BUNDLE, [
       'name' => 'relative-date',
       'field_seen' => ['relative:2026-01-02 03:04:05'],
-    ];
-    $this->core->entityCreate(self::ENTITY_TYPE, $stub);
+    ]);
+    $this->core->entityCreate($stub);
 
     // The 'relative:' prefix is stripped before parsing; the resulting value
     // matches the same storage string the plain timestamp would have produced.
-    $this->assertSame(['2026-01-02T03:04:05'], $stub->field_seen);
+    $this->assertSame(['2026-01-02T03:04:05'], $stub->getValue('field_seen'));
   }
 
 }

--- a/tests/Drupal/Tests/Driver/Kernel/Core/Field/FieldHandlerKernelTestBase.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/Field/FieldHandlerKernelTestBase.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\Driver\Kernel\Core\Field;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Driver\Core\Core;
+use Drupal\Driver\Entity\EntityStub;
 use Drupal\entity_test\EntityTestHelper;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
@@ -21,7 +22,7 @@ use Drupal\KernelTests\KernelTestBase;
  *   1. Call attachField() to declare the field under test.
  *   2. Call assertFieldRoundTripViaDriver() with the input value.
  *
- * The round-trip assertion compares the driver-mutated stdClass stub (which
+ * The round-trip assertion compares the driver-mutated EntityStub (which
  * holds whatever the handler emitted from expand()) against the reloaded
  * entity. No assertions are made against expect-specific expand() values;
  * that coverage belongs in per-handler unit tests.
@@ -113,9 +114,9 @@ abstract class FieldHandlerKernelTestBase extends KernelTestBase {
   /**
    * Drives entity creation through the driver and asserts field round-trip.
    *
-   * Core::entityCreate mutates the passed stdClass so its field values reflect
-   * whatever the handler emitted. This method iterates those post-expansion
-   * values and asserts the reloaded entity holds the same data.
+   * Core::entityCreate mutates the passed stub so its values reflect whatever
+   * the handler emitted. This method iterates those post-expansion values and
+   * asserts the reloaded entity holds the same data.
    *
    * For single-property scalar values, the assertion compares against the
    * main field column. For multi-property arrays (e.g. link.uri / link.title),
@@ -129,25 +130,25 @@ abstract class FieldHandlerKernelTestBase extends KernelTestBase {
    *   or an associative array (for multi-property fields).
    */
   protected function assertFieldRoundTripViaDriver(string $field_name, array $values): void {
-    $stub = (object) [
-      'type' => self::BUNDLE,
+    $stub = new EntityStub(self::ENTITY_TYPE, self::BUNDLE, [
       'name' => 'test entity',
       $field_name => $values,
-    ];
+    ]);
 
-    $this->core->entityCreate(self::ENTITY_TYPE, $stub);
+    $this->core->entityCreate($stub);
 
     $reloaded = \Drupal::entityTypeManager()
       ->getStorage(self::ENTITY_TYPE)
-      ->loadUnchanged($stub->id);
+      ->loadUnchanged($stub->getValue('id'));
     $this->assertInstanceOf(ContentEntityInterface::class, $reloaded);
 
     // Some handlers (e.g. ImageHandler) emit a flat associative array as
     // single-delta shorthand rather than a list of deltas. Normalise that
     // shape into a one-element list so the iteration below is uniform.
-    $deltas = is_array($stub->$field_name) && !array_is_list($stub->$field_name)
-      ? [$stub->$field_name]
-      : $stub->$field_name;
+    $expanded = $stub->getValue($field_name);
+    $deltas = is_array($expanded) && !array_is_list($expanded)
+      ? [$expanded]
+      : $expanded;
 
     // Assert the stored delta count matches the stub so a handler that
     // duplicates or appends deltas cannot slip through the per-delta loop.

--- a/tests/Drupal/Tests/Driver/Kernel/Core/Field/FieldHandlerRegistryKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/Field/FieldHandlerRegistryKernelTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\Driver\Kernel\Core\Field;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Driver\Core\Field\AbstractHandler;
+use Drupal\Driver\Entity\EntityStub;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -54,19 +55,19 @@ class FieldHandlerRegistryKernelTest extends FieldHandlerKernelTestBase {
     $this->core->registerFieldHandler('text_with_summary', MarkerTextWithSummaryHandler::class);
     $this->attachField('field_body', 'text_with_summary');
 
-    $stub = (object) [
-      'type' => self::BUNDLE,
+    $stub = new EntityStub(self::ENTITY_TYPE, self::BUNDLE, [
       'name' => 'test entity',
       'field_body' => [
         ['value' => 'raw input', 'format' => 'plain_text'],
       ],
-    ];
+    ]);
 
-    $this->core->entityCreate(self::ENTITY_TYPE, $stub);
+    $this->core->entityCreate($stub);
 
-    $this->assertSame(MarkerTextWithSummaryHandler::MARKER, $stub->field_body[0]['value'], 'Consumer handler did not transform the field value during expand().');
+    $field_body = $stub->getValue('field_body');
+    $this->assertSame(MarkerTextWithSummaryHandler::MARKER, $field_body[0]['value'], 'Consumer handler did not transform the field value during expand().');
 
-    $reloaded = \Drupal::entityTypeManager()->getStorage(self::ENTITY_TYPE)->loadUnchanged($stub->id);
+    $reloaded = \Drupal::entityTypeManager()->getStorage(self::ENTITY_TYPE)->loadUnchanged($stub->getValue('id'));
     $this->assertInstanceOf(ContentEntityInterface::class, $reloaded);
     $this->assertSame(MarkerTextWithSummaryHandler::MARKER, $reloaded->get('field_body')->getValue()[0]['value'], 'Storage did not receive the consumer handler output.');
   }

--- a/tests/Drupal/Tests/Driver/Kernel/Core/Field/FileHandlerReuseKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/Field/FileHandlerReuseKernelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\Driver\Kernel\Core\Field;
 
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Driver\Entity\EntityStub;
 use Drupal\file\Entity\File;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -54,15 +55,14 @@ class FileHandlerReuseKernelTest extends FieldHandlerKernelTestBase {
 
     $existing = $this->createManagedFileAt('public://preexisting-uri.txt', 'hello uri');
 
-    $stub = (object) [
-      'type' => self::BUNDLE,
+    $stub = new EntityStub(self::ENTITY_TYPE, self::BUNDLE, [
       'name' => 'with existing file',
       'field_attachment' => ['public://preexisting-uri.txt'],
-    ];
+    ]);
 
-    $this->core->entityCreate(self::ENTITY_TYPE, $stub);
+    $this->core->entityCreate($stub);
 
-    $this->assertEquals($existing->id(), $this->loadFieldTargetId($stub->id, 'field_attachment'));
+    $this->assertEquals($existing->id(), $this->loadFieldTargetId($stub->getValue('id'), 'field_attachment'));
     $this->assertSame(1, $this->fileEntityCount(), 'A second managed file was created instead of reusing the existing one.');
   }
 
@@ -74,15 +74,14 @@ class FileHandlerReuseKernelTest extends FieldHandlerKernelTestBase {
 
     $existing = $this->createManagedFileAt('public://preexisting-basename.txt', 'hello basename');
 
-    $stub = (object) [
-      'type' => self::BUNDLE,
+    $stub = new EntityStub(self::ENTITY_TYPE, self::BUNDLE, [
       'name' => 'with existing file by basename',
       'field_attachment' => ['preexisting-basename.txt'],
-    ];
+    ]);
 
-    $this->core->entityCreate(self::ENTITY_TYPE, $stub);
+    $this->core->entityCreate($stub);
 
-    $this->assertEquals($existing->id(), $this->loadFieldTargetId($stub->id, 'field_attachment'));
+    $this->assertEquals($existing->id(), $this->loadFieldTargetId($stub->getValue('id'), 'field_attachment'));
     $this->assertSame(1, $this->fileEntityCount());
   }
 

--- a/tests/Drupal/Tests/Driver/Kernel/Core/Field/ImageHandlerReuseKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/Field/ImageHandlerReuseKernelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\Driver\Kernel\Core\Field;
 
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Driver\Entity\EntityStub;
 use Drupal\file\Entity\File;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -55,15 +56,14 @@ class ImageHandlerReuseKernelTest extends FieldHandlerKernelTestBase {
 
     $existing = $this->createManagedFileAt('public://existing-hero.jpg', 'fixture');
 
-    $stub = (object) [
-      'type' => self::BUNDLE,
+    $stub = new EntityStub(self::ENTITY_TYPE, self::BUNDLE, [
       'name' => 'reuse by uri',
       'field_photo' => ['public://existing-hero.jpg', 'alt' => 'Hero', 'title' => 'Hero title'],
-    ];
+    ]);
 
-    $this->core->entityCreate(self::ENTITY_TYPE, $stub);
+    $this->core->entityCreate($stub);
 
-    $stored = $this->loadFirstItem($stub->id, 'field_photo');
+    $stored = $this->loadFirstItem($stub->getValue('id'), 'field_photo');
     $this->assertEquals($existing->id(), $stored->get('target_id')->getValue());
     $this->assertSame('Hero', $stored->get('alt')->getValue());
     $this->assertSame('Hero title', $stored->get('title')->getValue());
@@ -78,15 +78,14 @@ class ImageHandlerReuseKernelTest extends FieldHandlerKernelTestBase {
 
     $existing = $this->createManagedFileAt('public://existing-logo.png', 'fixture');
 
-    $stub = (object) [
-      'type' => self::BUNDLE,
+    $stub = new EntityStub(self::ENTITY_TYPE, self::BUNDLE, [
       'name' => 'reuse by basename',
       'field_photo' => ['existing-logo.png'],
-    ];
+    ]);
 
-    $this->core->entityCreate(self::ENTITY_TYPE, $stub);
+    $this->core->entityCreate($stub);
 
-    $stored = $this->loadFirstItem($stub->id, 'field_photo');
+    $stored = $this->loadFirstItem($stub->getValue('id'), 'field_photo');
     $this->assertEquals($existing->id(), $stored->get('target_id')->getValue());
     $this->assertSame(1, $this->fileEntityCount());
   }

--- a/tests/Drupal/Tests/Driver/Kernel/Core/Field/ListStringHandlerKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/Field/ListStringHandlerKernelTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\Driver\Kernel\Core\Field;
 
+use Drupal\Driver\Entity\EntityStub;
 use Drupal\entity_test\Entity\EntityTest;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -50,13 +51,12 @@ class ListStringHandlerKernelTest extends FieldHandlerKernelTestBase {
     // Pin the translation explicitly so a regression where the handler stops
     // converting labels to keys is caught even though the mutated-stub
     // round-trip would otherwise pass.
-    $stub = (object) [
-      'type' => 'entity_test',
+    $stub = new EntityStub('entity_test', 'entity_test', [
       'name' => 'pinned',
       'field_status' => ['Active'],
-    ];
-    $this->core->entityCreate('entity_test', $stub);
-    $reloaded = EntityTest::load($stub->id);
+    ]);
+    $this->core->entityCreate($stub);
+    $reloaded = EntityTest::load($stub->getValue('id'));
     $this->assertSame('active', $reloaded->get('field_status')->value);
   }
 

--- a/tests/Drupal/Tests/Driver/Unit/Core/CoreErrorPathsTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/CoreErrorPathsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\Driver\Unit\Core;
 
 use Drupal\Driver\Core\Core;
+use Drupal\Driver\Entity\EntityStub;
 use Drupal\Driver\Exception\BootstrapException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -81,7 +82,7 @@ class CoreErrorPathsTest extends TestCase {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessageMatches('/You must specify an entity type/');
 
-    $core->entityCreate('', (object) []);
+    $core->entityCreate(new EntityStub(''));
   }
 
   /**

--- a/tests/Drupal/Tests/Driver/Unit/Core/CoreFieldHandlerLookupTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/CoreFieldHandlerLookupTest.php
@@ -14,6 +14,7 @@ use Drupal\Driver\Core\Core;
 use Drupal\Driver\Core\Field\AbstractHandler;
 use Drupal\Driver\Core\Field\AddressHandler;
 use Drupal\Driver\Core\Field\DefaultHandler;
+use Drupal\Driver\Entity\EntityStub;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
@@ -55,7 +56,7 @@ class CoreFieldHandlerLookupTest extends TestCase {
   public function testConstructorRegistersBuiltInHandlers(): void {
     $core = new FieldTypeMapCore(__DIR__, 'default', ['field_address' => 'address']);
 
-    $handler = $core->getFieldHandler(new \stdClass(), 'node', 'field_address');
+    $handler = $core->getFieldHandler(new EntityStub('node'), 'node', 'field_address');
 
     $this->assertInstanceOf(AddressHandler::class, $handler);
   }
@@ -67,7 +68,7 @@ class CoreFieldHandlerLookupTest extends TestCase {
     $core = new FieldTypeMapCore(__DIR__, 'default', ['field_address' => 'address']);
     $core->registerFieldHandler('address', CustomFieldHandler::class);
 
-    $handler = $core->getFieldHandler(new \stdClass(), 'node', 'field_address');
+    $handler = $core->getFieldHandler(new EntityStub('node'), 'node', 'field_address');
 
     $this->assertInstanceOf(CustomFieldHandler::class, $handler);
   }
@@ -78,7 +79,7 @@ class CoreFieldHandlerLookupTest extends TestCase {
   public function testUnknownFieldTypeFallsBackToDefaultHandler(): void {
     $core = new FieldTypeMapCore(__DIR__, 'default', ['field_x' => 'nonexistent_type']);
 
-    $handler = $core->getFieldHandler(new \stdClass(), 'node', 'field_x');
+    $handler = $core->getFieldHandler(new EntityStub('node'), 'node', 'field_x');
 
     $this->assertInstanceOf(DefaultHandler::class, $handler);
   }
@@ -92,7 +93,7 @@ class CoreFieldHandlerLookupTest extends TestCase {
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessageMatches('/Field "field_missing" not found/');
 
-    $core->getFieldHandler(new \stdClass(), 'node', 'field_missing');
+    $core->getFieldHandler(new EntityStub('node'), 'node', 'field_missing');
   }
 
   /**

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/AbstractHandlerErrorPathsTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/AbstractHandlerErrorPathsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\Driver\Unit\Core\Field;
 
 use Drupal\Driver\Core\Field\DefaultHandler;
+use Drupal\Driver\Entity\EntityStub;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
@@ -29,7 +30,7 @@ class AbstractHandlerErrorPathsTest extends TestCase {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessageMatches('/You must specify an entity type/');
 
-    new DefaultHandler((object) [], '', 'field_any');
+    new DefaultHandler(new EntityStub(''), '', 'field_any');
   }
 
 }

--- a/tests/Drupal/Tests/Driver/Unit/DrupalDriverDelegationTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/DrupalDriverDelegationTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\Driver\Unit;
 use Drupal\Component\Utility\Random;
 use Drupal\Driver\Core\CoreInterface;
 use Drupal\Driver\DrupalDriver;
+use Drupal\Driver\Entity\EntityStub;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -100,7 +101,7 @@ class DrupalDriverDelegationTest extends TestCase {
     $core = $this->createMock(CoreInterface::class);
     $driver = $this->createDriverWithCore($core);
 
-    $driver->login(new \stdClass());
+    $driver->login(new EntityStub('user'));
 
     $this->addToAssertionCount(1);
   }
@@ -142,11 +143,13 @@ class DrupalDriverDelegationTest extends TestCase {
    * Data provider listing every delegating method and its arguments.
    */
   public static function dataProviderForwardsToCore(): \Iterator {
-    $user = new \stdClass();
-    $node = new \stdClass();
-    $term = new \stdClass();
-    $entity = new \stdClass();
-    $language = new \stdClass();
+    $user = new EntityStub('user');
+    $node = new EntityStub('node', 'article');
+    $term = new EntityStub('taxonomy_term', 'tags');
+    $entity = new EntityStub('node', 'article');
+    $language = new EntityStub('language', NULL, ['langcode' => 'fr']);
+    $block = new EntityStub('block');
+    $block_content = new EntityStub('block_content', 'basic');
 
     yield 'userCreate' => ['userCreate', [$user], 'userCreate'];
     yield 'userDelete' => ['userDelete', [$user], 'userDelete'];
@@ -168,12 +171,12 @@ class DrupalDriverDelegationTest extends TestCase {
     yield 'configGet' => ['configGet', ['system.site', 'name'], 'configGet'];
     yield 'configGetOriginal' => ['configGetOriginal', ['system.site', 'name'], 'configGetOriginal'];
     yield 'configSet' => ['configSet', ['system.site', 'name', 'v'], 'configSet'];
-    yield 'entityCreate' => ['entityCreate', ['node', $entity], 'entityCreate'];
-    yield 'entityDelete' => ['entityDelete', ['node', $entity], 'entityDelete'];
-    yield 'blockPlace' => ['blockPlace', [new \stdClass()], 'blockPlace'];
-    yield 'blockDelete' => ['blockDelete', [new \stdClass()], 'blockDelete'];
-    yield 'blockContentCreate' => ['blockContentCreate', [new \stdClass()], 'blockContentCreate'];
-    yield 'blockContentDelete' => ['blockContentDelete', [new \stdClass()], 'blockContentDelete'];
+    yield 'entityCreate' => ['entityCreate', [$entity], 'entityCreate'];
+    yield 'entityDelete' => ['entityDelete', [$entity], 'entityDelete'];
+    yield 'blockPlace' => ['blockPlace', [$block], 'blockPlace'];
+    yield 'blockDelete' => ['blockDelete', [$block], 'blockDelete'];
+    yield 'blockContentCreate' => ['blockContentCreate', [$block_content], 'blockContentCreate'];
+    yield 'blockContentDelete' => ['blockContentDelete', [$block_content], 'blockContentDelete'];
     yield 'mailStartCollecting' => ['mailStartCollecting', [], 'mailStartCollecting'];
     yield 'mailStopCollecting' => ['mailStopCollecting', [], 'mailStopCollecting'];
     yield 'mailGet' => ['mailGet', [], 'mailGet'];

--- a/tests/Drupal/Tests/Driver/Unit/DrushDriverMethodsTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/DrushDriverMethodsTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\Driver\Unit;
 
 use Drupal\Component\Utility\Random;
 use Drupal\Driver\DrushDriver;
+use Drupal\Driver\Entity\EntityStub;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
@@ -138,12 +139,12 @@ class DrushDriverMethodsTest extends TestCase {
     $driver = $this->createDriver();
     $driver->drushResponse = "User ID   :   7\nUser name :   bob\n";
 
-    $user = (object) [
+    $user = new EntityStub('user', NULL, [
       'name' => 'bob',
       'pass' => 'pw',
       'mail' => 'bob@ex.co',
       'roles' => ['editor', 'reviewer'],
-    ];
+    ]);
     $driver->userCreate($user);
 
     $commands = array_column($driver->invocations, 'command');
@@ -367,7 +368,7 @@ class DrushDriverMethodsTest extends TestCase {
    * Data provider: method -> args -> first-expected-drush-command.
    */
   public static function dataProviderInvokesDrush(): \Iterator {
-    $user = (object) ['name' => 'alice', 'pass' => 'pw', 'mail' => 'alice@ex.co'];
+    $user = new EntityStub('user', NULL, ['name' => 'alice', 'pass' => 'pw', 'mail' => 'alice@ex.co']);
 
     yield 'userCreate' => ['userCreate', [$user], 'user-create'];
     yield 'userDelete' => ['userDelete', [$user], 'user-cancel'];

--- a/tests/Drupal/Tests/Driver/Unit/Entity/EntityStubTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Entity/EntityStubTest.php
@@ -72,13 +72,19 @@ class EntityStubTest extends TestCase {
 
   /**
    * Tests that 'hasValue()' is true even when the stored value is NULL.
+   *
+   * Pinned alongside the 'getValue()' assertion so a future regression that
+   * swaps 'array_key_exists()' back for the null-coalescing operator surfaces
+   * here rather than as a quiet null-vs-default ambiguity downstream.
    */
   public function testHasValueDistinguishesNullFromAbsent(): void {
     $stub = new EntityStub('node', 'article');
     $stub->setValue('title', NULL);
 
     $this->assertTrue($stub->hasValue('title'), 'NULL is a stored value.');
+    $this->assertNull($stub->getValue('title', 'fallback'), 'Stored NULL is preserved by getValue, not replaced by the default.');
     $this->assertFalse($stub->hasValue('promote'), 'unset key is not a stored value.');
+    $this->assertSame('fallback', $stub->getValue('promote', 'fallback'), 'Unset key falls back to the supplied default.');
   }
 
   /**

--- a/tests/Drupal/Tests/Driver/Unit/Entity/EntityStubTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Entity/EntityStubTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\Driver\Unit\Entity;
+
+use Drupal\Driver\Entity\EntityStub;
+use Drupal\Driver\Entity\EntityStubInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the EntityStub typed envelope.
+ *
+ * @group entity
+ */
+#[Group('entity')]
+class EntityStubTest extends TestCase {
+
+  /**
+   * Tests that the constructor pins entity type and bundle.
+   */
+  public function testConstructorPinsTypeAndBundle(): void {
+    $stub = new EntityStub('node', 'article');
+
+    $this->assertSame('node', $stub->getEntityType());
+    $this->assertSame('article', $stub->getBundle());
+  }
+
+  /**
+   * Tests that the constructor accepts an initial values bag.
+   */
+  public function testConstructorAcceptsInitialValues(): void {
+    $stub = new EntityStub('node', 'article', ['title' => 'Hello']);
+
+    $this->assertTrue($stub->hasValue('title'));
+    $this->assertSame('Hello', $stub->getValue('title'));
+    $this->assertSame(['title' => 'Hello'], $stub->getValues());
+  }
+
+  /**
+   * Tests that the bundle defaults to NULL for entity types without bundles.
+   */
+  public function testBundleDefaultsToNull(): void {
+    $stub = new EntityStub('user');
+
+    $this->assertNull($stub->getBundle());
+  }
+
+  /**
+   * Tests that 'getValue()' returns the supplied default for unset keys.
+   */
+  public function testGetValueReturnsDefaultWhenAbsent(): void {
+    $stub = new EntityStub('node', 'article');
+
+    $this->assertNull($stub->getValue('title'));
+    $this->assertSame('fallback', $stub->getValue('title', 'fallback'));
+  }
+
+  /**
+   * Tests that 'setValue()' returns $this for chaining.
+   */
+  public function testSetValueIsChainable(): void {
+    $stub = new EntityStub('node', 'article');
+
+    $returned = $stub->setValue('title', 'Hello')->setValue('promote', 1);
+
+    $this->assertSame($stub, $returned);
+    $this->assertSame('Hello', $stub->getValue('title'));
+    $this->assertSame(1, $stub->getValue('promote'));
+  }
+
+  /**
+   * Tests that 'hasValue()' is true even when the stored value is NULL.
+   */
+  public function testHasValueDistinguishesNullFromAbsent(): void {
+    $stub = new EntityStub('node', 'article');
+    $stub->setValue('title', NULL);
+
+    $this->assertTrue($stub->hasValue('title'), 'NULL is a stored value.');
+    $this->assertFalse($stub->hasValue('promote'), 'unset key is not a stored value.');
+  }
+
+  /**
+   * Tests that 'removeValue()' deletes a key from the bag.
+   */
+  public function testRemoveValueDeletesKey(): void {
+    $stub = new EntityStub('node', 'article', ['title' => 'Hello']);
+
+    $stub->removeValue('title');
+
+    $this->assertFalse($stub->hasValue('title'));
+    $this->assertSame([], $stub->getValues());
+  }
+
+  /**
+   * Tests that 'setValues()' replaces the bag wholesale.
+   */
+  public function testSetValuesReplacesBag(): void {
+    $stub = new EntityStub('node', 'article', ['title' => 'Old']);
+
+    $stub->setValues(['promote' => 1]);
+
+    $this->assertFalse($stub->hasValue('title'), 'old keys were dropped.');
+    $this->assertSame(1, $stub->getValue('promote'));
+  }
+
+  /**
+   * Tests that 'isSaved()' flips after 'markSaved()'.
+   */
+  public function testIsSavedFlipsAfterMarkSaved(): void {
+    $stub = new EntityStub('node', 'article');
+
+    $this->assertFalse($stub->isSaved());
+
+    $stub->markSaved((object) ['id' => 7]);
+
+    $this->assertTrue($stub->isSaved());
+  }
+
+  /**
+   * Tests that 'getSavedEntity()' returns the supplied entity.
+   */
+  public function testGetSavedEntityReturnsAttachedObject(): void {
+    $entity = (object) ['id' => 7];
+    $stub = new EntityStub('node', 'article');
+    $stub->markSaved($entity);
+
+    $this->assertSame($entity, $stub->getSavedEntity());
+  }
+
+  /**
+   * Tests that 'getSavedEntity()' throws on an unsaved stub.
+   */
+  public function testGetSavedEntityThrowsWhenUnsaved(): void {
+    $stub = new EntityStub('node', 'article');
+
+    $this->expectException(\LogicException::class);
+    $this->expectExceptionMessageMatches('/EntityStub for "node" has not been saved/');
+
+    $stub->getSavedEntity();
+  }
+
+  /**
+   * Tests that 'getId()' resolves through the saved entity's id() method.
+   */
+  public function testGetIdReadsFromSavedEntity(): void {
+    $entity = new class() {
+
+      /**
+       * Returns a fixed identifier mirroring Drupal's entity 'id()' contract.
+       */
+      public function id(): int {
+        return 42;
+      }
+
+    };
+
+    $stub = new EntityStub('node', 'article');
+    $stub->markSaved($entity);
+
+    $this->assertSame(42, $stub->getId());
+  }
+
+  /**
+   * Tests that 'getId()' returns NULL when the stub is not saved.
+   */
+  public function testGetIdReturnsNullWhenUnsaved(): void {
+    $stub = new EntityStub('node', 'article');
+
+    $this->assertNull($stub->getId());
+  }
+
+  /**
+   * Tests that 'getId()' returns NULL when the saved entity has no 'id()'.
+   */
+  public function testGetIdReturnsNullWhenSavedEntityHasNoIdMethod(): void {
+    $stub = new EntityStub('node', 'article');
+    $stub->markSaved((object) ['identifier' => 'x']);
+
+    $this->assertNull($stub->getId());
+  }
+
+  /**
+   * Tests that the bundle key defaults to 'type' and is mutable.
+   */
+  public function testBundleKeyDefaultsToTypeAndIsMutable(): void {
+    $stub = new EntityStub('taxonomy_term', 'tags');
+
+    $this->assertSame(EntityStubInterface::DEFAULT_BUNDLE_KEY, $stub->getBundleKey());
+    $this->assertSame('type', $stub->getBundleKey());
+
+    $returned = $stub->setBundleKey('vid');
+
+    $this->assertSame($stub, $returned);
+    $this->assertSame('vid', $stub->getBundleKey());
+  }
+
+  /**
+   * Tests that the stub implements the documented interface.
+   */
+  public function testImplementsInterface(): void {
+    $this->assertInstanceOf(EntityStubInterface::class, new EntityStub('node'));
+  }
+
+}


### PR DESCRIPTION
Closes #362

## Summary

This PR replaces the untyped `\stdClass` shape that flowed between callers and every driver create/delete method with a purposefully typed `EntityStub` class and its `EntityStubInterface` contract. The `EntityStub` carries the entity type, bundle, a mutable values bag, and a saved-entity slot - giving call sites a single coherent object that self-describes its state both before and after a driver write. Because this is a hard type break in all public capability interfaces, it ships as a `4.0.0` semver major.

## Changes

### New types

- `src/Drupal/Driver/Entity/EntityStubInterface.php` - contract with `getEntityType()`, `getBundle()`, `getBundleKey()`, values-bag accessors (`getValue`, `setValue`, `hasValue`, `removeValue`, `getValues`, `setValues`), and saved-entity accessors (`isSaved`, `markSaved`, `getSavedEntity`, `getId`).
- `src/Drupal/Driver/Entity/EntityStub.php` - `final` implementation; entity type and bundle are constructor-pinned (immutable), values bag and saved-entity slot are mutable.

### Capability interfaces

All five interfaces that previously accepted or returned `\stdClass` or `object` now declare `EntityStubInterface`:

- `AuthenticationCapabilityInterface::login()` - parameter changed from `\stdClass` to `EntityStubInterface`.
- `BlockCapabilityInterface` - all four methods (`blockPlace`, `blockDelete`, `blockContentCreate`, `blockContentDelete`) updated.
- `ContentCapabilityInterface` - all five methods (`nodeCreate`, `nodeDelete`, `termCreate`, `termDelete`, `entityCreate`, `entityDelete`) updated.
- `LanguageCapabilityInterface` - `languageCreate()` updated.
- `UserCapabilityInterface` - `userCreate()`, `userDelete()`, `userAddRole()` updated.

### Driver implementations

- `DrupalDriver` - all delegating methods updated to accept/return `EntityStubInterface`; internal `\stdClass`-construction sites replaced with `new EntityStub(...)`.
- `DrushDriver` - same as above for the subset of capabilities it declares.
- `Core` / `CoreInterface` - all create/delete/login implementations updated; the synthesised `\stdClass` that the field-handler pipeline previously received replaced with a typed `EntityStubInterface`.

### Field handler boundary

`AbstractHandler::__construct()` and `Core::getFieldHandler()` now accept `EntityStubInterface` directly instead of synthesising a temporary `\stdClass` from bundle context. This removes an internal impedance mismatch that existed even before callers were typed.

### Tests

- `tests/Drupal/Tests/Driver/Unit/Entity/EntityStubTest.php` - 206-line PHPUnit unit test covering construction, values-bag mutations, saved-entity lifecycle, `getId()`, and error paths.
- All 20+ kernel tests and unit tests that constructed stubs as `(object) [...]` or `new \stdClass` migrated to `new EntityStub(...)`.

## Before / After

**Before** - a node-create call used an anonymous `\stdClass`:

```
Caller                        DrupalDriver               Core
  |                               |                        |
  |  nodeCreate(\stdClass $node)  |                        |
  |------------------------------>|                        |
  |                               |  nodeCreate(\stdClass) |
  |                               |----------------------->|
  |                               |            synthesise \stdClass for field handler
  |                               |            [field_handler->expand($stub_as_stdClass)]
  |                               |            $node->save()
  |                               |            $node->id() written back to stdClass->nid
  |                               |<-----------------------|
  |  returns object (\stdClass)   |                        |
  |<------------------------------|                        |
  [caller must know which property holds the saved id]
```

**After** - same call with `EntityStub`:

```
Caller                              DrupalDriver                  Core
  |                                     |                           |
  |  nodeCreate(EntityStubInterface)    |                           |
  |------------------------------------>|                           |
  |                                     |  nodeCreate(EntityStub)  |
  |                                     |-------------------------->|
  |                                     |       [field_handler->expand($stub)]
  |                                     |       $node->save()
  |                                     |       $stub->markSaved($node)
  |                                     |<--------------------------|
  |  returns EntityStubInterface        |                           |
  |  ($stub->isSaved() === TRUE)        |                           |
  |  ($stub->getId() === $nid)          |                           |
  |<------------------------------------|                           |
  [caller uses typed accessors; no property-name guessing]
```

## Notes for reviewers

Four intentional deviations from the original plan in `.artifacts/entity-stub-plan.md`:

1. **Clean break, no `\stdClass` shim** - the plan mentioned a dual-acceptance shim during a transition window. That was dropped in favour of a clean cut paired with the major-version bump. Simpler code, no dead path to maintain.
2. **`step_bundle` legacy fallback removed** - the plan preserved a secondary bundle lookup via a `step_bundle` property on the old `\stdClass`. The typed `EntityStub` constructor argument is now the single canonical bundle source.
3. **`Drupal\Driver\Entity` namespace + `EntityStubInterface` contract** - the plan placed `EntityStub` directly under `Drupal\Driver` with no interface. It was promoted to its own namespace and given an interface so that callers can depend on the contract rather than the concrete class, and so a future subclass or decorator (e.g. for a remote driver) does not need to extend the `final` implementation.
4. **`bundle_key` accessor added to the stub** - `getBundleKey()` / `setBundleKey()` default to `'type'` and let drivers write the real bundle key from the entity type definition once. This avoids repeated entity-type-definition lookups at field-handler call time and removes the implicit `'type'` assumption that was scattered across `Core` previously.
5. **`EntityStubInterface` propagated into `AbstractHandler` and `Core::getFieldHandler()`** - the plan kept the field-handler boundary untyped. The user explicitly requested full propagation so the typed contract reaches all the way to the expand pipeline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a typed entity stub concept for carrying entity type, bundle, values and persisted IDs through driver workflows.

* **Refactor**
  * Driver APIs now uniformly accept/return the typed stub, improving lifecycle consistency (creates return the same stub populated with IDs; deletes use persisted stub state).
  * Field and bundle resolution now derive context from the stub.

* **Tests**
  * Test suites updated to exercise the new stub-based flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->