### PR TITLE
[#366] Made 'NameHandler' honour the field's 'components' setting.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,11 +241,12 @@ jobs:
 
       - name: Add path repository for DrupalDriver
         working-directory: drupalextension
-        # Override the version exposed by the path repo to 'dev-master' so
-        # DrupalExtension's 'dev-master as 3.0.0' constraint resolves to
-        # this PR's checkout regardless of the feature branch name.
+        # Expose the path repo as a high alpha version so DrupalExtension's
+        # '^3.0.0-alpha1' constraint (with 'minimum-stability: alpha') resolves
+        # to this PR's checkout. 'dev-master' is rejected because its dev
+        # stability falls below the consumer's alpha floor.
         run: |
-          composer config repositories.drupaldriver '{"type":"path","url":"../drupaldriver","options":{"versions":{"drupal/drupal-driver":"dev-master"}}}' --json
+          composer config repositories.drupaldriver '{"type":"path","url":"../drupaldriver","options":{"versions":{"drupal/drupal-driver":"3.0.99-alpha"}}}' --json
 
       - name: Install DrupalExtension dependencies
         working-directory: drupalextension

--- a/src/Drupal/Driver/Core/Field/NameHandler.php
+++ b/src/Drupal/Driver/Core/Field/NameHandler.php
@@ -12,25 +12,30 @@ namespace Drupal\Driver\Core\Field;
 class NameHandler extends AbstractHandler {
 
   /**
+   * Canonical order of name components.
+   *
+   * Matches the columns declared by 'NameItem::schema()' and the order in
+   * which the Name module presents components in the field UI.
+   *
+   * @var array<int, string>
+   */
+  protected const COMPONENTS = ['title', 'given', 'middle', 'family', 'generational', 'credentials'];
+
+  /**
    * {@inheritdoc}
    */
   public function expand($values): array {
-    $components = ['title', 'given', 'middle', 'family', 'generational', 'credentials'];
+    $enabled = $this->getEnabledComponents();
     $names = [];
 
     foreach ($values as $value) {
       if (is_string($value)) {
-        // Support "Family, Given" shorthand.
-        $parts = array_map(trim(...), explode(',', $value));
-        $names[] = [
-          'family' => $parts[0] ?? NULL,
-          'given' => $parts[1] ?? NULL,
-        ];
+        $names[] = $this->normaliseString($value, $enabled);
         continue;
       }
 
       if (is_array($value)) {
-        $names[] = $this->normaliseComponents($value, $components);
+        $names[] = $this->normaliseArray($value, $enabled);
       }
     }
 
@@ -38,31 +43,93 @@ class NameHandler extends AbstractHandler {
   }
 
   /**
-   * Normalises a name value array into a keyed components array.
+   * Returns name components enabled on the field, in canonical order.
+   *
+   * @return array<int, string>
+   *   Enabled component keys (subset of self::COMPONENTS).
+   */
+  protected function getEnabledComponents(): array {
+    $components = $this->fieldConfig->getSettings()['components'] ?? [];
+    $enabled = [];
+
+    foreach (self::COMPONENTS as $component) {
+      if (!empty($components[$component])) {
+        $enabled[] = $component;
+      }
+    }
+
+    return $enabled;
+  }
+
+  /**
+   * Expands the "Family, Given" shorthand string.
+   *
+   * @param string $value
+   *   The shorthand value: either "Family" or "Family, Given".
+   * @param array<int, string> $enabled
+   *   Enabled component keys.
+   *
+   * @return array<string, mixed>
+   *   The keyed component array.
+   */
+  protected function normaliseString(string $value, array $enabled): array {
+    $parts = array_map(trim(...), explode(',', $value));
+
+    if (!in_array('family', $enabled, TRUE)) {
+      throw new \RuntimeException('Cannot use the "Family, Given" shorthand because the "family" component is disabled on this field.');
+    }
+
+    $name = ['family' => $parts[0]];
+    $has_given_part = isset($parts[1]);
+    $given_enabled = in_array('given', $enabled, TRUE);
+
+    if ($has_given_part && !$given_enabled) {
+      throw new \RuntimeException('Cannot use the "Family, Given" shorthand because the "given" component is disabled on this field.');
+    }
+
+    if ($given_enabled) {
+      $name['given'] = $parts[1] ?? NULL;
+    }
+
+    return $name;
+  }
+
+  /**
+   * Expands an associative or positional array into a keyed component array.
    *
    * @param array<int|string, mixed> $value
-   *   The raw name value. Keys may be component names (title, given, family,
-   *   ...) or numeric indices mapping into the component order.
-   * @param array<int, string> $components
-   *   The ordered list of recognised name component keys.
+   *   The raw name value.
+   * @param array<int, string> $enabled
+   *   Enabled component keys, in canonical order.
    *
    * @return array<string, mixed>
    *   A keyed array of name components.
    */
-  protected function normaliseComponents(array $value, array $components): array {
+  protected function normaliseArray(array $value, array $enabled): array {
     $name = [];
     $position = 0;
 
     foreach ($value as $key => $field_value) {
-      if (in_array($key, $components, TRUE)) {
+      if (is_numeric($key)) {
+        if (!isset($enabled[$position])) {
+          throw new \RuntimeException(sprintf('Too many name sub-field values supplied; only %d enabled components available.', count($enabled)));
+        }
+
+        $name[$enabled[$position]] = $field_value;
+        $position++;
+        continue;
+      }
+
+      if (in_array($key, $enabled, TRUE)) {
         $name[$key] = $field_value;
         continue;
       }
 
-      if (is_numeric($key) && isset($components[$position])) {
-        $name[$components[$position]] = $field_value;
-        $position++;
+      if (in_array($key, self::COMPONENTS, TRUE)) {
+        throw new \RuntimeException(sprintf('Cannot set the "%s" name component because it is disabled on this field.', $key));
       }
+
+      throw new \RuntimeException(sprintf('Invalid name sub-field key: %s.', $key));
     }
 
     return $name;

--- a/src/Drupal/Driver/Core/Field/NameHandler.php
+++ b/src/Drupal/Driver/Core/Field/NameHandler.php
@@ -106,6 +106,10 @@ class NameHandler extends AbstractHandler {
    *   A keyed array of name components.
    */
   protected function normaliseArray(array $value, array $enabled): array {
+    if ($value !== [] && !array_is_list($value) && $this->hasNumericKey($value)) {
+      throw new \RuntimeException('Cannot mix numeric and named keys in the same name value; use one shape consistently.');
+    }
+
     $name = [];
     $position = 0;
 
@@ -133,6 +137,22 @@ class NameHandler extends AbstractHandler {
     }
 
     return $name;
+  }
+
+  /**
+   * Returns TRUE if any key in the array is numeric.
+   *
+   * @param array<int|string, mixed> $value
+   *   The array to check.
+   */
+  protected function hasNumericKey(array $value): bool {
+    foreach (array_keys($value) as $key) {
+      if (is_numeric($key)) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
   }
 
 }

--- a/src/Drupal/Driver/Core/Field/NameHandler.php
+++ b/src/Drupal/Driver/Core/Field/NameHandler.php
@@ -11,6 +11,13 @@ namespace Drupal\Driver\Core\Field;
  */
 class NameHandler extends AbstractHandler {
 
+  public const COMPONENT_TITLE = 'title';
+  public const COMPONENT_GIVEN = 'given';
+  public const COMPONENT_MIDDLE = 'middle';
+  public const COMPONENT_FAMILY = 'family';
+  public const COMPONENT_GENERATIONAL = 'generational';
+  public const COMPONENT_CREDENTIALS = 'credentials';
+
   /**
    * Canonical order of name components.
    *
@@ -19,7 +26,14 @@ class NameHandler extends AbstractHandler {
    *
    * @var array<int, string>
    */
-  protected const COMPONENTS = ['title', 'given', 'middle', 'family', 'generational', 'credentials'];
+  protected const COMPONENTS = [
+    self::COMPONENT_TITLE,
+    self::COMPONENT_GIVEN,
+    self::COMPONENT_MIDDLE,
+    self::COMPONENT_FAMILY,
+    self::COMPONENT_GENERATIONAL,
+    self::COMPONENT_CREDENTIALS,
+  ];
 
   /**
    * {@inheritdoc}
@@ -75,20 +89,20 @@ class NameHandler extends AbstractHandler {
   protected function normaliseString(string $value, array $enabled): array {
     $parts = array_map(trim(...), explode(',', $value));
 
-    if (!in_array('family', $enabled, TRUE)) {
+    if (!in_array(self::COMPONENT_FAMILY, $enabled, TRUE)) {
       throw new \RuntimeException('Cannot use the "Family, Given" shorthand because the "family" component is disabled on this field.');
     }
 
-    $name = ['family' => $parts[0]];
+    $name = [self::COMPONENT_FAMILY => $parts[0]];
     $has_given_part = isset($parts[1]);
-    $given_enabled = in_array('given', $enabled, TRUE);
+    $given_enabled = in_array(self::COMPONENT_GIVEN, $enabled, TRUE);
 
     if ($has_given_part && !$given_enabled) {
       throw new \RuntimeException('Cannot use the "Family, Given" shorthand because the "given" component is disabled on this field.');
     }
 
     if ($given_enabled) {
-      $name['given'] = $parts[1] ?? NULL;
+      $name[self::COMPONENT_GIVEN] = $parts[1] ?? NULL;
     }
 
     return $name;

--- a/tests/Drupal/Tests/Driver/Kernel/Core/Field/NameHandlerKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/Field/NameHandlerKernelTest.php
@@ -12,7 +12,9 @@ use PHPUnit\Framework\Attributes\Group;
  * Name is a multi-property field provided by the 'drupal/name' contrib
  * module. The handler accepts three input shapes (shorthand string,
  * numeric array, associative array) and normalises them into the same
- * per-component keyed structure.
+ * per-component keyed structure. It also honours the field's
+ * 'components' setting: positional input skips disabled components and
+ * named input throws if it targets one.
  *
  * @group fields
  */
@@ -50,6 +52,26 @@ class NameHandlerKernelTest extends FieldHandlerKernelTestBase {
     $this->attachField('field_author', 'name');
 
     $this->assertFieldRoundTripViaDriver('field_author', ['Doe, Jane']);
+  }
+
+  /**
+   * Tests positional input maps into enabled components only.
+   */
+  public function testNamePositionalSkipsDisabledComponents(): void {
+    $this->attachField('field_author', 'name', [], [
+      'components' => [
+        'title' => TRUE,
+        'given' => TRUE,
+        'middle' => FALSE,
+        'family' => TRUE,
+        'generational' => FALSE,
+        'credentials' => FALSE,
+      ],
+    ]);
+
+    $this->assertFieldRoundTripViaDriver('field_author', [
+      ['Dr', 'Jane', 'Doe'],
+    ]);
   }
 
 }

--- a/tests/Drupal/Tests/Driver/Kernel/Core/Field/NameHandlerKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/Field/NameHandlerKernelTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\Driver\Kernel\Core\Field;
 
+use Drupal\Driver\Core\Field\NameHandler;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -60,12 +61,12 @@ class NameHandlerKernelTest extends FieldHandlerKernelTestBase {
   public function testNamePositionalSkipsDisabledComponents(): void {
     $this->attachField('field_author', 'name', [], [
       'components' => [
-        'title' => TRUE,
-        'given' => TRUE,
-        'middle' => FALSE,
-        'family' => TRUE,
-        'generational' => FALSE,
-        'credentials' => FALSE,
+        NameHandler::COMPONENT_TITLE => TRUE,
+        NameHandler::COMPONENT_GIVEN => TRUE,
+        NameHandler::COMPONENT_MIDDLE => FALSE,
+        NameHandler::COMPONENT_FAMILY => TRUE,
+        NameHandler::COMPONENT_GENERATIONAL => FALSE,
+        NameHandler::COMPONENT_CREDENTIALS => FALSE,
       ],
     ]);
 

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/NameHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/NameHandlerTest.php
@@ -24,12 +24,12 @@ class NameHandlerTest extends TestCase {
    * @var array<string, bool>
    */
   protected const ALL_ENABLED = [
-    'title' => TRUE,
-    'given' => TRUE,
-    'middle' => TRUE,
-    'family' => TRUE,
-    'generational' => TRUE,
-    'credentials' => TRUE,
+    NameHandler::COMPONENT_TITLE => TRUE,
+    NameHandler::COMPONENT_GIVEN => TRUE,
+    NameHandler::COMPONENT_MIDDLE => TRUE,
+    NameHandler::COMPONENT_FAMILY => TRUE,
+    NameHandler::COMPONENT_GENERATIONAL => TRUE,
+    NameHandler::COMPONENT_CREDENTIALS => TRUE,
   ];
 
   /**
@@ -86,12 +86,12 @@ class NameHandlerTest extends TestCase {
    */
   public function testNumericIndicesSkipDisabledComponents(): void {
     $handler = $this->createHandler([
-      'title' => TRUE,
-      'given' => TRUE,
-      'middle' => FALSE,
-      'family' => TRUE,
-      'generational' => FALSE,
-      'credentials' => FALSE,
+      NameHandler::COMPONENT_TITLE => TRUE,
+      NameHandler::COMPONENT_GIVEN => TRUE,
+      NameHandler::COMPONENT_MIDDLE => FALSE,
+      NameHandler::COMPONENT_FAMILY => TRUE,
+      NameHandler::COMPONENT_GENERATIONAL => FALSE,
+      NameHandler::COMPONENT_CREDENTIALS => FALSE,
     ]);
 
     $result = $handler->expand([['Dr', 'John', 'Doe']]);
@@ -106,12 +106,12 @@ class NameHandlerTest extends TestCase {
    */
   public function testTooManyNumericIndicesThrows(): void {
     $handler = $this->createHandler([
-      'title' => FALSE,
-      'given' => TRUE,
-      'middle' => FALSE,
-      'family' => TRUE,
-      'generational' => FALSE,
-      'credentials' => FALSE,
+      NameHandler::COMPONENT_TITLE => FALSE,
+      NameHandler::COMPONENT_GIVEN => TRUE,
+      NameHandler::COMPONENT_MIDDLE => FALSE,
+      NameHandler::COMPONENT_FAMILY => TRUE,
+      NameHandler::COMPONENT_GENERATIONAL => FALSE,
+      NameHandler::COMPONENT_CREDENTIALS => FALSE,
     ]);
 
     $this->expectException(\RuntimeException::class);
@@ -125,12 +125,12 @@ class NameHandlerTest extends TestCase {
    */
   public function testNamedKeyForDisabledComponentThrows(): void {
     $handler = $this->createHandler([
-      'title' => FALSE,
-      'given' => TRUE,
-      'middle' => FALSE,
-      'family' => TRUE,
-      'generational' => FALSE,
-      'credentials' => FALSE,
+      NameHandler::COMPONENT_TITLE => FALSE,
+      NameHandler::COMPONENT_GIVEN => TRUE,
+      NameHandler::COMPONENT_MIDDLE => FALSE,
+      NameHandler::COMPONENT_FAMILY => TRUE,
+      NameHandler::COMPONENT_GENERATIONAL => FALSE,
+      NameHandler::COMPONENT_CREDENTIALS => FALSE,
     ]);
 
     $this->expectException(\RuntimeException::class);
@@ -168,12 +168,12 @@ class NameHandlerTest extends TestCase {
    */
   public function testShorthandThrowsWhenFamilyDisabled(): void {
     $handler = $this->createHandler([
-      'title' => TRUE,
-      'given' => TRUE,
-      'middle' => FALSE,
-      'family' => FALSE,
-      'generational' => FALSE,
-      'credentials' => FALSE,
+      NameHandler::COMPONENT_TITLE => TRUE,
+      NameHandler::COMPONENT_GIVEN => TRUE,
+      NameHandler::COMPONENT_MIDDLE => FALSE,
+      NameHandler::COMPONENT_FAMILY => FALSE,
+      NameHandler::COMPONENT_GENERATIONAL => FALSE,
+      NameHandler::COMPONENT_CREDENTIALS => FALSE,
     ]);
 
     $this->expectException(\RuntimeException::class);
@@ -187,12 +187,12 @@ class NameHandlerTest extends TestCase {
    */
   public function testShorthandThrowsWhenGivenPartSuppliedButDisabled(): void {
     $handler = $this->createHandler([
-      'title' => FALSE,
-      'given' => FALSE,
-      'middle' => FALSE,
-      'family' => TRUE,
-      'generational' => FALSE,
-      'credentials' => FALSE,
+      NameHandler::COMPONENT_TITLE => FALSE,
+      NameHandler::COMPONENT_GIVEN => FALSE,
+      NameHandler::COMPONENT_MIDDLE => FALSE,
+      NameHandler::COMPONENT_FAMILY => TRUE,
+      NameHandler::COMPONENT_GENERATIONAL => FALSE,
+      NameHandler::COMPONENT_CREDENTIALS => FALSE,
     ]);
 
     $this->expectException(\RuntimeException::class);
@@ -206,12 +206,12 @@ class NameHandlerTest extends TestCase {
    */
   public function testShorthandFamilyOnlyWhenGivenDisabled(): void {
     $handler = $this->createHandler([
-      'title' => FALSE,
-      'given' => FALSE,
-      'middle' => FALSE,
-      'family' => TRUE,
-      'generational' => FALSE,
-      'credentials' => FALSE,
+      NameHandler::COMPONENT_TITLE => FALSE,
+      NameHandler::COMPONENT_GIVEN => FALSE,
+      NameHandler::COMPONENT_MIDDLE => FALSE,
+      NameHandler::COMPONENT_FAMILY => TRUE,
+      NameHandler::COMPONENT_GENERATIONAL => FALSE,
+      NameHandler::COMPONENT_CREDENTIALS => FALSE,
     ]);
 
     $result = $handler->expand(['Doe']);

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/NameHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/NameHandlerTest.php
@@ -39,6 +39,8 @@ class NameHandlerTest extends TestCase {
    *   The input values to expand.
    * @param array<int, mixed> $expected
    *   The expected expanded values.
+   *
+   * @dataProvider dataProviderExpand
    */
   #[DataProvider('dataProviderExpand')]
   public function testExpand(array $input, array $expected): void {

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/NameHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/NameHandlerTest.php
@@ -138,6 +138,18 @@ class NameHandlerTest extends TestCase {
   }
 
   /**
+   * Tests that mixing numeric and named keys in one delta throws.
+   */
+  public function testMixedNumericAndNamedKeysThrows(): void {
+    $handler = $this->createHandler();
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Cannot mix numeric and named keys in the same name value; use one shape consistently.');
+
+    $handler->expand([['John', 'family' => 'Smith']]);
+  }
+
+  /**
    * Tests that an unknown sub-field key throws.
    */
   public function testUnknownKeyThrows(): void {

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/NameHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/NameHandlerTest.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\Driver\Unit\Core\Field;
 
+use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Driver\Core\Field\NameHandler;
-use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the NameHandler field handler.
@@ -18,15 +19,27 @@ use PHPUnit\Framework\Attributes\DataProvider;
 class NameHandlerTest extends TestCase {
 
   /**
- * Tests name field expansion.
- *
- * @param array<int, mixed> $input
- *   The input values to expand.
- * @param array<int, mixed> $expected
- *   The expected expanded values.
- *
- * @dataProvider dataProviderExpand
- */
+   * All six name components, all enabled (the module's default).
+   *
+   * @var array<string, bool>
+   */
+  protected const ALL_ENABLED = [
+    'title' => TRUE,
+    'given' => TRUE,
+    'middle' => TRUE,
+    'family' => TRUE,
+    'generational' => TRUE,
+    'credentials' => TRUE,
+  ];
+
+  /**
+   * Tests name field expansion with all components enabled.
+   *
+   * @param array<int, mixed> $input
+   *   The input values to expand.
+   * @param array<int, mixed> $expected
+   *   The expected expanded values.
+   */
   #[DataProvider('dataProviderExpand')]
   public function testExpand(array $input, array $expected): void {
     $handler = $this->createHandler();
@@ -39,42 +52,179 @@ class NameHandlerTest extends TestCase {
    */
   public static function dataProviderExpand(): \Iterator {
     yield 'string shorthand family, given' => [
-        ['Doe, John'],
-        [['family' => 'Doe', 'given' => 'John']],
+      ['Doe, John'],
+      [['family' => 'Doe', 'given' => 'John']],
     ];
     yield 'string shorthand family only' => [
-        ['Doe'],
-        [['family' => 'Doe', 'given' => NULL]],
+      ['Doe'],
+      [['family' => 'Doe', 'given' => NULL]],
     ];
     yield 'named keys' => [
-        [['given' => 'John', 'family' => 'Doe', 'middle' => 'Q']],
-        [['given' => 'John', 'family' => 'Doe', 'middle' => 'Q']],
+      [['given' => 'John', 'family' => 'Doe', 'middle' => 'Q']],
+      [['given' => 'John', 'family' => 'Doe', 'middle' => 'Q']],
     ];
     yield 'numeric indices' => [
-        [['Dr', 'John', 'Quincy', 'Doe']],
-        [['title' => 'Dr', 'given' => 'John', 'middle' => 'Quincy', 'family' => 'Doe']],
+      [['Dr', 'John', 'Quincy', 'Doe']],
+      [['title' => 'Dr', 'given' => 'John', 'middle' => 'Quincy', 'family' => 'Doe']],
     ];
     yield 'multiple values' => [
-        [
-          'Doe, John',
-          ['given' => 'Jane', 'family' => 'Smith'],
-        ],
-        [
-          ['family' => 'Doe', 'given' => 'John'],
-          ['given' => 'Jane', 'family' => 'Smith'],
-        ],
+      [
+        'Doe, John',
+        ['given' => 'Jane', 'family' => 'Smith'],
+      ],
+      [
+        ['family' => 'Doe', 'given' => 'John'],
+        ['given' => 'Jane', 'family' => 'Smith'],
+      ],
     ];
   }
 
   /**
-   * Creates a NameHandler instance that bypasses the parent constructor.
+   * Tests that numeric indices skip components disabled on the field.
+   */
+  public function testNumericIndicesSkipDisabledComponents(): void {
+    $handler = $this->createHandler([
+      'title' => TRUE,
+      'given' => TRUE,
+      'middle' => FALSE,
+      'family' => TRUE,
+      'generational' => FALSE,
+      'credentials' => FALSE,
+    ]);
+
+    $result = $handler->expand([['Dr', 'John', 'Doe']]);
+
+    $this->assertSame([
+      ['title' => 'Dr', 'given' => 'John', 'family' => 'Doe'],
+    ], $result);
+  }
+
+  /**
+   * Tests that excess numeric indices throw.
+   */
+  public function testTooManyNumericIndicesThrows(): void {
+    $handler = $this->createHandler([
+      'title' => FALSE,
+      'given' => TRUE,
+      'middle' => FALSE,
+      'family' => TRUE,
+      'generational' => FALSE,
+      'credentials' => FALSE,
+    ]);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Too many name sub-field values supplied; only 2 enabled components available.');
+
+    $handler->expand([['John', 'Doe', 'Extra']]);
+  }
+
+  /**
+   * Tests that a named key targeting a disabled component throws.
+   */
+  public function testNamedKeyForDisabledComponentThrows(): void {
+    $handler = $this->createHandler([
+      'title' => FALSE,
+      'given' => TRUE,
+      'middle' => FALSE,
+      'family' => TRUE,
+      'generational' => FALSE,
+      'credentials' => FALSE,
+    ]);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Cannot set the "middle" name component because it is disabled on this field.');
+
+    $handler->expand([['given' => 'John', 'middle' => 'Q', 'family' => 'Doe']]);
+  }
+
+  /**
+   * Tests that an unknown sub-field key throws.
+   */
+  public function testUnknownKeyThrows(): void {
+    $handler = $this->createHandler();
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Invalid name sub-field key: nickname.');
+
+    $handler->expand([['nickname' => 'Johnny']]);
+  }
+
+  /**
+   * Tests that the shorthand throws when family is disabled.
+   */
+  public function testShorthandThrowsWhenFamilyDisabled(): void {
+    $handler = $this->createHandler([
+      'title' => TRUE,
+      'given' => TRUE,
+      'middle' => FALSE,
+      'family' => FALSE,
+      'generational' => FALSE,
+      'credentials' => FALSE,
+    ]);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Cannot use the "Family, Given" shorthand because the "family" component is disabled on this field.');
+
+    $handler->expand(['Doe, John']);
+  }
+
+  /**
+   * Tests that the shorthand throws when a given part is supplied but disabled.
+   */
+  public function testShorthandThrowsWhenGivenPartSuppliedButDisabled(): void {
+    $handler = $this->createHandler([
+      'title' => FALSE,
+      'given' => FALSE,
+      'middle' => FALSE,
+      'family' => TRUE,
+      'generational' => FALSE,
+      'credentials' => FALSE,
+    ]);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Cannot use the "Family, Given" shorthand because the "given" component is disabled on this field.');
+
+    $handler->expand(['Doe, John']);
+  }
+
+  /**
+   * Tests the family-only shorthand when 'given' is disabled.
+   */
+  public function testShorthandFamilyOnlyWhenGivenDisabled(): void {
+    $handler = $this->createHandler([
+      'title' => FALSE,
+      'given' => FALSE,
+      'middle' => FALSE,
+      'family' => TRUE,
+      'generational' => FALSE,
+      'credentials' => FALSE,
+    ]);
+
+    $result = $handler->expand(['Doe']);
+
+    $this->assertSame([['family' => 'Doe']], $result);
+  }
+
+  /**
+   * Creates a NameHandler with an injected fieldConfig mock.
+   *
+   * @param array<string, bool> $components
+   *   Map of component name to enabled flag. Defaults to all enabled.
    *
    * @return \Drupal\Driver\Core\Field\NameHandler
    *   The handler instance.
    */
-  protected function createHandler(): NameHandler {
+  protected function createHandler(array $components = self::ALL_ENABLED): NameHandler {
+    $field_config = $this->createMock(FieldDefinitionInterface::class);
+    $field_config->method('getSettings')->willReturn(['components' => $components]);
+
     $reflection = new \ReflectionClass(NameHandler::class);
-    return $reflection->newInstanceWithoutConstructor();
+    $handler = $reflection->newInstanceWithoutConstructor();
+
+    $property = new \ReflectionProperty(NameHandler::class, 'fieldConfig');
+    $property->setValue($handler, $field_config);
+
+    return $handler;
   }
 
 }


### PR DESCRIPTION
Closes #366

## Summary

`NameHandler` previously hard-coded all six name components (`title`, `given`, `middle`, `family`, `generational`, `credentials`) regardless of which ones a site had enabled via the Name module's field settings. After this change, the handler reads the field's `components` config map, filters to only the enabled subset, and fails loudly when the caller supplies values that cannot be honoured - mimicking the pattern already established by `AddressHandler` for its `field_overrides` setting.

## Changes

**`src/Drupal/Driver/Core/Field/NameHandler.php`**

- Added `COMPONENTS` class constant: the canonical six-component order, matching `NameItem::schema()`.
- Added `getEnabledComponents()`: reads `$this->fieldConfig->getSettings()['components']` and returns only the enabled subset in canonical order.
- Replaced the inline string shorthand logic with `normaliseString()`: throws if `family` is disabled, or if a `given` part is supplied but `given` is disabled; otherwise builds the keyed map from enabled components only.
- Replaced `normaliseComponents()` with `normaliseArray()`: throws on mixed numeric/named keys, throws when too many positional values are supplied for the enabled count, throws when a named key targets a disabled component, and throws on entirely unknown keys.
- Added `hasNumericKey()` helper: returns `true` if any key in an array is numeric (used for mixed-key detection).

**`tests/Drupal/Tests/Driver/Unit/Core/Field/NameHandlerTest.php`**

- Rewrote `createHandler()` to accept an optional `components` map (defaults to all enabled) and inject a `FieldDefinitionInterface` mock via `ReflectionProperty`.
- Added `ALL_ENABLED` constant to reduce repetition across test cases.
- Added unit tests for: positional skipping of disabled components, too-many-positional throws, named-key-on-disabled throws, mixed-keys throws, unknown-key throws, shorthand throws when `family` disabled, shorthand throws when `given` part supplied but disabled, and family-only shorthand succeeds when `given` is disabled.

**`tests/Drupal/Tests/Driver/Kernel/Core/Field/NameHandlerKernelTest.php`**

- Added `testNamePositionalSkipsDisabledComponents`: attaches the `name` field with `middle`, `generational`, and `credentials` disabled, then asserts that positional input `['Dr', 'Jane', 'Doe']` round-trips correctly into the `title`, `given`, `family` columns via the driver.

## Before / After

```
BEFORE: expand() - all six components always available
─────────────────────────────────────────────────────
Input shape        Component order used
─────────────────  ────────────────────────────────────────────
string "Doe, John" hard-coded: family=Doe, given=John
array  [0]=>'Dr'   hard-coded: title/given/middle/family/gen/cred
array  ['middle']  accepted silently even if middle is disabled


AFTER: expand() - reads field settings, rejects bad input
──────────────────────────────────────────────────────────────
Enabled (example):  title=1, given=1, middle=0, family=1, gen=0, cred=0

Input shape          Result
───────────────────  ─────────────────────────────────────────────────────
['Dr','Jane','Doe']  -> {title:Dr, given:Jane, family:Doe}  (skips middle)
['Dr','J','Q','D']   -> RuntimeException: too many values (only 3 enabled)
['middle'=>'Q']      -> RuntimeException: component disabled
['J', family='D']    -> RuntimeException: mixed numeric + named keys
['nickname'=>'J']    -> RuntimeException: unknown key
'Doe, John'          -> {family:Doe, given:John}  (unchanged when both enabled)
'Doe, John'          -> RuntimeException: family disabled
'Doe, John'          -> RuntimeException: given part supplied, given disabled
'Doe'                -> {family:Doe}              (given omitted when disabled)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced name field input handling to respect field configuration settings for enabled components. Improved validation to prevent invalid input patterns, including mixed key types and attempts to target disabled components. Positional input now correctly maps only to enabled components.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhedstrom/DrupalDriver/pull/368)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->