### PR TITLE
Updated 'UPGRADING.md' for v3 audit and cleaned '.gitattributes' export list.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,16 +1,11 @@
 # Ignore files for distribution archives.
-/.artifacts      export-ignore
 /.editorconfig   export-ignore
 /.gitattributes  export-ignore
 /.github         export-ignore
 /.gitignore      export-ignore
 /CONTRIBUTING.md export-ignore
-/doc             export-ignore
-/docker-compose.yml export-ignore
-/drupal          export-ignore
-/drush           export-ignore
-/phpcs-ruleset.xml export-ignore
+/phpcs.xml       export-ignore
+/phpstan.neon    export-ignore
 /phpunit.xml     export-ignore
-/recipes         export-ignore
-/spec            export-ignore
+/rector.php      export-ignore
 /tests           export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,10 +256,12 @@ jobs:
         run: composer show drupal/drupal-driver
 
       # BrowserKitFactoryTest mocks getCwd() to '/var/www/html/build' and calls
-      # DrupalFinder on it. Symlink that path to the DrupalExtension checkout
-      # so DrupalFinder locates 'build/web/core' via composer.json scaffolding.
+      # DrupalFinder on it. DrupalExtension's composer scaffolds drupal/core
+      # to 'build/web/core' (via installer-paths), so symlink the mocked
+      # cwd to the 'build' subdirectory of the checkout so DrupalFinder
+      # locates 'web/core' from there.
       - name: Symlink expected Drupal root for BrowserKitFactoryTest
-        run: sudo ln -sfn "${GITHUB_WORKSPACE}/drupalextension" /var/www/html/build
+        run: sudo ln -sfn "${GITHUB_WORKSPACE}/drupalextension/build" /var/www/html/build
 
       - name: Run DrupalExtension PHPUnit
         working-directory: drupalextension

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,9 +212,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           # Check out the branch by name (not the merge SHA) so the path
-          # repo composer adds below presents the package as
-          # 'dev-<branch>', matching the dev-branch constraint that the
-          # downstream DrupalExtension branch pins for this PR.
+          # repo composer adds below has a real branch to work with. The
+          # version exposed to composer is overridden in the 'Add path
+          # repository' step so DrupalExtension's 'dev-master' constraint
+          # resolves regardless of the actual branch name.
           ref: ${{ github.head_ref || github.ref_name }}
           path: drupaldriver
 
@@ -240,7 +241,10 @@ jobs:
 
       - name: Add path repository for DrupalDriver
         working-directory: drupalextension
-        run: composer config repositories.drupaldriver path ../drupaldriver
+        # Override the version exposed by the path repo to 'dev-master' so
+        # DrupalExtension's 'dev-master as 3.0.0' constraint resolves to
+        # this PR's checkout regardless of the feature branch name.
+        run: composer config repositories.drupaldriver '{"type": "path", "url": "../drupaldriver", "options": {"versions": {"drupal/drupal-driver": "dev-master"}}}'
 
       - name: Install DrupalExtension dependencies
         working-directory: drupalextension

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,13 +255,15 @@ jobs:
         working-directory: drupalextension
         run: composer show drupal/drupal-driver
 
-      # BrowserKitFactoryTest mocks getCwd() to '/var/www/html/build' and calls
+      # BrowserKitFactoryTest mocks getCwd() to '/app/build' and calls
       # DrupalFinder on it. DrupalExtension's composer scaffolds drupal/core
       # to 'build/web/core' (via installer-paths), so symlink the mocked
       # cwd to the 'build' subdirectory of the checkout so DrupalFinder
       # locates 'web/core' from there.
       - name: Symlink expected Drupal root for BrowserKitFactoryTest
-        run: sudo ln -sfn "${GITHUB_WORKSPACE}/drupalextension/build" /var/www/html/build
+        run: |
+          sudo mkdir -p /app
+          sudo ln -sfn "${GITHUB_WORKSPACE}/drupalextension/build" /app/build
 
       - name: Run DrupalExtension PHPUnit
         working-directory: drupalextension

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,8 @@ jobs:
         # Override the version exposed by the path repo to 'dev-master' so
         # DrupalExtension's 'dev-master as 3.0.0' constraint resolves to
         # this PR's checkout regardless of the feature branch name.
