### PR TITLE
Renamed 'classifier()' accessor to 'getFieldClassifier()' on 'CoreInterface'.

### DIFF
--- a/src/Drupal/Driver/Core/Core.php
+++ b/src/Drupal/Driver/Core/Core.php
@@ -199,7 +199,7 @@ class Core implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function classifier(): FieldClassifierInterface {
+  public function getFieldClassifier(): FieldClassifierInterface {
     if (!$this->fieldClassifier instanceof FieldClassifierInterface) {
       $this->fieldClassifier = $this->createFieldClassifier();
     }
@@ -885,11 +885,11 @@ class Core implements CoreInterface {
       // F5 is additionally scoped to the bundle when known - otherwise a
       // configurable field storage attached only to other bundles would slip
       // into the type map and blow up in AbstractHandler::__construct().
-      $is_base_standard = $this->classifier()->fieldIsBaseStandard($entity_type, $field_name);
-      $is_configurable = $this->classifier()->fieldIsConfigurable($entity_type, $field_name)
+      $is_base_standard = $this->getFieldClassifier()->fieldIsBaseStandard($entity_type, $field_name);
+      $is_configurable = $this->getFieldClassifier()->fieldIsConfigurable($entity_type, $field_name)
         && ($bundle === NULL || isset($bundle_fields[$field_name]));
       $is_bundle_storage_backed = $bundle !== NULL
-        && $this->classifier()->fieldIsBundleStorageBacked($entity_type, $field_name, $bundle);
+        && $this->getFieldClassifier()->fieldIsBundleStorageBacked($entity_type, $field_name, $bundle);
 
       if (!$is_base_standard && !$is_configurable && !$is_bundle_storage_backed) {
         continue;

--- a/src/Drupal/Driver/Core/CoreInterface.php
+++ b/src/Drupal/Driver/Core/CoreInterface.php
@@ -142,12 +142,12 @@ interface CoreInterface extends
   /**
    * Returns the field classifier, lazily instantiating on first access.
    *
-   * Consumers call into the classifier to ask which F-row a field belongs to
-   * (F1, F2, ..., F9). See 'src/Drupal/Driver/Core/Field/README.md'.
+   * Consumers call into the field classifier to ask which F-row a field belongs
+   * to (F1, F2, ..., F9). See 'src/Drupal/Driver/Core/Field/README.md'.
    *
    * @return \Drupal\Driver\Core\Field\FieldClassifierInterface
-   *   The classifier instance.
+   *   The field classifier instance.
    */
-  public function classifier(): FieldClassifierInterface;
+  public function getFieldClassifier(): FieldClassifierInterface;
 
 }

--- a/src/Drupal/Driver/Core/Field/README.md
+++ b/src/Drupal/Driver/Core/Field/README.md
@@ -126,9 +126,9 @@ No aggregate predicate. Code that needs to decide whether a field enters the
 expansion pipeline OR's the three expand-row predicates inline:
 
 ```php
-if ($this->classifier()->fieldIsBaseStandard($entity_type, $field_name)
-  || $this->classifier()->fieldIsConfigurable($entity_type, $field_name)
-  || $this->classifier()->fieldIsBundleStorageBacked($entity_type, $field_name, $bundle)) {
+if ($this->getFieldClassifier()->fieldIsBaseStandard($entity_type, $field_name)
+  || $this->getFieldClassifier()->fieldIsConfigurable($entity_type, $field_name)
+  || $this->getFieldClassifier()->fieldIsBundleStorageBacked($entity_type, $field_name, $bundle)) {
   // expand
 }
 ```


### PR DESCRIPTION
## Summary

Renamed the public accessor `classifier()` on `CoreInterface` and `Core` to `getFieldClassifier()`. Every other accessor on `CoreInterface` follows a `getX()` naming convention (`getRandom()`, `getModuleList()`, `getFieldHandler()`, `getEntityFieldTypes()`), but `classifier()` was the odd one out. The new name also matches the field-qualified naming already used by the backing property (`$fieldClassifier`), the factory method (`createFieldClassifier()`), and the class itself (`FieldClassifier`).

## Changes

**`src/Drupal/Driver/Core/CoreInterface.php`**
- Renamed method signature from `classifier()` to `getFieldClassifier()`.
- Updated the docblock to use the full term "field classifier" for consistency.

**`src/Drupal/Driver/Core/Core.php`**
- Renamed the method implementation from `classifier()` to `getFieldClassifier()`.
- Updated the three internal call sites in `getEntityFieldTypes()` that previously called `$this->classifier()`.

**`src/Drupal/Driver/Core/Field/README.md`**
- Updated the inline code example that demonstrated calling `classifier()` to use `getFieldClassifier()`.

## Before / After

Interface signature:

```
// Before
public function classifier(): FieldClassifierInterface;

// After
public function getFieldClassifier(): FieldClassifierInterface;
```

Call-site pattern in `Core.php` and in the README example:

```
// Before
$this->classifier()->fieldIsBaseStandard($entity_type, $field_name)
$this->classifier()->fieldIsConfigurable($entity_type, $field_name)
$this->classifier()->fieldIsBundleStorageBacked($entity_type, $field_name, $bundle)

// After
$this->getFieldClassifier()->fieldIsBaseStandard($entity_type, $field_name)
$this->getFieldClassifier()->fieldIsConfigurable($entity_type, $field_name)
$this->getFieldClassifier()->fieldIsBundleStorageBacked($entity_type, $field_name, $bundle)
```

Naming consistency across the `FieldClassifier` surface:

```
Property:  $fieldClassifier          (unchanged)
Factory:   createFieldClassifier()   (unchanged)
Accessor:  classifier()          -->  getFieldClassifier()
```