-        run: composer config repositories.drupaldriver '{"type": "path", "url": "../drupaldriver", "options": {"versions": {"drupal/drupal-driver": "dev-master"}}}'
+        run: |
+          composer config repositories.drupaldriver '{"type":"path","url":"../drupaldriver","options":{"versions":{"drupal/drupal-driver":"dev-master"}}}' --json
 
       - name: Install DrupalExtension dependencies
         working-directory: drupalextension

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,9 +2,43 @@
 
 ## From v2 to v3
 
-v3 reworks the driver contract into a set of composable capability interfaces.
-Most changes are mechanical; a small amount of consumer-side code (typically in
-DrupalExtension integrations) may need updating.
+v3 reworks the driver contract into a set of composable capability interfaces,
+narrows entity stubs to a typed value object, drops Drupal 6/7, and tightens
+the supported PHP/Drupal range. Most changes are mechanical; a small amount of
+consumer-side code (typically in DrupalExtension integrations) may need
+updating.
+
+### Platform requirements
+
+- PHP `^8.2` (was `>=7.4`).
+- Drupal `^10 || ^11`. Drupal 6, 7, 8, and 9 are no longer supported.
+  `DrupalDriver::detectMajorVersion()` throws a `BootstrapException` when it
+  detects Drupal < 10.
+- Symfony `^6.4 || ^7` for `dependency-injection`, `process`, and
+  `phpunit-bridge`.
+- Sites that need to stay on PHP 8.1 or Drupal 9 should pin to the 2.x line,
+  now maintained on the `2.x` branch. `master` is the active 3.x branch.
+
+### Namespace and source layout changes
+
+Cores and field handlers moved out of the legacy `Cores/Drupal8/` and
+`Fields/Drupal8/` directories into a single `Core/` tree.
+
+| v2 namespace / path | v3 namespace / path |
+|---|---|
+| `Drupal\Driver\Cores\Drupal8` (`src/Drupal/Driver/Cores/Drupal8.php`) | `Drupal\Driver\Core\Core` (`src/Drupal/Driver/Core/Core.php`) |
+| `Drupal\Driver\Cores\AbstractCore` | merged into `Drupal\Driver\Core\Core` (extend `Core` directly) |
+| `Drupal\Driver\Cores\CoreInterface` | `Drupal\Driver\Core\CoreInterface` |
+| `Drupal\Driver\Fields\FieldHandlerInterface` | `Drupal\Driver\Core\Field\FieldHandlerInterface` |
+| `Drupal\Driver\Fields\Drupal8\*Handler` | `Drupal\Driver\Core\Field\*Handler` |
+| `Drupal\Driver\Fields\Drupal6\*`, `Drupal7\*` | removed |
+
+Consumers that referenced the old namespaces (custom field handlers, custom
+cores, `instanceof` checks) must update the `use` statements. A future Drupal
+version that needs to override behaviour can ship `Drupal\Driver\Core{N}\Core`
+or `Drupal\Driver\Core{N}\Field\*Handler` classes; the lookup chains in
+`DrupalDriver::setCoreFromVersion()` and `Core::getFieldHandler()` walk that
+chain and fall back to the default `Core\` implementation.
 
 ### New interface layout
 
@@ -44,41 +78,173 @@ classification into the nine F-row categories (F1-F9) now lives on
 If consumer code called `$driver->fieldExists(...)` or `$driver->fieldIsBase(...)`,
 replace with:
 
-- `fieldExists($type, $name)` → `$core->classifier()->fieldIsConfigurable($type, $name)` (if you were checking for a configurable field)
-- `fieldIsBase($type, $name)` → `$core->classifier()->fieldIsBaseStandard($type, $name)` (or one of the more specific F-row predicates, depending on intent)
+- `fieldExists($type, $name)` → `$core->getFieldClassifier()->fieldIsConfigurable($type, $name)` (if you were checking for a configurable field)
+- `fieldIsBase($type, $name)` → `$core->getFieldClassifier()->fieldIsBaseStandard($type, $name)` (or one of the more specific F-row predicates, depending on intent)
 
 The classifier is the single source of truth for field classification; the
 old two-predicate API was insufficient to distinguish F1-F9 correctly and
 caused downstream bugs (notably with computed writable base fields like
 `moderation_state`).
 
+The accessor on `CoreInterface` is `getFieldClassifier()`. An earlier 3.x
+prerelease named it `classifier()`; that name was renamed before
+3.0.0-alpha1 for consistency with the other `getX()` accessors
+(`getRandom()`, `getModuleList()`, `getFieldHandler()`,
+`getEntityFieldTypes()`).
+
+### Field-expansion pipeline signature changes
+
+The pipeline that drives `entityCreate()` was rewritten around the classifier.
+The following methods on `Core` / `CoreInterface` changed or were removed:
+
+| v2 | v3 |
+|---|---|
+| `expandEntityFields(string $type, \stdClass $entity, array $base_fields = [])` | `expandEntityFields(string $type, EntityStubInterface $entity)` (no `$base_fields`) |
+| `getEntityFieldTypes(string $type, array $base_fields = [])` | `getEntityFieldTypes(string $type, ?string $bundle = NULL)` |
+| `expandEntityBaseFields()` | removed (callers use `expandEntityFields()` directly) |
+| `detectBaseFieldsOnEntity()` | removed (replaced by an internal `resolveBundleFromEntity()` helper) |
+| `fieldExists()`, `fieldIsBase()` | removed (use `FieldClassifier` predicates) |
+
+`DefaultHandler::expand()` now throws `\RuntimeException` for any field whose
+storage schema is not a single `value` column, instead of silently emitting
+garbage. Custom handlers for multi-column types must be registered explicitly;
+the new `FieldTypeCoverageKernelTest` will fail at CI time if a registered
+core type has no handler.
+
 ### DrushDriver no longer supports Content or Field capabilities
 
-`DrushDriver` used to rely on a companion module installed on the
-site-under-test to provide entity CRUD and field introspection over Drush.
-That indirection has been removed: `DrushDriver` now exposes only operations
-that Drush services natively.
+`DrushDriver` used to rely on a companion module
+(`drush-ops/behat-drush-endpoint`) installed on the site-under-test to provide
+entity CRUD and field introspection over Drush. That dev dependency and the
+indirection have been removed: `DrushDriver` now exposes only operations that
+Drush services natively.
 
-`DrushDriverInterface` no longer extends `ContentCapabilityInterface`. The
-following methods are gone from `DrushDriver`:
+`DrushDriverInterface` no longer extends `ContentCapabilityInterface` or
+`FieldCapabilityInterface`. The following methods are gone from `DrushDriver`:
 
 - `nodeCreate`, `nodeDelete`
 - `termCreate`, `termDelete`
 - `entityCreate`, `entityDelete`
+- `fieldExists`, `fieldIsBase`
 
-Consumers that need entity CRUD should use `DrupalDriver` (which bootstraps
-Drupal and delegates to `Core`) or implement the missing behaviour themselves.
-Test the capability with `instanceof ContentCapabilityInterface` before
-calling.
+Consumers that need entity CRUD or field introspection should use
+`DrupalDriver` (which bootstraps Drupal and delegates to `Core`) or implement
+the missing behaviour themselves. Test the capability with
+`instanceof ContentCapabilityInterface` (or the relevant capability interface)
+before calling.
 
 ### CoreInterface expanded
 
 `Drupal\Driver\Core\CoreInterface` now extends every capability interface in
 addition to declaring its bootstrap internals (`validateDrupalSite`,
 `getModuleList`, `getExtensionPathList`, `getFieldHandler`,
-`getEntityFieldTypes`, `processBatch`). `DrupalDriver::getCore()` still
-returns `CoreInterface` - you get the full capability surface from the same
-type hint.
+`getEntityFieldTypes`, `processBatch`, `getFieldClassifier`).
+`DrupalDriver::getCore()` still returns `CoreInterface` - you get the full
+capability surface from the same type hint.
+
+### DrupalDriverInterface tightened, properties narrowed
+
+Three accessors that previously lived only on the concrete `DrupalDriver` are
+now part of the `DrupalDriverInterface` contract:
+
+- `getCore(): CoreInterface`
+- `setCore(CoreInterface $core): void`
+- `getDrupalVersion(): int`
+
+Consumers that hand-rolled a class implementing `DrupalDriverInterface` must
+add these three methods.
+
+`DrupalDriver::$core` and `DrupalDriver::$version` were narrowed from `public`
+to `protected`. Replace direct property access with the public accessors:
+
+```php
+// v2
+$core    = $driver->core;
+$version = $driver->version;
+
+// v3
+$core    = $driver->getCore();
+$version = $driver->getDrupalVersion();
+```
+
+`DrupalDriver::setCore()` also changed shape. v2 took an array of
+version-keyed `Core` classes; v3 takes a single `CoreInterface` instance:
+
+```php
+// v2
+$driver->setCore([10 => Drupal8::class, 11 => Drupal8::class]);
+
+// v3
+$driver->setCore(new \Drupal\Driver\Core\Core($driver));
+```
+
+The convention-based `setCoreFromVersion()` lookup that walks
+`Drupal\Driver\Core{N}\Core` classes is unchanged and still the recommended
+way to wire a core for the detected Drupal version.
+
+### Entity stubs are now typed
+
+Every capability method that previously accepted or returned `\stdClass` now
+declares `Drupal\Driver\Entity\EntityStubInterface`. This affects
+`AuthenticationCapabilityInterface::login()` and every create/delete method
+on `Block*`, `Content*`, `Language*`, and `User*` capability interfaces.
+
+```php
+// v2 - construct a stub as an anonymous \stdClass
+$node = (object) [
+    'type'  => 'page',
+    'title' => 'Example',
+];
+$created = $driver->nodeCreate($node);
+// guess: $created->nid? $created->id?
+
+// v3 - construct a typed stub
+use Drupal\Driver\Entity\EntityStub;
+
+$node    = new EntityStub('node', 'page', ['title' => 'Example']);
+$created = $driver->nodeCreate($node);
+// typed access:
+$id     = $created->getId();           // saved entity id
+$entity = $created->getSavedEntity();  // EntityInterface
+$saved  = $created->isSaved();         // bool
+```
+
+There is no `\stdClass` shim. Callers must construct `EntityStub` instances
+directly. The field-handler boundary (`AbstractHandler::__construct()`,
+`Core::getFieldHandler()`) is also typed, so custom handler subclasses see the
+typed stub instead of a synthesised `\stdClass`.
+
+### entityCreate() now writes the entity-type-specific id key
+
+`entityCreate()` previously always populated `$entity->id` after save. v3
+resolves the id key per entity type and writes there instead:
+
+| Entity type | Property populated |
+|---|---|
+| `node` | `$stub->nid` |
+| `user` | `$stub->uid` |
+| `taxonomy_term` | `$stub->tid` |
+| custom | `$entity_type_definition->getKey('id')` |
+
+Consumers that read `$stub->id` after `entityCreate('user', $stub)` must
+switch to `$stub->getId()` (preferred), `$stub->uid`, or read from the
+returned entity. `entityDelete()` was changed in the same way - it loads via
+the resolved id key instead of `$stub->id`.
+
+`entityCreate()` also auto-detects base fields set as properties on the stub
+(excluding the id and bundle keys) and routes them through the field-handler
+pipeline. Base entity-reference fields like `commerce_product.variations` no
+longer reach storage in raw label form.
+
+### Removed handler classes
+
+- `TaxonomyTermReferenceHandler` was removed. The legacy
+  `taxonomy_term_reference` field type was deleted from Drupal core in
+  8.0.0-beta10 (2015) and is unreachable on every supported Drupal version.
+  Consumers that subclassed it should subclass `EntityReferenceHandler`
+  instead. Modern taxonomy references are `entity_reference` with
+  `target_type = taxonomy_term` and route through `EntityReferenceHandler`
+  automatically.
 
 ### Renamed driver methods
 
@@ -107,11 +273,17 @@ prefix naturally. All other capability methods (`user*`, `role*`, `module*`,
 
 ### Tightened signatures
 
-Parameter and return types were tightened to match the capability contracts.
-Where v2 accepted untyped arguments, v3 expects `string`, `\stdClass`, or
-`object` as declared by each capability interface. The change is transparent
-to well-typed callers and will surface via PHP's built-in type errors
-otherwise.
+Every source and test file declares `declare(strict_types=1)`, and parameter
+/ return / property types were tightened across all interfaces and concrete
+classes via Rector's PHP 8.2 typeDeclarations set. Callers that previously
+relied on PHP loose-mode coercion (passing strings where ints are expected,
+returning the wrong type from an overridden method, etc.) will now hit
+`TypeError` at the boundary. Audit any consumer code that calls into `Core`,
+`DrupalDriver`, `DrushDriver`, or any field handler.
+
+Where v2 accepted `\stdClass` for entity stubs, v3 expects
+`EntityStubInterface` - see "Entity stubs are now typed" above for the
+migration.
 
 ### New methods
 

--- a/composer.json
+++ b/composer.json
@@ -42,16 +42,13 @@
         "ergebnis/composer-normalize": "^2.50",
         "mglaman/phpstan-drupal": "^2.0",
         "mikey179/vfsstream": "^1.6.11",
-        "mockery/mockery": "^1.5",
         "palantirnet/drupal-rector": "^0.21.1",
         "php-parallel-lint/php-parallel-lint": "^1.0",
         "phpspec/prophecy-phpunit": "^2",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^10.5.19 || ^11.5.3",
-        "rector/rector": "^1 || ^2",
-        "symfony/phpunit-bridge": "^7.3",
-        "webmozart/assert": "^2.3"
+        "rector/rector": "^1 || ^2"
     },
     "repositories": {
         "drupal": {


### PR DESCRIPTION
## Summary

- Updated `UPGRADING.md` migration guide for v3 with new sections covering all
  breaking changes shipped in 3.0.0-alpha1, and corrected two stale code
  snippets from pre-alpha prereleases.
- Cleaned up `.gitattributes` export-ignore list: removed seven stale entries
  for paths that no longer exist in the repo, fixed a typo'd entry, and added
  three new entries so the Composer distribution archive ships only the
  essential files.

## Changes

### UPGRADING.md

Added new sections to the v2-to-v3 migration guide:

- **Platform requirements** - PHP `^8.2`, Drupal `^10 || ^11`, Symfony
  `^6.4 || ^7`; note about pinning to the `2.x` branch for older platforms.
- **Namespace and source layout changes** - table mapping every moved
  namespace from the legacy `Cores/Drupal8/` and `Fields/Drupal8/` trees to
  their new `Core/` equivalents.
- **Field-expansion pipeline signature changes** - table of changed / removed
  `Core` / `CoreInterface` methods (`expandEntityFields`, `getEntityFieldTypes`,
  removed helpers), plus the `DefaultHandler::expand()` strictness change.
- **DrupalDriverInterface tightened, properties narrowed** - the three new
  interface methods (`getCore`, `setCore`, `getDrupalVersion`), the
  `public`-to-`protected` property narrowing, and the changed `setCore()`
  signature, with before/after code snippets.
- **Entity stubs are now typed** - `\stdClass` -> `EntityStubInterface`
  migration with before/after examples.
- **entityCreate() now writes the entity-type-specific id key** - per-type id
  property table and guidance to switch to `getId()`.
- **Removed handler classes** - `TaxonomyTermReferenceHandler` removal and
  migration path to `EntityReferenceHandler`.

Fixed two stale snippets that referenced pre-alpha names:

- `$core->classifier()` corrected to `$core->getFieldClassifier()` (renamed
  in #364).
- `\stdClass` claim under "Tightened signatures" updated to reference
  `EntityStubInterface` (replaced in #363).

Updated the DrushDriver removal list to include `fieldExists`, `fieldIsBase`,
and `FieldCapabilityInterface` (removed in #343), which were missing from the
draft.

### .gitattributes

Removed seven stale `export-ignore` entries for paths that no longer exist:

- `/.artifacts` (gitignored, never in the archive)
- `/doc`
- `/docker-compose.yml`
- `/drupal`
- `/drush`
- `/recipes`
- `/spec`

Fixed a typo'd entry: `phpcs-ruleset.xml` -> `phpcs.xml` (actual filename).

Added three new `export-ignore` entries so CI/QA config files stay out of
Composer distribution archives:

- `/phpcs.xml`
- `/phpstan.neon`
- `/rector.php`

Post-change the archive ships only: `LICENSE`, `README.md`, `UPGRADING.md`,
`composer.json`, and `src/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded v2 to v3 migration guide with comprehensive breaking changes, capability interface updates, stricter API contracts, and updated platform requirements.

* **Chores**
  * Updated repository export configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->