### PR TITLE
Fixed 'ImageHandler' and 'DatetimeHandler' compound parser shape.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,12 +241,16 @@ jobs:
 
       - name: Add path repository for DrupalDriver
         working-directory: drupalextension
-        # Expose the path repo as a high alpha version so DrupalExtension's
-        # '^3.0.0-alpha1' constraint (with 'minimum-stability: alpha') resolves
-        # to this PR's checkout. 'dev-master' is rejected because its dev
-        # stability falls below the consumer's alpha floor.
+        # Expose the path repo at a stable version so the constraint resolves
+        # regardless of what stability floor DrupalExtension currently sets.
+        # Earlier iterations of this step hard-coded an 'alpha' suffix to
+        # match DE's then-current 'minimum-stability'; every time DE bumped
+        # the floor (alpha -> beta -> RC -> stable) the workflow had to be
+        # bumped in lockstep. Declaring stable here satisfies any floor up
+        # to and including stable, breaking that coupling. 'dev-master' is
+        # still rejected when DE's floor is above 'dev'.
         run: |
-          composer config repositories.drupaldriver '{"type":"path","url":"../drupaldriver","options":{"versions":{"drupal/drupal-driver":"3.0.99-alpha"}}}' --json
+          composer config repositories.drupaldriver '{"type":"path","url":"../drupaldriver","options":{"versions":{"drupal/drupal-driver":"3.0.99"}}}' --json
 
       - name: Install DrupalExtension dependencies
         working-directory: drupalextension

--- a/src/Drupal/Driver/Core/Field/AbstractHandler.php
+++ b/src/Drupal/Driver/Core/Field/AbstractHandler.php
@@ -23,6 +23,19 @@ abstract class AbstractHandler implements FieldHandlerInterface {
   protected FieldDefinitionInterface $fieldConfig;
 
   /**
+   * Main property name of the field's storage definition.
+   *
+   * Cached once at construction so 'normalise()' and subclass 'expand()'
+   * methods do not have to look it up on every call. Resolves to the
+   * column key that a bare scalar maps to ('target_id' for image/file/
+   * entity_reference, 'value' for datetime/boolean/list/text, 'uri' for
+   * link, etc.). NULL for field types without a single main column (e.g.
+   * 'address', 'name'); those handlers must override 'normalise()' or
+   * 'expand()' to interpret records themselves.
+   */
+  protected ?string $mainProperty = NULL;
+
+  /**
    * Constructs an AbstractHandler object.
    *
    * @param \Drupal\Driver\Entity\EntityStubInterface $stub
@@ -64,6 +77,7 @@ abstract class AbstractHandler implements FieldHandlerInterface {
 
     $this->fieldInfo = $storage_definitions[$field_name];
     $this->fieldConfig = $field_definitions[$field_name];
+    $this->mainProperty = $this->fieldInfo->getMainPropertyName();
   }
 
   /**
@@ -96,10 +110,12 @@ abstract class AbstractHandler implements FieldHandlerInterface {
    *   A canonical list of records.
    */
   protected function normalise(mixed $values): array {
-    $main_property = $this->fieldInfo->getMainPropertyName();
+    if ($this->mainProperty === NULL) {
+      throw new \LogicException(sprintf('Handler "%s" has no main property and cannot use the default normalise(); override normalise() in the handler subclass.', static::class));
+    }
 
     if (!is_array($values)) {
-      return [[$main_property => $values]];
+      return [[$this->mainProperty => $values]];
     }
 
     if ($values === []) {
@@ -135,7 +151,7 @@ abstract class AbstractHandler implements FieldHandlerInterface {
       $records = [];
 
       foreach ($values as $value) {
-        $records[] = is_array($value) ? $value : [$main_property => $value];
+        $records[] = is_array($value) ? $value : [$this->mainProperty => $value];
       }
     }
 
@@ -144,10 +160,10 @@ abstract class AbstractHandler implements FieldHandlerInterface {
     // left only the extras like 'alt' or 'format'); flag it here so the
     // handler does not silently dispatch on missing data.
     foreach ($records as $record) {
-      if (!array_key_exists($main_property, $record)) {
+      if (!array_key_exists($this->mainProperty, $record)) {
         throw new \InvalidArgumentException(sprintf(
           'Field record must include the main property "%s". Got keys: %s.',
-          $main_property,
+          $this->mainProperty,
           implode(', ', array_keys($record)) ?: '(none)',
         ));
       }

--- a/src/Drupal/Driver/Core/Field/AbstractHandler.php
+++ b/src/Drupal/Driver/Core/Field/AbstractHandler.php
@@ -66,4 +66,79 @@ abstract class AbstractHandler implements FieldHandlerInterface {
     $this->fieldConfig = $field_definitions[$field_name];
   }
 
+  /**
+   * Normalises loose handler input into a canonical list of records.
+   *
+   * Consumers should not have to know whether a field is single- or
+   * multi-column; this method accepts any of the natural shapes a caller
+   * is likely to produce and returns a uniform 'array<int, array<string,
+   * mixed>>' that 'expand()' implementations can iterate without sniffing.
+   *
+   * Recognised input shapes:
+   *   - Bare scalar -> wrapped as a single record using the main property.
+   *   - List of scalars -> each wrapped as a record.
+   *   - Single keyed record -> wrapped in a one-element list.
+   *   - List of records -> returned unchanged.
+   *   - Mixed list of scalars and records -> scalars wrapped, records kept.
+   *
+   * The main property name (the column a bare scalar maps to) is pulled
+   * from the field's storage definition - 'target_id' for image/file/
+   * entity_reference, 'value' for datetime/boolean/list/text, 'uri' for
+   * link, etc. Subclasses with custom shorthand (e.g. 'NameHandler's
+   * 'Family, Given' string, 'AddressHandler's first-visible-field
+   * shorthand) should override this method and call 'parent::normalise()'
+   * for the residual cases they do not handle themselves.
+   *
+   * @param mixed $values
+   *   Whatever shape the caller produced.
+   *
+   * @return array<int, array<string, mixed>>
+   *   A canonical list of records.
+   */
+  protected function normalise(mixed $values): array {
+    $main_property = $this->fieldInfo->getMainPropertyName();
+
+    if (!is_array($values)) {
+      return [[$main_property => $values]];
+    }
+
+    if ($values === []) {
+      return [];
+    }
+
+    // '['foo.jpg', 'alt' => 'A']' is ambiguous: is 'foo.jpg' the main
+    // value with 'alt' as an extra, or two separate deltas with one of
+    // them named? Reject rather than silently picking one.
+    $has_int_key = FALSE;
+    $has_string_key = FALSE;
+
+    foreach (array_keys($values) as $key) {
+      if (is_int($key)) {
+        $has_int_key = TRUE;
+      }
+      else {
+        $has_string_key = TRUE;
+      }
+    }
+
+    if ($has_int_key && $has_string_key) {
+      throw new \InvalidArgumentException(sprintf(
+        'Field value cannot mix positional and named keys at the top level. Got keys: %s. Pass either a list of values or a single keyed record, not both.',
+        implode(', ', array_keys($values)),
+      ));
+    }
+
+    if (!array_is_list($values)) {
+      return [$values];
+    }
+
+    $records = [];
+
+    foreach ($values as $value) {
+      $records[] = is_array($value) ? $value : [$main_property => $value];
+    }
+
+    return $records;
+  }
+
 }

--- a/src/Drupal/Driver/Core/Field/AbstractHandler.php
+++ b/src/Drupal/Driver/Core/Field/AbstractHandler.php
@@ -129,13 +129,28 @@ abstract class AbstractHandler implements FieldHandlerInterface {
     }
 
     if (!array_is_list($values)) {
-      return [$values];
+      $records = [$values];
+    }
+    else {
+      $records = [];
+
+      foreach ($values as $value) {
+        $records[] = is_array($value) ? $value : [$main_property => $value];
+      }
     }
 
-    $records = [];
-
-    foreach ($values as $value) {
-      $records[] = is_array($value) ? $value : [$main_property => $value];
+    // Every record must carry the main property key. A record without it
+    // is almost always a caller mistake (omitted the path/value/uri and
+    // left only the extras like 'alt' or 'format'); flag it here so the
+    // handler does not silently dispatch on missing data.
+    foreach ($records as $record) {
+      if (!array_key_exists($main_property, $record)) {
+        throw new \InvalidArgumentException(sprintf(
+          'Field record must include the main property "%s". Got keys: %s.',
+          $main_property,
+          implode(', ', array_keys($record)) ?: '(none)',
+        ));
+      }
     }
 
     return $records;

--- a/src/Drupal/Driver/Core/Field/DatetimeHandler.php
+++ b/src/Drupal/Driver/Core/Field/DatetimeHandler.php
@@ -16,10 +16,11 @@ class DatetimeHandler extends AbstractHandler {
   /**
    * {@inheritdoc}
    *
-   * Canonical contract: '$values' is a list of records keyed by column name
-   * ('value'). Returns the same shape with each 'value' formatted for
-   * storage. Callers that hold scalar dates must wrap them into
-   * '['value' => $date]' records.
+   * Accepts whatever shape the caller naturally has: a bare date string,
+   * a list of date strings, a single record, or a list of records.
+   * 'normalise()' folds all of those into a canonical list of records
+   * before iteration. Returns a uniform list of records with 'value'
+   * formatted for storage.
    */
   public function expand($values): array {
     // Fresh Drupal installs leave system.date:timezone.default NULL until the
@@ -27,9 +28,10 @@ class DatetimeHandler extends AbstractHandler {
     // NULL to DateTimeZone.
     $site_timezone = new \DateTimeZone(\Drupal::config('system.date')->get('timezone.default') ?: 'UTC');
     $storage_timezone = new \DateTimeZone(DateTimeItemInterface::STORAGE_TIMEZONE);
+    $records = $this->normalise($values);
     $formatted = [];
 
-    foreach ($values as $record) {
+    foreach ($records as $record) {
       $formatted[] = [
         'value' => $this->formatDateValue($record['value'] ?? NULL, $site_timezone, $storage_timezone),
       ];

--- a/src/Drupal/Driver/Core/Field/DatetimeHandler.php
+++ b/src/Drupal/Driver/Core/Field/DatetimeHandler.php
@@ -15,6 +15,11 @@ class DatetimeHandler extends AbstractHandler {
 
   /**
    * {@inheritdoc}
+   *
+   * Canonical contract: '$values' is a list of records keyed by column name
+   * ('value'). Returns the same shape with each 'value' formatted for
+   * storage. Callers that hold scalar dates must wrap them into
+   * '['value' => $date]' records.
    */
   public function expand($values): array {
     // Fresh Drupal installs leave system.date:timezone.default NULL until the
@@ -24,12 +29,10 @@ class DatetimeHandler extends AbstractHandler {
     $storage_timezone = new \DateTimeZone(DateTimeItemInterface::STORAGE_TIMEZONE);
     $formatted = [];
 
-    foreach ($values as $value) {
-      // EntityFieldParser emits compound-mode deltas as '['value' => '...']'
-      // arrays. Sibling DaterangeHandler accepts the same shape; mirror it
-      // here so 'datetime' fields work uniformly with the parser.
-      $date = is_array($value) ? ($value['value'] ?? $value[0] ?? NULL) : $value;
-      $formatted[] = $this->formatDateValue($date, $site_timezone, $storage_timezone);
+    foreach ($values as $record) {
+      $formatted[] = [
+        'value' => $this->formatDateValue($record['value'] ?? NULL, $site_timezone, $storage_timezone),
+      ];
     }
 
     return $formatted;

--- a/src/Drupal/Driver/Core/Field/DatetimeHandler.php
+++ b/src/Drupal/Driver/Core/Field/DatetimeHandler.php
@@ -22,12 +22,17 @@ class DatetimeHandler extends AbstractHandler {
     // NULL to DateTimeZone.
     $site_timezone = new \DateTimeZone(\Drupal::config('system.date')->get('timezone.default') ?: 'UTC');
     $storage_timezone = new \DateTimeZone(DateTimeItemInterface::STORAGE_TIMEZONE);
+    $formatted = [];
 
-    foreach ($values as $key => $value) {
-      $values[$key] = $this->formatDateValue($value, $site_timezone, $storage_timezone);
+    foreach ($values as $value) {
+      // EntityFieldParser emits compound-mode deltas as '['value' => '...']'
+      // arrays. Sibling DaterangeHandler accepts the same shape; mirror it
+      // here so 'datetime' fields work uniformly with the parser.
+      $date = is_array($value) ? ($value['value'] ?? $value[0] ?? NULL) : $value;
+      $formatted[] = $this->formatDateValue($date, $site_timezone, $storage_timezone);
     }
 
-    return $values;
+    return $formatted;
   }
 
   /**

--- a/src/Drupal/Driver/Core/Field/ImageHandler.php
+++ b/src/Drupal/Driver/Core/Field/ImageHandler.php
@@ -16,15 +16,17 @@ class ImageHandler extends FileHandler {
   /**
    * {@inheritdoc}
    *
-   * Canonical contract: '$values' is a list of records keyed by column name
-   * ('target_id', 'alt', 'title'). Returns the same shape with 'target_id'
-   * resolved from path/URI/basename to a File entity id. Callers that hold
-   * scalar paths must wrap them into '['target_id' => $path]' records.
+   * Accepts whatever shape the caller naturally has: a bare path, a list
+   * of paths, a single record, or a list of records. 'normalise()' folds
+   * all of those into a canonical list of records before iteration.
+   * Returns a uniform list of records with 'target_id' resolved to a
+   * File entity id.
    */
   public function expand($values): array {
+    $records = $this->normalise($values);
     $expanded = [];
 
-    foreach ($values as $record) {
+    foreach ($records as $record) {
       $file_path = (string) $record['target_id'];
       $file = $this->resolveExistingFile($file_path) ?? $this->uploadAndSave($file_path);
 

--- a/src/Drupal/Driver/Core/Field/ImageHandler.php
+++ b/src/Drupal/Driver/Core/Field/ImageHandler.php
@@ -17,15 +17,27 @@ class ImageHandler extends FileHandler {
    * {@inheritdoc}
    */
   public function expand($values): array {
-    $file_path = $values[0];
+    // Normalise three accepted shapes into a list of records:
+    //   - ['foo.jpg'] (scalar mode)
+    //   - ['foo.jpg', 'alt' => 'A', 'title' => 'B'] (legacy flat positional)
+    //   - [['target_id' => 'foo.jpg', 'alt' => 'A', 'title' => 'B']] (compound
+    //     mode from EntityFieldParser row 16).
+    $records = (isset($values[0]) && is_array($values[0])) ? $values : [$values];
 
-    $file = $this->resolveExistingFile($file_path) ?? $this->uploadAndSave($file_path);
+    $expanded = [];
 
-    return [
-      'target_id' => $file->id(),
-      'alt' => $values['alt'] ?? NULL,
-      'title' => $values['title'] ?? NULL,
-    ];
+    foreach ($records as $record) {
+      $file_path = (string) ($record['target_id'] ?? $record[0] ?? '');
+      $file = $this->resolveExistingFile($file_path) ?? $this->uploadAndSave($file_path);
+
+      $expanded[] = [
+        'target_id' => $file->id(),
+        'alt' => $record['alt'] ?? NULL,
+        'title' => $record['title'] ?? NULL,
+      ];
+    }
+
+    return count($expanded) === 1 ? $expanded[0] : $expanded;
   }
 
 }

--- a/src/Drupal/Driver/Core/Field/ImageHandler.php
+++ b/src/Drupal/Driver/Core/Field/ImageHandler.php
@@ -15,19 +15,17 @@ class ImageHandler extends FileHandler {
 
   /**
    * {@inheritdoc}
+   *
+   * Canonical contract: '$values' is a list of records keyed by column name
+   * ('target_id', 'alt', 'title'). Returns the same shape with 'target_id'
+   * resolved from path/URI/basename to a File entity id. Callers that hold
+   * scalar paths must wrap them into '['target_id' => $path]' records.
    */
   public function expand($values): array {
-    // Normalise three accepted shapes into a list of records:
-    // - ['foo.jpg'] (scalar mode)
-    // - ['foo.jpg', 'alt' => 'A', 'title' => 'B'] (legacy flat positional)
-    // - [['target_id' => 'foo.jpg', 'alt' => 'A', 'title' => 'B']] (compound
-    //   mode from EntityFieldParser row 16).
-    $records = (isset($values[0]) && is_array($values[0])) ? $values : [$values];
-
     $expanded = [];
 
-    foreach ($records as $record) {
-      $file_path = (string) ($record['target_id'] ?? $record[0] ?? '');
+    foreach ($values as $record) {
+      $file_path = (string) $record['target_id'];
       $file = $this->resolveExistingFile($file_path) ?? $this->uploadAndSave($file_path);
 
       $expanded[] = [
@@ -37,7 +35,7 @@ class ImageHandler extends FileHandler {
       ];
     }
 
-    return count($expanded) === 1 ? $expanded[0] : $expanded;
+    return $expanded;
   }
 
 }

--- a/src/Drupal/Driver/Core/Field/ImageHandler.php
+++ b/src/Drupal/Driver/Core/Field/ImageHandler.php
@@ -27,6 +27,10 @@ class ImageHandler extends FileHandler {
     $expanded = [];
 
     foreach ($records as $record) {
+      if (!array_key_exists('target_id', $record) || $record['target_id'] === NULL || $record['target_id'] === '') {
+        throw new \InvalidArgumentException('Image field record must include a non-empty "target_id".');
+      }
+
       $file_path = (string) $record['target_id'];
       $file = $this->resolveExistingFile($file_path) ?? $this->uploadAndSave($file_path);
 

--- a/src/Drupal/Driver/Core/Field/ImageHandler.php
+++ b/src/Drupal/Driver/Core/Field/ImageHandler.php
@@ -27,18 +27,18 @@ class ImageHandler extends FileHandler {
     $expanded = [];
 
     foreach ($records as $record) {
-      // normalise() already enforced that 'target_id' is a key on every
+      // normalise() already enforced that the main property key is on every
       // record; here we additionally reject NULL/empty values because the
       // file resolver and uploader need a real path/URI/basename.
-      if ($record['target_id'] === NULL || $record['target_id'] === '') {
-        throw new \InvalidArgumentException('Image field "target_id" must not be NULL or empty.');
+      if ($record[$this->mainProperty] === NULL || $record[$this->mainProperty] === '') {
+        throw new \InvalidArgumentException(sprintf('Image field "%s" must not be NULL or empty.', $this->mainProperty));
       }
 
-      $file_path = (string) $record['target_id'];
+      $file_path = (string) $record[$this->mainProperty];
       $file = $this->resolveExistingFile($file_path) ?? $this->uploadAndSave($file_path);
 
       $expanded[] = [
-        'target_id' => $file->id(),
+        $this->mainProperty => $file->id(),
         'alt' => $record['alt'] ?? NULL,
         'title' => $record['title'] ?? NULL,
       ];

--- a/src/Drupal/Driver/Core/Field/ImageHandler.php
+++ b/src/Drupal/Driver/Core/Field/ImageHandler.php
@@ -18,10 +18,10 @@ class ImageHandler extends FileHandler {
    */
   public function expand($values): array {
     // Normalise three accepted shapes into a list of records:
-    //   - ['foo.jpg'] (scalar mode)
-    //   - ['foo.jpg', 'alt' => 'A', 'title' => 'B'] (legacy flat positional)
-    //   - [['target_id' => 'foo.jpg', 'alt' => 'A', 'title' => 'B']] (compound
-    //     mode from EntityFieldParser row 16).
+    // - ['foo.jpg'] (scalar mode)
+    // - ['foo.jpg', 'alt' => 'A', 'title' => 'B'] (legacy flat positional)
+    // - [['target_id' => 'foo.jpg', 'alt' => 'A', 'title' => 'B']] (compound
+    //   mode from EntityFieldParser row 16).
     $records = (isset($values[0]) && is_array($values[0])) ? $values : [$values];
 
     $expanded = [];

--- a/src/Drupal/Driver/Core/Field/ImageHandler.php
+++ b/src/Drupal/Driver/Core/Field/ImageHandler.php
@@ -27,8 +27,11 @@ class ImageHandler extends FileHandler {
     $expanded = [];
 
     foreach ($records as $record) {
-      if (!array_key_exists('target_id', $record) || $record['target_id'] === NULL || $record['target_id'] === '') {
-        throw new \InvalidArgumentException('Image field record must include a non-empty "target_id".');
+      // normalise() already enforced that 'target_id' is a key on every
+      // record; here we additionally reject NULL/empty values because the
+      // file resolver and uploader need a real path/URI/basename.
+      if ($record['target_id'] === NULL || $record['target_id'] === '') {
+        throw new \InvalidArgumentException('Image field "target_id" must not be NULL or empty.');
       }
 
       $file_path = (string) $record['target_id'];

--- a/src/Drupal/Driver/Core/Field/TextHandler.php
+++ b/src/Drupal/Driver/Core/Field/TextHandler.php
@@ -11,13 +11,13 @@ namespace Drupal\Driver\Core\Field;
  * 'text_long'. Both share the multi-column shape and therefore need a
  * dedicated pass-through so DefaultHandler does not reject the payload.
  */
-class TextHandler implements FieldHandlerInterface {
+class TextHandler extends AbstractHandler {
 
   /**
    * {@inheritdoc}
    */
   public function expand(mixed $values): array {
-    return (array) $values;
+    return $this->normalise($values);
   }
 
 }

--- a/src/Drupal/Driver/Core/Field/TextLongHandler.php
+++ b/src/Drupal/Driver/Core/Field/TextLongHandler.php
@@ -11,13 +11,13 @@ namespace Drupal\Driver\Core\Field;
  * paragraph body, custom block body. DefaultHandler cannot marshal it
  * because it is multi-column, so a dedicated pass-through is required.
  */
-class TextLongHandler implements FieldHandlerInterface {
+class TextLongHandler extends AbstractHandler {
 
   /**
    * {@inheritdoc}
    */
   public function expand(mixed $values): array {
-    return (array) $values;
+    return $this->normalise($values);
   }
 
 }

--- a/src/Drupal/Driver/Core/Field/TextWithSummaryHandler.php
+++ b/src/Drupal/Driver/Core/Field/TextWithSummaryHandler.php
@@ -7,13 +7,13 @@ namespace Drupal\Driver\Core\Field;
 /**
  * Default field handler for Drupal 8.
  */
-class TextWithSummaryHandler implements FieldHandlerInterface {
+class TextWithSummaryHandler extends AbstractHandler {
 
   /**
    * {@inheritdoc}
    */
   public function expand(mixed $values): array {
-    return (array) $values;
+    return $this->normalise($values);
   }
 
 }

--- a/tests/Drupal/Tests/Driver/Kernel/Core/Field/DatetimeHandlerKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/Field/DatetimeHandlerKernelTest.php
@@ -33,12 +33,17 @@ class DatetimeHandlerKernelTest extends FieldHandlerKernelTestBase {
 
   /**
    * Tests round-trip for a datetime field (with time component).
+   *
+   * Input matches the canonical handler contract: a list of records keyed
+   * by datetime column name ('value').
    */
   public function testDatetimeRoundTrip(): void {
     $this->attachField('field_event_date', 'datetime', [
       'datetime_type' => DateTimeItem::DATETIME_TYPE_DATETIME,
     ]);
-    $this->assertFieldRoundTripViaDriver('field_event_date', ['2026-07-15T10:00:00']);
+    $this->assertFieldRoundTripViaDriver('field_event_date', [
+      ['value' => '2026-07-15T10:00:00'],
+    ]);
   }
 
   /**
@@ -48,7 +53,9 @@ class DatetimeHandlerKernelTest extends FieldHandlerKernelTestBase {
     $this->attachField('field_birthday', 'datetime', [
       'datetime_type' => DateTimeItem::DATETIME_TYPE_DATE,
     ]);
-    $this->assertFieldRoundTripViaDriver('field_birthday', ['2026-07-15']);
+    $this->assertFieldRoundTripViaDriver('field_birthday', [
+      ['value' => '2026-07-15'],
+    ]);
   }
 
   /**
@@ -61,27 +68,13 @@ class DatetimeHandlerKernelTest extends FieldHandlerKernelTestBase {
 
     $stub = new EntityStub(self::ENTITY_TYPE, self::BUNDLE, [
       'name' => 'relative-date',
-      'field_seen' => ['relative:2026-01-02 03:04:05'],
+      'field_seen' => [['value' => 'relative:2026-01-02 03:04:05']],
     ]);
     $this->core->entityCreate($stub);
 
     // The 'relative:' prefix is stripped before parsing; the resulting value
     // matches the same storage string the plain timestamp would have produced.
-    $this->assertSame(['2026-01-02T03:04:05'], $stub->getValue('field_seen'));
-  }
-
-  /**
-   * Tests round-trip for the compound-parser shape ('[['value' => ...]]').
-   *
-   * @see \Drupal\DrupalExtension\Parser\EntityFieldParser
-   */
-  public function testDatetimeRoundTripWithCompoundParserShape(): void {
-    $this->attachField('field_event_date', 'datetime', [
-      'datetime_type' => DateTimeItem::DATETIME_TYPE_DATETIME,
-    ]);
-    $this->assertFieldRoundTripViaDriver('field_event_date', [
-      ['value' => '2026-07-15T10:00:00'],
-    ]);
+    $this->assertSame([['value' => '2026-01-02T03:04:05']], $stub->getValue('field_seen'));
   }
 
 }

--- a/tests/Drupal/Tests/Driver/Kernel/Core/Field/DatetimeHandlerKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/Field/DatetimeHandlerKernelTest.php
@@ -70,4 +70,18 @@ class DatetimeHandlerKernelTest extends FieldHandlerKernelTestBase {
     $this->assertSame(['2026-01-02T03:04:05'], $stub->getValue('field_seen'));
   }
 
+  /**
+   * Tests round-trip for the compound-parser shape ('[['value' => ...]]').
+   *
+   * @see \Drupal\DrupalExtension\Parser\EntityFieldParser
+   */
+  public function testDatetimeRoundTripWithCompoundParserShape(): void {
+    $this->attachField('field_event_date', 'datetime', [
+      'datetime_type' => DateTimeItem::DATETIME_TYPE_DATETIME,
+    ]);
+    $this->assertFieldRoundTripViaDriver('field_event_date', [
+      ['value' => '2026-07-15T10:00:00'],
+    ]);
+  }
+
 }

--- a/tests/Drupal/Tests/Driver/Kernel/Core/Field/ImageHandlerKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/Field/ImageHandlerKernelTest.php
@@ -50,29 +50,11 @@ class ImageHandlerKernelTest extends FieldHandlerKernelTestBase {
 
   /**
    * Tests round-trip for an image field with a source JPEG from disk.
+   *
+   * Input matches the canonical handler contract: a list of records keyed
+   * by image column name ('target_id', 'alt', 'title').
    */
   public function testImageRoundTrip(): void {
-    $this->attachField('field_photo', 'image');
-
-    $fixture = dirname(__DIR__, 6) . '/fixtures/files/sample.jpg';
-
-    // ImageHandler takes [$path] or [$path, 'alt' => ..., 'title' => ...].
-    // The alt/title keys come in as associative keys beside the numeric path.
-    $this->assertFieldRoundTripViaDriver('field_photo', [
-      0 => $fixture,
-      'alt' => 'A red pixel.',
-      'title' => 'Sample photo.',
-    ]);
-
-    $this->assertInstanceOf(File::class, File::load($this->latestFileId()));
-  }
-
-  /**
-   * Tests round-trip for the compound-parser shape ('[['target_id' => ...]]').
-   *
-   * @see \Drupal\DrupalExtension\Parser\EntityFieldParser
-   */
-  public function testImageRoundTripWithCompoundParserShape(): void {
     $this->attachField('field_photo', 'image');
 
     $fixture = dirname(__DIR__, 6) . '/fixtures/files/sample.jpg';
@@ -80,8 +62,8 @@ class ImageHandlerKernelTest extends FieldHandlerKernelTestBase {
     $this->assertFieldRoundTripViaDriver('field_photo', [
       [
         'target_id' => $fixture,
-        'alt' => 'Compound alt.',
-        'title' => 'Compound title.',
+        'alt' => 'A red pixel.',
+        'title' => 'Sample photo.',
       ],
     ]);
 

--- a/tests/Drupal/Tests/Driver/Kernel/Core/Field/ImageHandlerKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/Field/ImageHandlerKernelTest.php
@@ -68,6 +68,27 @@ class ImageHandlerKernelTest extends FieldHandlerKernelTestBase {
   }
 
   /**
+   * Tests round-trip for the compound-parser shape ('[['target_id' => ...]]').
+   *
+   * @see \Drupal\DrupalExtension\Parser\EntityFieldParser
+   */
+  public function testImageRoundTripWithCompoundParserShape(): void {
+    $this->attachField('field_photo', 'image');
+
+    $fixture = dirname(__DIR__, 6) . '/fixtures/files/sample.jpg';
+
+    $this->assertFieldRoundTripViaDriver('field_photo', [
+      [
+        'target_id' => $fixture,
+        'alt' => 'Compound alt.',
+        'title' => 'Compound title.',
+      ],
+    ]);
+
+    $this->assertInstanceOf(File::class, File::load($this->latestFileId()));
+  }
+
+  /**
    * Returns the highest file id currently in storage.
    */
   protected function latestFileId(): int {

--- a/tests/Drupal/Tests/Driver/Kernel/Core/Field/ImageHandlerReuseKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/Field/ImageHandlerReuseKernelTest.php
@@ -58,7 +58,9 @@ class ImageHandlerReuseKernelTest extends FieldHandlerKernelTestBase {
 
     $stub = new EntityStub(self::ENTITY_TYPE, self::BUNDLE, [
       'name' => 'reuse by uri',
-      'field_photo' => ['public://existing-hero.jpg', 'alt' => 'Hero', 'title' => 'Hero title'],
+      'field_photo' => [
+        ['target_id' => 'public://existing-hero.jpg', 'alt' => 'Hero', 'title' => 'Hero title'],
+      ],
     ]);
 
     $this->core->entityCreate($stub);
@@ -80,7 +82,9 @@ class ImageHandlerReuseKernelTest extends FieldHandlerKernelTestBase {
 
     $stub = new EntityStub(self::ENTITY_TYPE, self::BUNDLE, [
       'name' => 'reuse by basename',
-      'field_photo' => ['existing-logo.png'],
+      'field_photo' => [
+        ['target_id' => 'existing-logo.png'],
+      ],
     ]);
 
     $this->core->entityCreate($stub);

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/AbstractHandlerNormaliseTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/AbstractHandlerNormaliseTest.php
@@ -183,6 +183,27 @@ class AbstractHandlerNormaliseTest extends TestCase {
       \InvalidArgumentException::class,
       'Got keys: 2, alt.',
     ];
+    yield 'rejects single record missing main property' => [
+      ['alt' => 'A', 'title' => 'B'],
+      'target_id',
+      NULL,
+      \InvalidArgumentException::class,
+      'Field record must include the main property "target_id". Got keys: alt, title.',
+    ];
+    yield 'rejects record in list missing main property' => [
+      [['target_id' => 'a.jpg'], ['alt' => 'orphan']],
+      'target_id',
+      NULL,
+      \InvalidArgumentException::class,
+      'Field record must include the main property "target_id". Got keys: alt.',
+    ];
+    yield 'rejects empty record' => [
+      [[]],
+      'value',
+      NULL,
+      \InvalidArgumentException::class,
+      'Field record must include the main property "value". Got keys: (none).',
+    ];
   }
 
   /**

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/AbstractHandlerNormaliseTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/AbstractHandlerNormaliseTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\Driver\Unit\Core\Field;
 
-use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Driver\Core\Field\AbstractHandler;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -218,20 +217,17 @@ class AbstractHandlerNormaliseTest extends TestCase {
   }
 
   /**
-   * Creates an AbstractHandler subclass with a stubbed fieldInfo.
+   * Creates an AbstractHandler subclass with the main property injected.
    *
    * Bypasses the constructor (which requires a full Drupal entity bootstrap)
-   * and injects a fieldInfo mock whose getMainPropertyName() returns the
-   * given value.
+   * and sets 'mainProperty' directly via reflection - 'normalise()' only
+   * needs that one value.
    */
   protected function createHandler(string $main_property): AbstractHandler {
-    $field_info = $this->createMock(FieldStorageDefinitionInterface::class);
-    $field_info->method('getMainPropertyName')->willReturn($main_property);
-
     $handler = (new \ReflectionClass(NormaliseTestHandler::class))->newInstanceWithoutConstructor();
 
-    $property = new \ReflectionProperty(AbstractHandler::class, 'fieldInfo');
-    $property->setValue($handler, $field_info);
+    $property = new \ReflectionProperty(AbstractHandler::class, 'mainProperty');
+    $property->setValue($handler, $main_property);
 
     return $handler;
   }

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/AbstractHandlerNormaliseTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/AbstractHandlerNormaliseTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\Driver\Unit\Core\Field;
+
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Driver\Core\Field\AbstractHandler;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests AbstractHandler::normalise() across every input shape we accept.
+ *
+ * @group fields
+ */
+#[Group('fields')]
+class AbstractHandlerNormaliseTest extends TestCase {
+
+  /**
+   * Tests every accepted and rejected input shape for normalise().
+   *
+   * Each data row carries the input, the field's main property name, the
+   * expected output (or NULL when an exception is expected), the expected
+   * exception class (or NULL for the happy path), and the expected
+   * substring of the exception message (or NULL).
+   *
+   * @param mixed $input
+   *   The loose input to feed to normalise().
+   * @param string $main_property
+   *   The field's main property name (returned by the mocked fieldInfo).
+   * @param array<int, array<string, mixed>>|null $expected
+   *   The expected canonical list of records, or NULL when expecting a throw.
+   * @param string|null $exception
+   *   The expected exception class, or NULL for the happy path.
+   * @param string|null $exception_message
+   *   Substring the exception message must contain, or NULL.
+   *
+   * @dataProvider dataProviderNormalise
+   */
+  #[DataProvider('dataProviderNormalise')]
+  public function testNormalise(mixed $input, string $main_property, ?array $expected, ?string $exception, ?string $exception_message): void {
+    $handler = $this->createHandler($main_property);
+
+    if ($exception !== NULL) {
+      $this->expectException($exception);
+
+      if ($exception_message !== NULL) {
+        $this->expectExceptionMessage($exception_message);
+      }
+    }
+
+    $result = $this->invokeNormalise($handler, $input);
+
+    if ($exception === NULL) {
+      $this->assertSame($expected, $result);
+    }
+  }
+
+  /**
+   * Data provider for testNormalise().
+   *
+   * Covers happy paths (every loose input shape the helper must accept)
+   * and error paths (every malformed shape the helper must reject).
+   */
+  public static function dataProviderNormalise(): \Iterator {
+    yield 'bare string scalar with target_id main' => [
+      'foo.jpg',
+      'target_id',
+      [['target_id' => 'foo.jpg']],
+      NULL,
+      NULL,
+    ];
+    yield 'bare integer scalar with value main' => [
+      42,
+      'value',
+      [['value' => 42]],
+      NULL,
+      NULL,
+    ];
+    yield 'bare NULL scalar' => [
+      NULL,
+      'value',
+      [['value' => NULL]],
+      NULL,
+      NULL,
+    ];
+    yield 'empty array' => [
+      [],
+      'value',
+      [],
+      NULL,
+      NULL,
+    ];
+    yield 'list of one scalar' => [
+      ['foo.jpg'],
+      'target_id',
+      [['target_id' => 'foo.jpg']],
+      NULL,
+      NULL,
+    ];
+    yield 'list of multiple scalars' => [
+      ['a.jpg', 'b.jpg'],
+      'target_id',
+      [['target_id' => 'a.jpg'], ['target_id' => 'b.jpg']],
+      NULL,
+      NULL,
+    ];
+    yield 'single record (assoc array)' => [
+      ['target_id' => 'foo.jpg', 'alt' => 'A', 'title' => 'B'],
+      'target_id',
+      [['target_id' => 'foo.jpg', 'alt' => 'A', 'title' => 'B']],
+      NULL,
+      NULL,
+    ];
+    yield 'list of one record' => [
+      [['target_id' => 'foo.jpg', 'alt' => 'A']],
+      'target_id',
+      [['target_id' => 'foo.jpg', 'alt' => 'A']],
+      NULL,
+      NULL,
+    ];
+    yield 'list of multiple records' => [
+      [
+        ['target_id' => 'a.jpg', 'alt' => 'A'],
+        ['target_id' => 'b.jpg', 'alt' => 'B'],
+      ],
+      'target_id',
+      [
+        ['target_id' => 'a.jpg', 'alt' => 'A'],
+        ['target_id' => 'b.jpg', 'alt' => 'B'],
+      ],
+      NULL,
+      NULL,
+    ];
+    yield 'mixed list of scalars and records' => [
+      ['plain', ['value' => 'rich', 'format' => 'basic_html']],
+      'value',
+      [['value' => 'plain'], ['value' => 'rich', 'format' => 'basic_html']],
+      NULL,
+      NULL,
+    ];
+    yield 'uri main property (link)' => [
+      'https://example.com',
+      'uri',
+      [['uri' => 'https://example.com']],
+      NULL,
+      NULL,
+    ];
+    yield 'list with NULL scalar' => [
+      [NULL, 'something'],
+      'value',
+      [['value' => NULL], ['value' => 'something']],
+      NULL,
+      NULL,
+    ];
+    yield 'rejects numeric 0 followed by named extras' => [
+      ['/path/foo.jpg', 'alt' => 'A'],
+      'target_id',
+      NULL,
+      \InvalidArgumentException::class,
+      'Got keys: 0, alt.',
+    ];
+    yield 'rejects numeric 0 with multiple named extras' => [
+      ['/path/foo.jpg', 'alt' => 'A', 'title' => 'B'],
+      'target_id',
+      NULL,
+      \InvalidArgumentException::class,
+      'Got keys: 0, alt, title.',
+    ];
+    yield 'rejects named keys followed by numeric' => [
+      ['alt' => 'A', 0 => '/path/foo.jpg'],
+      'target_id',
+      NULL,
+      \InvalidArgumentException::class,
+      'Got keys: alt, 0.',
+    ];
+    yield 'rejects gappy numeric mixed with named' => [
+      [2 => 'a', 'alt' => 'A'],
+      'value',
+      NULL,
+      \InvalidArgumentException::class,
+      'Got keys: 2, alt.',
+    ];
+  }
+
+  /**
+   * Invokes the protected normalise() method on the given handler.
+   *
+   * @return array<int, array<string, mixed>>
+   *   The canonical list of records returned by normalise().
+   */
+  protected function invokeNormalise(AbstractHandler $handler, mixed $input): array {
+    $method = new \ReflectionMethod(AbstractHandler::class, 'normalise');
+    return $method->invoke($handler, $input);
+  }
+
+  /**
+   * Creates an AbstractHandler subclass with a stubbed fieldInfo.
+   *
+   * Bypasses the constructor (which requires a full Drupal entity bootstrap)
+   * and injects a fieldInfo mock whose getMainPropertyName() returns the
+   * given value.
+   */
+  protected function createHandler(string $main_property): AbstractHandler {
+    $field_info = $this->createMock(FieldStorageDefinitionInterface::class);
+    $field_info->method('getMainPropertyName')->willReturn($main_property);
+
+    $handler = (new \ReflectionClass(NormaliseTestHandler::class))->newInstanceWithoutConstructor();
+
+    $property = new \ReflectionProperty(AbstractHandler::class, 'fieldInfo');
+    $property->setValue($handler, $field_info);
+
+    return $handler;
+  }
+
+}
+
+/**
+ * Concrete AbstractHandler subclass used only by the normalise() tests.
+ *
+ * Provides the abstract surface (expand()) without doing any real work,
+ * so reflection-based tests can exercise the inherited normalise() helper
+ * in isolation from any specific field handler's resolution behaviour.
+ */
+final class NormaliseTestHandler extends AbstractHandler {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function expand(mixed $values): array {
+    return $this->normalise($values);
+  }
+
+}

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/DatetimeHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/DatetimeHandlerTest.php
@@ -56,30 +56,14 @@ class DatetimeHandlerTest extends TestCase {
   }
 
   /**
-   * Tests that empty strings and NULLs pass through as NULL values.
+   * Tests that the canonical shape preserves empty values as a NULL 'value'.
    */
   public function testExpandPreservesEmptyValuesAsNull(): void {
     $handler = $this->createHandler('datetime');
 
-    $result = $handler->expand(['', NULL]);
-
-    $this->assertSame([NULL, NULL], $result);
-  }
-
-  /**
-   * Tests that the compound-parser shape ('[['value' => '']]') is accepted.
-   *
-   * Verifying with an empty value side-steps the DrupalDateTime path (which
-   * needs the language_manager service). The shape coverage is the point.
-   *
-   * @see \Drupal\DrupalExtension\Parser\EntityFieldParser
-   */
-  public function testExpandHandlesCompoundParserShapeEmpty(): void {
-    $handler = $this->createHandler('datetime');
-
     $result = $handler->expand([['value' => ''], ['value' => NULL]]);
 
-    $this->assertSame([NULL, NULL], $result);
+    $this->assertSame([['value' => NULL], ['value' => NULL]], $result);
   }
 
   /**

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/DatetimeHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/DatetimeHandlerTest.php
@@ -67,6 +67,22 @@ class DatetimeHandlerTest extends TestCase {
   }
 
   /**
+   * Tests that the compound-parser shape ('[['value' => '']]') is accepted.
+   *
+   * Verifying with an empty value side-steps the DrupalDateTime path (which
+   * needs the language_manager service). The shape coverage is the point.
+   *
+   * @see \Drupal\DrupalExtension\Parser\EntityFieldParser
+   */
+  public function testExpandHandlesCompoundParserShapeEmpty(): void {
+    $handler = $this->createHandler('datetime');
+
+    $result = $handler->expand([['value' => ''], ['value' => NULL]]);
+
+    $this->assertSame([NULL, NULL], $result);
+  }
+
+  /**
    * Creates a DatetimeHandler with a fieldInfo mock returning datetime_type.
    */
   protected function createHandler(string $datetime_type): DatetimeHandler {

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/DatetimeHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/DatetimeHandlerTest.php
@@ -11,6 +11,7 @@ use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\Driver\Core\Field\AbstractHandler;
 use Drupal\Driver\Core\Field\DatetimeHandler;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Group;
@@ -107,23 +108,26 @@ class DatetimeHandlerTest extends TestCase {
   }
 
   /**
-   * Creates a DatetimeHandler with a fieldInfo mock.
+   * Creates a DatetimeHandler with fieldInfo and main property injected.
    *
-   * Stubs both getSetting('datetime_type') (used by formatDateValue) and
-   * getMainPropertyName() (used by AbstractHandler::normalise()).
+   * The fieldInfo mock is still needed for getSetting('datetime_type')
+   * (used by formatDateValue); mainProperty is injected separately because
+   * normalise() reads it as a property, not via fieldInfo.
    */
   protected function createHandler(string $datetime_type): DatetimeHandler {
     $field_info = $this->createMock(FieldStorageDefinitionInterface::class);
     $field_info->method('getSetting')
       ->with('datetime_type')
       ->willReturn($datetime_type);
-    $field_info->method('getMainPropertyName')->willReturn('value');
 
     $reflection = new \ReflectionClass(DatetimeHandler::class);
     $handler = $reflection->newInstanceWithoutConstructor();
 
-    $property = new \ReflectionProperty(DatetimeHandler::class, 'fieldInfo');
-    $property->setValue($handler, $field_info);
+    $info_property = new \ReflectionProperty(DatetimeHandler::class, 'fieldInfo');
+    $info_property->setValue($handler, $field_info);
+
+    $main_property = new \ReflectionProperty(AbstractHandler::class, 'mainProperty');
+    $main_property->setValue($handler, 'value');
 
     return $handler;
   }

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/DatetimeHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/DatetimeHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\Driver\Unit\Core\Field;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Composer\InstalledVersions;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ImmutableConfig;
@@ -56,24 +57,67 @@ class DatetimeHandlerTest extends TestCase {
   }
 
   /**
-   * Tests that the canonical shape preserves empty values as a NULL 'value'.
+   * Tests that empty values are accepted in every input shape.
+   *
+   * @param mixed $input
+   *   Any of the loose shapes 'normalise()' accepts.
+   * @param array<int, array<string, mixed>> $expected
+   *   The expected expand() output: a list of records keyed by 'value'.
+   *
+   * @dataProvider dataProviderExpandPreservesEmptyValuesAsNull
    */
-  public function testExpandPreservesEmptyValuesAsNull(): void {
+  #[DataProvider('dataProviderExpandPreservesEmptyValuesAsNull')]
+  public function testExpandPreservesEmptyValuesAsNull(mixed $input, array $expected): void {
     $handler = $this->createHandler('datetime');
 
-    $result = $handler->expand([['value' => ''], ['value' => NULL]]);
+    $result = $handler->expand($input);
 
-    $this->assertSame([['value' => NULL], ['value' => NULL]], $result);
+    $this->assertSame($expected, $result);
   }
 
   /**
-   * Creates a DatetimeHandler with a fieldInfo mock returning datetime_type.
+   * Data provider for testExpandPreservesEmptyValuesAsNull().
+   *
+   * Non-empty dates exercise DrupalDateTime, which needs the language_manager
+   * service and a full container; those cases live in the kernel test. The
+   * shape coverage here uses empty values so that 'formatDateValue()' early
+   * returns and the only assertion is on the normalised record shape.
+   */
+  public static function dataProviderExpandPreservesEmptyValuesAsNull(): \Iterator {
+    yield 'bare empty string scalar' => [
+      '',
+      [['value' => NULL]],
+    ];
+    yield 'bare NULL scalar' => [
+      NULL,
+      [['value' => NULL]],
+    ];
+    yield 'list of empty scalars' => [
+      ['', NULL],
+      [['value' => NULL], ['value' => NULL]],
+    ];
+    yield 'single record with empty value' => [
+      ['value' => ''],
+      [['value' => NULL]],
+    ];
+    yield 'list of records with empty values' => [
+      [['value' => ''], ['value' => NULL]],
+      [['value' => NULL], ['value' => NULL]],
+    ];
+  }
+
+  /**
+   * Creates a DatetimeHandler with a fieldInfo mock.
+   *
+   * Stubs both getSetting('datetime_type') (used by formatDateValue) and
+   * getMainPropertyName() (used by AbstractHandler::normalise()).
    */
   protected function createHandler(string $datetime_type): DatetimeHandler {
     $field_info = $this->createMock(FieldStorageDefinitionInterface::class);
     $field_info->method('getSetting')
       ->with('datetime_type')
       ->willReturn($datetime_type);
+    $field_info->method('getMainPropertyName')->willReturn('value');
 
     $reflection = new \ReflectionClass(DatetimeHandler::class);
     $handler = $reflection->newInstanceWithoutConstructor();

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/FileHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/FileHandlerTest.php
@@ -8,6 +8,7 @@ use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Driver\Core\Field\FileHandler;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests the FileHandler field handler.
@@ -39,98 +40,123 @@ class FileHandlerTest extends TestCase {
   }
 
   /**
-   * Tests absolute disk paths fall through to upload when no match exists.
+   * Tests every accepted input shape on the upload code path.
+   *
+   * Covers the parser shapes that 'EntityFieldParser' emits:
+   *   - Scalar single ('['foo.bin']') and scalar multi-value.
+   *   - Compound mode from row 16 ('[['target_id' => 'foo.bin', 'display' => 1, ...]]').
+   *
+   * @param \Closure(string): array<int|string, mixed> $build_input
+   *   Builds the input array given the temp file path.
+   * @param array<int, array<string, mixed>> $expected
+   *   The expected expand() output (always a list of records for FileHandler).
    */
-  public function testExpandHandlesStringValueWithDefaults(): void {
-    $path = $this->createTempFile('png');
-    $this->setServicesWithUploadReturnId(99);
-
-    $handler = $this->createHandler();
-
-    $result = $handler->expand([$path]);
-
-    $this->assertSame([
-      ['target_id' => 99, 'display' => 1, 'description' => ''],
-    ], $result);
-  }
-
-  /**
-   * Tests that keyed array values honour their explicit overrides.
-   */
-  public function testExpandHandlesArrayValueWithOverrides(): void {
+  #[DataProvider('dataProviderExpandUploadShapes')]
+  public function testExpandUploadsFile(\Closure $build_input, array $expected): void {
     $path = $this->createTempFile('pdf');
     $this->setServicesWithUploadReturnId(42);
 
     $handler = $this->createHandler();
 
-    $result = $handler->expand([
+    $result = $handler->expand($build_input($path));
+
+    $this->assertSame($expected, $result);
+  }
+
+  /**
+   * Data provider for testExpandUploadsFile().
+   */
+  public static function dataProviderExpandUploadShapes(): \Iterator {
+    yield 'scalar single' => [
+      static fn (string $path) => [$path],
+      [['target_id' => 42, 'display' => 1, 'description' => '']],
+    ];
+    yield 'scalar multi-value' => [
+      static fn (string $path) => [$path, $path],
       [
-        'target_id' => $path,
-        'display' => 0,
-        'description' => 'Spec sheet',
+        ['target_id' => 42, 'display' => 1, 'description' => ''],
+        ['target_id' => 42, 'display' => 1, 'description' => ''],
       ],
-    ]);
-
-    $this->assertSame([
-      ['target_id' => 42, 'display' => 0, 'description' => 'Spec sheet'],
-    ], $result);
+    ];
+    yield 'compound single with display and description' => [
+      static fn (string $path) => [
+        ['target_id' => $path, 'display' => 0, 'description' => 'Spec sheet'],
+      ],
+      [['target_id' => 42, 'display' => 0, 'description' => 'Spec sheet']],
+    ];
+    yield 'compound single, bare target_id' => [
+      static fn (string $path) => [['target_id' => $path]],
+      [['target_id' => 42, 'display' => 1, 'description' => '']],
+    ];
+    yield 'compound multi-record' => [
+      static fn (string $path) => [
+        ['target_id' => $path, 'display' => 1, 'description' => 'Public'],
+        ['target_id' => $path, 'display' => 0, 'description' => 'Hidden'],
+      ],
+      [
+        ['target_id' => 42, 'display' => 1, 'description' => 'Public'],
+        ['target_id' => 42, 'display' => 0, 'description' => 'Hidden'],
+      ],
+    ];
   }
 
   /**
-   * Tests that a full URI input reuses an existing managed File if present.
+   * Tests every accepted input shape on the reuse-existing-managed-file path.
    *
-   * Restored 2.x behaviour: passing 'public://logo.png' must not trigger a
-   * new upload when a managed File already points at that URI.
+   * @param string $managed_uri
+   *   URI of the pre-existing managed File the storage stub will return.
+   * @param int $file_id
+   *   ID of the pre-existing managed File.
+   * @param array<int|string, mixed> $input
+   *   The input passed to expand().
+   * @param array<int, array<string, mixed>> $expected
+   *   The expected expand() output.
    */
-  public function testExpandReusesExistingManagedFileByUri(): void {
-    $this->setServicesWithMatchingManagedFile(
-      uri: 'public://logo.png',
-      file_id: 77,
-    );
+  #[DataProvider('dataProviderExpandReuseShapes')]
+  public function testExpandReusesManagedFile(string $managed_uri, int $file_id, array $input, array $expected): void {
+    $this->setServicesWithMatchingManagedFile(uri: $managed_uri, file_id: $file_id);
 
     $handler = $this->createHandler();
 
-    $result = $handler->expand(['public://logo.png']);
+    $result = $handler->expand($input);
 
-    $this->assertSame([
-      ['target_id' => 77, 'display' => 1, 'description' => ''],
-    ], $result);
+    $this->assertSame($expected, $result);
   }
 
   /**
-   * Tests that a bare basename reuses an existing managed File via public://.
+   * Data provider for testExpandReusesManagedFile().
    */
-  public function testExpandReusesExistingManagedFileByBareBasenamePublic(): void {
-    $this->setServicesWithMatchingManagedFile(
-      uri: 'public://report.pdf',
-      file_id: 123,
-    );
-
-    $handler = $this->createHandler();
-
-    $result = $handler->expand(['report.pdf']);
-
-    $this->assertSame([
-      ['target_id' => 123, 'display' => 1, 'description' => ''],
-    ], $result);
-  }
-
-  /**
-   * Tests that a bare basename falls back to private:// when public:// misses.
-   */
-  public function testExpandReusesExistingManagedFileByBareBasenamePrivate(): void {
-    $this->setServicesWithMatchingManagedFile(
-      uri: 'private://secret.pdf',
-      file_id: 444,
-    );
-
-    $handler = $this->createHandler();
-
-    $result = $handler->expand(['secret.pdf']);
-
-    $this->assertSame([
-      ['target_id' => 444, 'display' => 1, 'description' => ''],
-    ], $result);
+  public static function dataProviderExpandReuseShapes(): \Iterator {
+    yield 'scalar full uri reuse' => [
+      'public://logo.png',
+      77,
+      ['public://logo.png'],
+      [['target_id' => 77, 'display' => 1, 'description' => '']],
+    ];
+    yield 'scalar bare basename, public scheme' => [
+      'public://report.pdf',
+      123,
+      ['report.pdf'],
+      [['target_id' => 123, 'display' => 1, 'description' => '']],
+    ];
+    yield 'scalar bare basename, private scheme fallback' => [
+      'private://secret.pdf',
+      444,
+      ['secret.pdf'],
+      [['target_id' => 444, 'display' => 1, 'description' => '']],
+    ];
+    yield 'compound parser shape, uri reuse' => [
+      'public://logo.png',
+      80,
+      [['target_id' => 'public://logo.png', 'display' => 0, 'description' => 'Brand mark']],
+      [['target_id' => 80, 'display' => 0, 'description' => 'Brand mark']],
+    ];
+    yield 'compound parser shape, bare basename reuse' => [
+      'public://report.pdf',
+      90,
+      [['target_id' => 'report.pdf']],
+      [['target_id' => 90, 'display' => 1, 'description' => '']],
+    ];
   }
 
   /**
@@ -187,16 +213,16 @@ class FileHandlerTest extends TestCase {
   /**
    * Creates a stand-in File entity that exposes an id() method.
    */
-  private function createFakeFile(int $file_id): object {
+  protected function createFakeFile(int $file_id): object {
     return new class($file_id) {
 
-      public function __construct(private readonly int $file_id) {}
+      public function __construct(protected readonly int $fileId) {}
 
       /**
        * Returns the stored file entity ID.
        */
       public function id(): int {
-        return $this->file_id;
+        return $this->fileId;
       }
 
       /**
@@ -211,10 +237,10 @@ class FileHandlerTest extends TestCase {
   /**
    * Creates a stand-in file.repository service returning the given file.
    */
-  private function createFileRepositoryReturning(object $file): object {
+  protected function createFileRepositoryReturning(object $file): object {
     return new class($file) {
 
-      public function __construct(private readonly object $file) {}
+      public function __construct(protected readonly object $file) {}
 
       /**
        * Returns the pre-configured stored file.
@@ -229,7 +255,7 @@ class FileHandlerTest extends TestCase {
   /**
    * Creates a stand-in entity_type.manager whose file storage never matches.
    */
-  private function createEntityTypeManagerReturningNoMatches(): object {
+  protected function createEntityTypeManagerReturningNoMatches(): object {
     $storage = new class {
 
       /**
@@ -249,7 +275,7 @@ class FileHandlerTest extends TestCase {
 
     return new class($storage) {
 
-      public function __construct(private readonly object $storage) {}
+      public function __construct(protected readonly object $storage) {}
 
       /**
        * Returns the stub file storage.
@@ -267,10 +293,10 @@ class FileHandlerTest extends TestCase {
    * The storage's loadByProperties() returns $file only when called with
    * exactly ['uri' => $uri], and an empty array for every other lookup.
    */
-  private function createEntityTypeManagerReturningFileAtUri(string $uri, object $file): object {
+  protected function createEntityTypeManagerReturningFileAtUri(string $uri, object $file): object {
     $storage = new class($uri, $file) {
 
-      public function __construct(private readonly string $uri, private readonly object $file) {}
+      public function __construct(protected readonly string $uri, protected readonly object $file) {}
 
       /**
        * Returns the configured file only for lookups matching the stored URI.
@@ -293,7 +319,7 @@ class FileHandlerTest extends TestCase {
 
     return new class($storage) {
 
-      public function __construct(private readonly object $storage) {}
+      public function __construct(protected readonly object $storage) {}
 
       /**
        * Returns the stub file storage.

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/FileHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/FileHandlerTest.php
@@ -44,14 +44,14 @@ class FileHandlerTest extends TestCase {
    *
    * Covers the parser shapes that 'EntityFieldParser' emits:
    *   - Scalar single ('['foo.bin']') and scalar multi-value.
-   *   - Compound mode from row 16 ('[['target_id' => 'foo.bin', 'display' => 1, ...]]').
+   *   - Compound mode (['target_id' => 'foo.bin', 'display' => 1, ...]).
    *
    * @param \Closure(string): array<int|string, mixed> $build_input
    *   Builds the input array given the temp file path.
    * @param array<int, array<string, mixed>> $expected
    *   The expected expand() output (always a list of records for FileHandler).
    */
-  #[DataProvider('dataProviderExpandUploadShapes')]
+  #[DataProvider('dataProviderExpandUploadsFile')]
   public function testExpandUploadsFile(\Closure $build_input, array $expected): void {
     $path = $this->createTempFile('pdf');
     $this->setServicesWithUploadReturnId(42);
@@ -66,30 +66,30 @@ class FileHandlerTest extends TestCase {
   /**
    * Data provider for testExpandUploadsFile().
    */
-  public static function dataProviderExpandUploadShapes(): \Iterator {
+  public static function dataProviderExpandUploadsFile(): \Iterator {
     yield 'scalar single' => [
-      static fn (string $path) => [$path],
+      static fn (string $path): array => [$path],
       [['target_id' => 42, 'display' => 1, 'description' => '']],
     ];
     yield 'scalar multi-value' => [
-      static fn (string $path) => [$path, $path],
+      static fn (string $path): array => [$path, $path],
       [
         ['target_id' => 42, 'display' => 1, 'description' => ''],
         ['target_id' => 42, 'display' => 1, 'description' => ''],
       ],
     ];
     yield 'compound single with display and description' => [
-      static fn (string $path) => [
+      static fn (string $path): array => [
         ['target_id' => $path, 'display' => 0, 'description' => 'Spec sheet'],
       ],
       [['target_id' => 42, 'display' => 0, 'description' => 'Spec sheet']],
     ];
     yield 'compound single, bare target_id' => [
-      static fn (string $path) => [['target_id' => $path]],
+      static fn (string $path): array => [['target_id' => $path]],
       [['target_id' => 42, 'display' => 1, 'description' => '']],
     ];
     yield 'compound multi-record' => [
-      static fn (string $path) => [
+      static fn (string $path): array => [
         ['target_id' => $path, 'display' => 1, 'description' => 'Public'],
         ['target_id' => $path, 'display' => 0, 'description' => 'Hidden'],
       ],
@@ -112,7 +112,7 @@ class FileHandlerTest extends TestCase {
    * @param array<int, array<string, mixed>> $expected
    *   The expected expand() output.
    */
-  #[DataProvider('dataProviderExpandReuseShapes')]
+  #[DataProvider('dataProviderExpandReusesManagedFile')]
   public function testExpandReusesManagedFile(string $managed_uri, int $file_id, array $input, array $expected): void {
     $this->setServicesWithMatchingManagedFile(uri: $managed_uri, file_id: $file_id);
 
@@ -126,7 +126,7 @@ class FileHandlerTest extends TestCase {
   /**
    * Data provider for testExpandReusesManagedFile().
    */
-  public static function dataProviderExpandReuseShapes(): \Iterator {
+  public static function dataProviderExpandReusesManagedFile(): \Iterator {
     yield 'scalar full uri reuse' => [
       'public://logo.png',
       77,

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/FileHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/FileHandlerTest.php
@@ -50,6 +50,8 @@ class FileHandlerTest extends TestCase {
    *   Builds the input array given the temp file path.
    * @param array<int, array<string, mixed>> $expected
    *   The expected expand() output (always a list of records for FileHandler).
+   *
+   * @dataProvider dataProviderExpandUploadsFile
    */
   #[DataProvider('dataProviderExpandUploadsFile')]
   public function testExpandUploadsFile(\Closure $build_input, array $expected): void {
@@ -111,6 +113,8 @@ class FileHandlerTest extends TestCase {
    *   The input passed to expand().
    * @param array<int, array<string, mixed>> $expected
    *   The expected expand() output.
+   *
+   * @dataProvider dataProviderExpandReusesManagedFile
    */
   #[DataProvider('dataProviderExpandReusesManagedFile')]
   public function testExpandReusesManagedFile(string $managed_uri, int $file_id, array $input, array $expected): void {

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/ImageHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/ImageHandlerTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Drupal\Tests\Driver\Unit\Core\Field;
 
 use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Driver\Core\Field\AbstractHandler;
 use Drupal\Driver\Core\Field\ImageHandler;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Group;
@@ -36,14 +38,19 @@ class ImageHandlerTest extends TestCase {
     $this->expectException(\Exception::class);
     $this->expectExceptionMessage('Error reading file /tmp/drupal-driver-nonexistent-image.jpg.');
 
-    @$handler->expand([['target_id' => '/tmp/drupal-driver-nonexistent-image.jpg']]);
+    @$handler->expand('/tmp/drupal-driver-nonexistent-image.jpg');
   }
 
   /**
-   * Tests the upload code path under the canonical input shape.
+   * Tests every accepted input shape on the upload code path.
    *
-   * @param \Closure(string): array<int, array<string, mixed>> $build_input
-   *   Builds the canonical input given the temp file path.
+   * The handler delegates shape normalisation to AbstractHandler::normalise(),
+   * which already has its own dedicated test. This test confirms that every
+   * loose shape arrives at the file-resolution code with the expected
+   * 'target_id' and that extras (alt/title) round-trip when present.
+   *
+   * @param \Closure(string): mixed $build_input
+   *   Builds the input given the temp file path.
    * @param array<int, array<string, mixed>> $expected
    *   The expected expand() output (always a list of records).
    *
@@ -66,15 +73,34 @@ class ImageHandlerTest extends TestCase {
    * Data provider for testExpandUploadsFile().
    */
   public static function dataProviderExpandUploadsFile(): \Iterator {
-    yield 'single record, bare target_id' => [
-      static fn (string $path): array => [['target_id' => $path]],
+    yield 'bare scalar path' => [
+      static fn (string $path): string => $path,
+      [['target_id' => 7, 'alt' => NULL, 'title' => NULL]],
+    ];
+    yield 'list of one scalar path' => [
+      static fn (string $path): array => [$path],
+      [['target_id' => 7, 'alt' => NULL, 'title' => NULL]],
+    ];
+    yield 'list of two scalar paths' => [
+      static fn (string $path): array => [$path, $path],
+      [
+        ['target_id' => 7, 'alt' => NULL, 'title' => NULL],
+        ['target_id' => 7, 'alt' => NULL, 'title' => NULL],
+      ],
+    ];
+    yield 'single record with target_id only' => [
+      static fn (string $path): array => ['target_id' => $path],
       [['target_id' => 7, 'alt' => NULL, 'title' => NULL]],
     ];
     yield 'single record with alt and title' => [
-      static fn (string $path): array => [['target_id' => $path, 'alt' => 'An image', 'title' => 'A title']],
+      static fn (string $path): array => ['target_id' => $path, 'alt' => 'An image', 'title' => 'A title'],
       [['target_id' => 7, 'alt' => 'An image', 'title' => 'A title']],
     ];
-    yield 'multi-record' => [
+    yield 'list of one record' => [
+      static fn (string $path): array => [['target_id' => $path, 'alt' => 'Solo']],
+      [['target_id' => 7, 'alt' => 'Solo', 'title' => NULL]],
+    ];
+    yield 'list of multiple records' => [
       static fn (string $path): array => [
         ['target_id' => $path, 'alt' => 'First'],
         ['target_id' => $path, 'alt' => 'Second', 'title' => 'Second title'],
@@ -87,21 +113,22 @@ class ImageHandlerTest extends TestCase {
   }
 
   /**
-   * Tests the reuse-existing-managed-file path under the canonical shape.
+   * Tests every accepted input shape on the reuse-existing-managed-file path.
    *
    * @param string $managed_uri
    *   URI of the pre-existing managed File the storage stub will return.
    * @param int $file_id
    *   ID of the pre-existing managed File.
-   * @param array<int, array<string, mixed>> $input
-   *   The canonical input passed to expand().
+   * @param mixed $input
+   *   The input passed to expand() (any of the loose shapes the consumer
+   *   can naturally produce).
    * @param array<int, array<string, mixed>> $expected
    *   The expected expand() output.
    *
    * @dataProvider dataProviderExpandReusesManagedFile
    */
   #[DataProvider('dataProviderExpandReusesManagedFile')]
-  public function testExpandReusesManagedFile(string $managed_uri, int $file_id, array $input, array $expected): void {
+  public function testExpandReusesManagedFile(string $managed_uri, int $file_id, mixed $input, array $expected): void {
     $this->setServicesWithMatchingManagedFile(uri: $managed_uri, file_id: $file_id);
 
     $handler = $this->createHandler();
@@ -115,13 +142,25 @@ class ImageHandlerTest extends TestCase {
    * Data provider for testExpandReusesManagedFile().
    */
   public static function dataProviderExpandReusesManagedFile(): \Iterator {
-    yield 'full uri reuse' => [
+    yield 'bare scalar uri' => [
+      'public://hero.jpg',
+      55,
+      'public://hero.jpg',
+      [['target_id' => 55, 'alt' => NULL, 'title' => NULL]],
+    ];
+    yield 'bare scalar basename' => [
+      'public://logo.png',
+      66,
+      'logo.png',
+      [['target_id' => 66, 'alt' => NULL, 'title' => NULL]],
+    ];
+    yield 'single record with uri and extras' => [
       'public://hero.jpg',
       77,
-      [['target_id' => 'public://hero.jpg', 'alt' => 'Hero', 'title' => 'Hero title']],
+      ['target_id' => 'public://hero.jpg', 'alt' => 'Hero', 'title' => 'Hero title'],
       [['target_id' => 77, 'alt' => 'Hero', 'title' => 'Hero title']],
     ];
-    yield 'bare basename reuse' => [
+    yield 'list of one record with basename' => [
       'public://logo.png',
       88,
       [['target_id' => 'logo.png']],
@@ -130,11 +169,19 @@ class ImageHandlerTest extends TestCase {
   }
 
   /**
-   * Creates an ImageHandler that bypasses the parent constructor.
+   * Creates an ImageHandler with a fieldInfo stub for normalise().
    */
   protected function createHandler(): ImageHandler {
+    $field_info = $this->createMock(FieldStorageDefinitionInterface::class);
+    $field_info->method('getMainPropertyName')->willReturn('target_id');
+
     $reflection = new \ReflectionClass(ImageHandler::class);
-    return $reflection->newInstanceWithoutConstructor();
+    $handler = $reflection->newInstanceWithoutConstructor();
+
+    $property = new \ReflectionProperty(AbstractHandler::class, 'fieldInfo');
+    $property->setValue($handler, $field_info);
+
+    return $handler;
   }
 
   /**

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/ImageHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/ImageHandlerTest.php
@@ -44,7 +44,7 @@ class ImageHandlerTest extends TestCase {
    *
    * Covers the three shapes the handler is contracted to accept:
    *   - Scalar mode from EntityFieldParser ('['foo.jpg']').
-   *   - Legacy flat-positional shape kept for back-compat ('['foo.jpg', 'alt' => ...]').
+   *   - Legacy flat-positional with extras (['foo.jpg', 'alt' => ...]).
    *   - Compound mode from EntityFieldParser row 16
    *     ('[['target_id' => 'foo.jpg', ...]]') including multi-record input.
    *
@@ -55,7 +55,7 @@ class ImageHandlerTest extends TestCase {
    *
    * @see \Drupal\DrupalExtension\Parser\EntityFieldParser
    */
-  #[DataProvider('dataProviderExpandUploadShapes')]
+  #[DataProvider('dataProviderExpandUploadsFile')]
   public function testExpandUploadsFile(\Closure $build_input, array $expected): void {
     $path = tempnam(sys_get_temp_dir(), 'drupal-driver-') . '.jpg';
     file_put_contents($path, 'fixture');
@@ -71,25 +71,25 @@ class ImageHandlerTest extends TestCase {
   /**
    * Data provider for testExpandUploadsFile().
    */
-  public static function dataProviderExpandUploadShapes(): \Iterator {
+  public static function dataProviderExpandUploadsFile(): \Iterator {
     yield 'scalar single' => [
-      static fn (string $path) => [$path],
+      static fn (string $path): array => [$path],
       ['target_id' => 7, 'alt' => NULL, 'title' => NULL],
     ];
     yield 'legacy flat positional with extras' => [
-      static fn (string $path) => [$path, 'alt' => 'Alt text', 'title' => 'Title text'],
+      static fn (string $path): array => [$path, 'alt' => 'Alt text', 'title' => 'Title text'],
       ['target_id' => 7, 'alt' => 'Alt text', 'title' => 'Title text'],
     ];
     yield 'compound single, bare target_id' => [
-      static fn (string $path) => [['target_id' => $path]],
+      static fn (string $path): array => [['target_id' => $path]],
       ['target_id' => 7, 'alt' => NULL, 'title' => NULL],
     ];
     yield 'compound single with alt and title' => [
-      static fn (string $path) => [['target_id' => $path, 'alt' => 'An image', 'title' => 'A title']],
+      static fn (string $path): array => [['target_id' => $path, 'alt' => 'An image', 'title' => 'A title']],
       ['target_id' => 7, 'alt' => 'An image', 'title' => 'A title'],
     ];
     yield 'compound multi-record' => [
-      static fn (string $path) => [
+      static fn (string $path): array => [
         ['target_id' => $path, 'alt' => 'First'],
         ['target_id' => $path, 'alt' => 'Second', 'title' => 'Second title'],
       ],
@@ -112,7 +112,7 @@ class ImageHandlerTest extends TestCase {
    * @param array<int|string, mixed> $expected
    *   The expected expand() output.
    */
-  #[DataProvider('dataProviderExpandReuseShapes')]
+  #[DataProvider('dataProviderExpandReusesManagedFile')]
   public function testExpandReusesManagedFile(string $managed_uri, int $file_id, array $input, array $expected): void {
     $this->setServicesWithMatchingManagedFile(uri: $managed_uri, file_id: $file_id);
 
@@ -126,7 +126,7 @@ class ImageHandlerTest extends TestCase {
   /**
    * Data provider for testExpandReusesManagedFile().
    */
-  public static function dataProviderExpandReuseShapes(): \Iterator {
+  public static function dataProviderExpandReusesManagedFile(): \Iterator {
     yield 'scalar uri reuse' => [
       'public://hero.jpg',
       55,

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/ImageHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/ImageHandlerTest.php
@@ -36,26 +36,18 @@ class ImageHandlerTest extends TestCase {
     $this->expectException(\Exception::class);
     $this->expectExceptionMessage('Error reading file /tmp/drupal-driver-nonexistent-image.jpg.');
 
-    @$handler->expand(['/tmp/drupal-driver-nonexistent-image.jpg']);
+    @$handler->expand([['target_id' => '/tmp/drupal-driver-nonexistent-image.jpg']]);
   }
 
   /**
-   * Tests every accepted input shape on the upload code path.
+   * Tests the upload code path under the canonical input shape.
    *
-   * Covers the three shapes the handler is contracted to accept:
-   *   - Scalar mode from EntityFieldParser ('['foo.jpg']').
-   *   - Legacy flat-positional with extras (['foo.jpg', 'alt' => ...]).
-   *   - Compound mode from EntityFieldParser row 16
-   *     ('[['target_id' => 'foo.jpg', ...]]') including multi-record input.
-   *
-   * @param \Closure(string): array<int|string, mixed> $build_input
-   *   Builds the input array given the temp file path.
-   * @param array<int|string, mixed> $expected
-   *   The expected expand() output.
+   * @param \Closure(string): array<int, array<string, mixed>> $build_input
+   *   Builds the canonical input given the temp file path.
+   * @param array<int, array<string, mixed>> $expected
+   *   The expected expand() output (always a list of records).
    *
    * @dataProvider dataProviderExpandUploadsFile
-   *
-   * @see \Drupal\DrupalExtension\Parser\EntityFieldParser
    */
   #[DataProvider('dataProviderExpandUploadsFile')]
   public function testExpandUploadsFile(\Closure $build_input, array $expected): void {
@@ -74,23 +66,15 @@ class ImageHandlerTest extends TestCase {
    * Data provider for testExpandUploadsFile().
    */
   public static function dataProviderExpandUploadsFile(): \Iterator {
-    yield 'scalar single' => [
-      static fn (string $path): array => [$path],
-      ['target_id' => 7, 'alt' => NULL, 'title' => NULL],
-    ];
-    yield 'legacy flat positional with extras' => [
-      static fn (string $path): array => [$path, 'alt' => 'Alt text', 'title' => 'Title text'],
-      ['target_id' => 7, 'alt' => 'Alt text', 'title' => 'Title text'],
-    ];
-    yield 'compound single, bare target_id' => [
+    yield 'single record, bare target_id' => [
       static fn (string $path): array => [['target_id' => $path]],
-      ['target_id' => 7, 'alt' => NULL, 'title' => NULL],
+      [['target_id' => 7, 'alt' => NULL, 'title' => NULL]],
     ];
-    yield 'compound single with alt and title' => [
+    yield 'single record with alt and title' => [
       static fn (string $path): array => [['target_id' => $path, 'alt' => 'An image', 'title' => 'A title']],
-      ['target_id' => 7, 'alt' => 'An image', 'title' => 'A title'],
+      [['target_id' => 7, 'alt' => 'An image', 'title' => 'A title']],
     ];
-    yield 'compound multi-record' => [
+    yield 'multi-record' => [
       static fn (string $path): array => [
         ['target_id' => $path, 'alt' => 'First'],
         ['target_id' => $path, 'alt' => 'Second', 'title' => 'Second title'],
@@ -103,15 +87,15 @@ class ImageHandlerTest extends TestCase {
   }
 
   /**
-   * Tests every accepted input shape on the reuse-existing-managed-file path.
+   * Tests the reuse-existing-managed-file path under the canonical shape.
    *
    * @param string $managed_uri
    *   URI of the pre-existing managed File the storage stub will return.
    * @param int $file_id
    *   ID of the pre-existing managed File.
-   * @param array<int|string, mixed> $input
-   *   The input passed to expand().
-   * @param array<int|string, mixed> $expected
+   * @param array<int, array<string, mixed>> $input
+   *   The canonical input passed to expand().
+   * @param array<int, array<string, mixed>> $expected
    *   The expected expand() output.
    *
    * @dataProvider dataProviderExpandReusesManagedFile
@@ -131,29 +115,17 @@ class ImageHandlerTest extends TestCase {
    * Data provider for testExpandReusesManagedFile().
    */
   public static function dataProviderExpandReusesManagedFile(): \Iterator {
-    yield 'scalar uri reuse' => [
-      'public://hero.jpg',
-      55,
-      ['public://hero.jpg', 'alt' => 'Hero', 'title' => 'Hero title'],
-      ['target_id' => 55, 'alt' => 'Hero', 'title' => 'Hero title'],
-    ];
-    yield 'scalar bare basename reuse' => [
-      'public://logo.png',
-      66,
-      ['logo.png'],
-      ['target_id' => 66, 'alt' => NULL, 'title' => NULL],
-    ];
-    yield 'compound parser shape, uri reuse' => [
+    yield 'full uri reuse' => [
       'public://hero.jpg',
       77,
       [['target_id' => 'public://hero.jpg', 'alt' => 'Hero', 'title' => 'Hero title']],
-      ['target_id' => 77, 'alt' => 'Hero', 'title' => 'Hero title'],
+      [['target_id' => 77, 'alt' => 'Hero', 'title' => 'Hero title']],
     ];
-    yield 'compound parser shape, bare basename reuse' => [
+    yield 'bare basename reuse' => [
       'public://logo.png',
       88,
       [['target_id' => 'logo.png']],
-      ['target_id' => 88, 'alt' => NULL, 'title' => NULL],
+      [['target_id' => 88, 'alt' => NULL, 'title' => NULL]],
     ];
   }
 

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/ImageHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/ImageHandlerTest.php
@@ -53,6 +53,8 @@ class ImageHandlerTest extends TestCase {
    * @param array<int|string, mixed> $expected
    *   The expected expand() output.
    *
+   * @dataProvider dataProviderExpandUploadsFile
+   *
    * @see \Drupal\DrupalExtension\Parser\EntityFieldParser
    */
   #[DataProvider('dataProviderExpandUploadsFile')]
@@ -111,6 +113,8 @@ class ImageHandlerTest extends TestCase {
    *   The input passed to expand().
    * @param array<int|string, mixed> $expected
    *   The expected expand() output.
+   *
+   * @dataProvider dataProviderExpandReusesManagedFile
    */
   #[DataProvider('dataProviderExpandReusesManagedFile')]
   public function testExpandReusesManagedFile(string $managed_uri, int $file_id, array $input, array $expected): void {

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/ImageHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/ImageHandlerTest.php
@@ -42,6 +42,42 @@ class ImageHandlerTest extends TestCase {
   }
 
   /**
+   * Tests that records missing 'target_id' throw with a clear message.
+   *
+   * @param array<int|string, mixed> $input
+   *   The malformed input (a record with no 'target_id' or an empty one).
+   *
+   * @dataProvider dataProviderExpandThrowsWhenTargetIdMissing
+   */
+  #[DataProvider('dataProviderExpandThrowsWhenTargetIdMissing')]
+  public function testExpandThrowsWhenTargetIdMissing(array $input): void {
+    $handler = $this->createHandler();
+
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('Image field record must include a non-empty "target_id".');
+
+    $handler->expand($input);
+  }
+
+  /**
+   * Data provider for testExpandThrowsWhenTargetIdMissing().
+   */
+  public static function dataProviderExpandThrowsWhenTargetIdMissing(): \Iterator {
+    yield 'record missing target_id key' => [
+      ['alt' => 'A', 'title' => 'B'],
+    ];
+    yield 'record with NULL target_id' => [
+      ['target_id' => NULL, 'alt' => 'A'],
+    ];
+    yield 'record with empty string target_id' => [
+      ['target_id' => '', 'alt' => 'A'],
+    ];
+    yield 'list with the bad record first' => [
+      [['alt' => 'orphan'], ['target_id' => 'foo.jpg']],
+    ];
+  }
+
+  /**
    * Tests every accepted input shape on the upload code path.
    *
    * The handler delegates shape normalisation to AbstractHandler::normalise(),

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/ImageHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/ImageHandlerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drupal\Tests\Driver\Unit\Core\Field;
 
 use Drupal\Core\DependencyInjection\ContainerBuilder;
-use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Driver\Core\Field\AbstractHandler;
 use Drupal\Driver\Core\Field\ImageHandler;
 use PHPUnit\Framework\TestCase;
@@ -206,17 +205,14 @@ class ImageHandlerTest extends TestCase {
   }
 
   /**
-   * Creates an ImageHandler with a fieldInfo stub for normalise().
+   * Creates an ImageHandler with the main property injected.
    */
   protected function createHandler(): ImageHandler {
-    $field_info = $this->createMock(FieldStorageDefinitionInterface::class);
-    $field_info->method('getMainPropertyName')->willReturn('target_id');
-
     $reflection = new \ReflectionClass(ImageHandler::class);
     $handler = $reflection->newInstanceWithoutConstructor();
 
-    $property = new \ReflectionProperty(AbstractHandler::class, 'fieldInfo');
-    $property->setValue($handler, $field_info);
+    $property = new \ReflectionProperty(AbstractHandler::class, 'mainProperty');
+    $property->setValue($handler, 'target_id');
 
     return $handler;
   }

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/ImageHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/ImageHandlerTest.php
@@ -8,6 +8,7 @@ use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Driver\Core\Field\ImageHandler;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests the ImageHandler field handler.
@@ -39,66 +40,117 @@ class ImageHandlerTest extends TestCase {
   }
 
   /**
-   * Tests that a readable path is expanded into an image field value.
+   * Tests every accepted input shape on the upload code path.
+   *
+   * Covers the three shapes the handler is contracted to accept:
+   *   - Scalar mode from EntityFieldParser ('['foo.jpg']').
+   *   - Legacy flat-positional shape kept for back-compat ('['foo.jpg', 'alt' => ...]').
+   *   - Compound mode from EntityFieldParser row 16
+   *     ('[['target_id' => 'foo.jpg', ...]]') including multi-record input.
+   *
+   * @param \Closure(string): array<int|string, mixed> $build_input
+   *   Builds the input array given the temp file path.
+   * @param array<int|string, mixed> $expected
+   *   The expected expand() output.
+   *
+   * @see \Drupal\DrupalExtension\Parser\EntityFieldParser
    */
-  public function testExpandReturnsImageValueWithDefaultAltAndTitle(): void {
+  #[DataProvider('dataProviderExpandUploadShapes')]
+  public function testExpandUploadsFile(\Closure $build_input, array $expected): void {
     $path = tempnam(sys_get_temp_dir(), 'drupal-driver-') . '.jpg';
     file_put_contents($path, 'fixture');
     $this->setServicesWithUploadReturnId(7);
 
     $handler = $this->createHandler();
 
-    $result = $handler->expand([$path]);
+    $result = $handler->expand($build_input($path));
 
-    $this->assertSame(['target_id' => 7, 'alt' => NULL, 'title' => NULL], $result);
+    $this->assertSame($expected, $result);
   }
 
   /**
-   * Tests that alt and title extras are propagated when provided.
+   * Data provider for testExpandUploadsFile().
    */
-  public function testExpandPropagatesAltAndTitleExtras(): void {
-    $path = tempnam(sys_get_temp_dir(), 'drupal-driver-') . '.jpg';
-    file_put_contents($path, 'fixture');
-    $this->setServicesWithUploadReturnId(12);
-
-    $handler = $this->createHandler();
-
-    $values = [$path, 'alt' => 'Alt text', 'title' => 'Title text'];
-    $result = $handler->expand($values);
-
-    $this->assertSame(['target_id' => 12, 'alt' => 'Alt text', 'title' => 'Title text'], $result);
+  public static function dataProviderExpandUploadShapes(): \Iterator {
+    yield 'scalar single' => [
+      static fn (string $path) => [$path],
+      ['target_id' => 7, 'alt' => NULL, 'title' => NULL],
+    ];
+    yield 'legacy flat positional with extras' => [
+      static fn (string $path) => [$path, 'alt' => 'Alt text', 'title' => 'Title text'],
+      ['target_id' => 7, 'alt' => 'Alt text', 'title' => 'Title text'],
+    ];
+    yield 'compound single, bare target_id' => [
+      static fn (string $path) => [['target_id' => $path]],
+      ['target_id' => 7, 'alt' => NULL, 'title' => NULL],
+    ];
+    yield 'compound single with alt and title' => [
+      static fn (string $path) => [['target_id' => $path, 'alt' => 'An image', 'title' => 'A title']],
+      ['target_id' => 7, 'alt' => 'An image', 'title' => 'A title'],
+    ];
+    yield 'compound multi-record' => [
+      static fn (string $path) => [
+        ['target_id' => $path, 'alt' => 'First'],
+        ['target_id' => $path, 'alt' => 'Second', 'title' => 'Second title'],
+      ],
+      [
+        ['target_id' => 7, 'alt' => 'First', 'title' => NULL],
+        ['target_id' => 7, 'alt' => 'Second', 'title' => 'Second title'],
+      ],
+    ];
   }
 
   /**
-   * Tests that a full URI reuses an existing managed image file.
+   * Tests every accepted input shape on the reuse-existing-managed-file path.
+   *
+   * @param string $managed_uri
+   *   URI of the pre-existing managed File the storage stub will return.
+   * @param int $file_id
+   *   ID of the pre-existing managed File.
+   * @param array<int|string, mixed> $input
+   *   The input passed to expand().
+   * @param array<int|string, mixed> $expected
+   *   The expected expand() output.
    */
-  public function testExpandReusesExistingManagedImageByUri(): void {
-    $this->setServicesWithMatchingManagedFile(
-      uri: 'public://hero.jpg',
-      file_id: 55,
-    );
+  #[DataProvider('dataProviderExpandReuseShapes')]
+  public function testExpandReusesManagedFile(string $managed_uri, int $file_id, array $input, array $expected): void {
+    $this->setServicesWithMatchingManagedFile(uri: $managed_uri, file_id: $file_id);
 
     $handler = $this->createHandler();
 
-    $result = $handler->expand(['public://hero.jpg', 'alt' => 'Hero', 'title' => 'Hero title']);
+    $result = $handler->expand($input);
 
-    $this->assertSame(['target_id' => 55, 'alt' => 'Hero', 'title' => 'Hero title'], $result);
+    $this->assertSame($expected, $result);
   }
 
   /**
-   * Tests that a bare basename reuses an existing managed image file.
+   * Data provider for testExpandReusesManagedFile().
    */
-  public function testExpandReusesExistingManagedImageByBareBasename(): void {
-    $this->setServicesWithMatchingManagedFile(
-      uri: 'public://logo.png',
-      file_id: 66,
-    );
-
-    $handler = $this->createHandler();
-
-    $result = $handler->expand(['logo.png']);
-
-    $this->assertSame(['target_id' => 66, 'alt' => NULL, 'title' => NULL], $result);
+  public static function dataProviderExpandReuseShapes(): \Iterator {
+    yield 'scalar uri reuse' => [
+      'public://hero.jpg',
+      55,
+      ['public://hero.jpg', 'alt' => 'Hero', 'title' => 'Hero title'],
+      ['target_id' => 55, 'alt' => 'Hero', 'title' => 'Hero title'],
+    ];
+    yield 'scalar bare basename reuse' => [
+      'public://logo.png',
+      66,
+      ['logo.png'],
+      ['target_id' => 66, 'alt' => NULL, 'title' => NULL],
+    ];
+    yield 'compound parser shape, uri reuse' => [
+      'public://hero.jpg',
+      77,
+      [['target_id' => 'public://hero.jpg', 'alt' => 'Hero', 'title' => 'Hero title']],
+      ['target_id' => 77, 'alt' => 'Hero', 'title' => 'Hero title'],
+    ];
+    yield 'compound parser shape, bare basename reuse' => [
+      'public://logo.png',
+      88,
+      [['target_id' => 'logo.png']],
+      ['target_id' => 88, 'alt' => NULL, 'title' => NULL],
+    ];
   }
 
   /**
@@ -143,16 +195,16 @@ class ImageHandlerTest extends TestCase {
   /**
    * Creates a stand-in File entity that exposes an id() method.
    */
-  private function createFakeFile(int $file_id): object {
+  protected function createFakeFile(int $file_id): object {
     return new class($file_id) {
 
-      public function __construct(private readonly int $file_id) {}
+      public function __construct(protected readonly int $fileId) {}
 
       /**
        * Returns the stored file entity ID.
        */
       public function id(): int {
-        return $this->file_id;
+        return $this->fileId;
       }
 
       /**
@@ -167,10 +219,10 @@ class ImageHandlerTest extends TestCase {
   /**
    * Creates a stand-in file.repository service returning the given file.
    */
-  private function createFileRepositoryReturning(object $file): object {
+  protected function createFileRepositoryReturning(object $file): object {
     return new class($file) {
 
-      public function __construct(private readonly object $file) {}
+      public function __construct(protected readonly object $file) {}
 
       /**
        * Returns the pre-configured stored file.
@@ -185,7 +237,7 @@ class ImageHandlerTest extends TestCase {
   /**
    * Creates a stand-in entity_type.manager whose file storage never matches.
    */
-  private function createEntityTypeManagerReturningNoMatches(): object {
+  protected function createEntityTypeManagerReturningNoMatches(): object {
     $storage = new class {
 
       /**
@@ -205,7 +257,7 @@ class ImageHandlerTest extends TestCase {
 
     return new class($storage) {
 
-      public function __construct(private readonly object $storage) {}
+      public function __construct(protected readonly object $storage) {}
 
       /**
        * Returns the stub file storage.
@@ -223,10 +275,10 @@ class ImageHandlerTest extends TestCase {
    * The storage's loadByProperties() returns $file only when called with
    * exactly ['uri' => $uri], and an empty array for every other lookup.
    */
-  private function createEntityTypeManagerReturningFileAtUri(string $uri, object $file): object {
+  protected function createEntityTypeManagerReturningFileAtUri(string $uri, object $file): object {
     $storage = new class($uri, $file) {
 
-      public function __construct(private readonly string $uri, private readonly object $file) {}
+      public function __construct(protected readonly string $uri, protected readonly object $file) {}
 
       /**
        * Returns the configured file only for lookups matching the stored URI.
@@ -249,7 +301,7 @@ class ImageHandlerTest extends TestCase {
 
     return new class($storage) {
 
-      public function __construct(private readonly object $storage) {}
+      public function __construct(protected readonly object $storage) {}
 
       /**
        * Returns the stub file storage.

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/ImageHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/ImageHandlerTest.php
@@ -42,38 +42,39 @@ class ImageHandlerTest extends TestCase {
   }
 
   /**
-   * Tests that records missing 'target_id' throw with a clear message.
+   * Tests that records with NULL or empty 'target_id' throw clearly.
+   *
+   * The "key missing entirely" case is caught one layer up by
+   * AbstractHandler::normalise(); this test covers the values that get
+   * past key validation but cannot drive file resolution.
    *
    * @param array<int|string, mixed> $input
-   *   The malformed input (a record with no 'target_id' or an empty one).
+   *   The malformed input.
    *
-   * @dataProvider dataProviderExpandThrowsWhenTargetIdMissing
+   * @dataProvider dataProviderExpandThrowsWhenTargetIdInvalid
    */
-  #[DataProvider('dataProviderExpandThrowsWhenTargetIdMissing')]
-  public function testExpandThrowsWhenTargetIdMissing(array $input): void {
+  #[DataProvider('dataProviderExpandThrowsWhenTargetIdInvalid')]
+  public function testExpandThrowsWhenTargetIdInvalid(array $input): void {
     $handler = $this->createHandler();
 
     $this->expectException(\InvalidArgumentException::class);
-    $this->expectExceptionMessage('Image field record must include a non-empty "target_id".');
+    $this->expectExceptionMessage('Image field "target_id" must not be NULL or empty.');
 
     $handler->expand($input);
   }
 
   /**
-   * Data provider for testExpandThrowsWhenTargetIdMissing().
+   * Data provider for testExpandThrowsWhenTargetIdInvalid().
    */
-  public static function dataProviderExpandThrowsWhenTargetIdMissing(): \Iterator {
-    yield 'record missing target_id key' => [
-      ['alt' => 'A', 'title' => 'B'],
-    ];
+  public static function dataProviderExpandThrowsWhenTargetIdInvalid(): \Iterator {
     yield 'record with NULL target_id' => [
       ['target_id' => NULL, 'alt' => 'A'],
     ];
     yield 'record with empty string target_id' => [
       ['target_id' => '', 'alt' => 'A'],
     ];
-    yield 'list with the bad record first' => [
-      [['alt' => 'orphan'], ['target_id' => 'foo.jpg']],
+    yield 'list with NULL target_id first' => [
+      [['target_id' => NULL, 'alt' => 'orphan'], ['target_id' => 'foo.jpg']],
     ];
   }
 

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/TextHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/TextHandlerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\Driver\Unit\Core\Field;
 
-use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Driver\Core\Field\AbstractHandler;
 use Drupal\Driver\Core\Field\TextHandler;
 use PHPUnit\Framework\TestCase;
@@ -32,17 +31,14 @@ class TextHandlerTest extends TestCase {
   }
 
   /**
-   * Creates a TextHandler with a fieldInfo stub for normalise().
+   * Creates a TextHandler with the main property injected.
    */
   protected function createHandler(): TextHandler {
-    $field_info = $this->createMock(FieldStorageDefinitionInterface::class);
-    $field_info->method('getMainPropertyName')->willReturn('value');
-
     $reflection = new \ReflectionClass(TextHandler::class);
     $handler = $reflection->newInstanceWithoutConstructor();
 
-    $property = new \ReflectionProperty(AbstractHandler::class, 'fieldInfo');
-    $property->setValue($handler, $field_info);
+    $property = new \ReflectionProperty(AbstractHandler::class, 'mainProperty');
+    $property->setValue($handler, 'value');
 
     return $handler;
   }

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/TextHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/TextHandlerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\Driver\Unit\Core\Field;
 
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Driver\Core\Field\AbstractHandler;
 use Drupal\Driver\Core\Field\TextHandler;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Group;
@@ -17,16 +19,32 @@ use PHPUnit\Framework\Attributes\Group;
 class TextHandlerTest extends TestCase {
 
   /**
-   * Tests that expand() returns the input unchanged.
+   * Tests that expand() returns a canonical list of records.
    */
-  public function testExpandReturnsValuesUnchanged(): void {
-    $handler = new TextHandler();
+  public function testExpandReturnsCanonicalRecordList(): void {
+    $handler = $this->createHandler();
 
     $values = [
       ['value' => 'Inline text.', 'format' => 'plain_text'],
     ];
 
     $this->assertSame($values, $handler->expand($values));
+  }
+
+  /**
+   * Creates a TextHandler with a fieldInfo stub for normalise().
+   */
+  protected function createHandler(): TextHandler {
+    $field_info = $this->createMock(FieldStorageDefinitionInterface::class);
+    $field_info->method('getMainPropertyName')->willReturn('value');
+
+    $reflection = new \ReflectionClass(TextHandler::class);
+    $handler = $reflection->newInstanceWithoutConstructor();
+
+    $property = new \ReflectionProperty(AbstractHandler::class, 'fieldInfo');
+    $property->setValue($handler, $field_info);
+
+    return $handler;
   }
 
 }

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/TextLongHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/TextLongHandlerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\Driver\Unit\Core\Field;
 
-use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Driver\Core\Field\AbstractHandler;
 use Drupal\Driver\Core\Field\TextLongHandler;
 use PHPUnit\Framework\TestCase;
@@ -32,17 +31,14 @@ class TextLongHandlerTest extends TestCase {
   }
 
   /**
-   * Creates a TextLongHandler with a fieldInfo stub for normalise().
+   * Creates a TextLongHandler with the main property injected.
    */
   protected function createHandler(): TextLongHandler {
-    $field_info = $this->createMock(FieldStorageDefinitionInterface::class);
-    $field_info->method('getMainPropertyName')->willReturn('value');
-
     $reflection = new \ReflectionClass(TextLongHandler::class);
     $handler = $reflection->newInstanceWithoutConstructor();
 
-    $property = new \ReflectionProperty(AbstractHandler::class, 'fieldInfo');
-    $property->setValue($handler, $field_info);
+    $property = new \ReflectionProperty(AbstractHandler::class, 'mainProperty');
+    $property->setValue($handler, 'value');
 
     return $handler;
   }

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/TextLongHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/TextLongHandlerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\Driver\Unit\Core\Field;
 
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Driver\Core\Field\AbstractHandler;
 use Drupal\Driver\Core\Field\TextLongHandler;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Group;
@@ -17,16 +19,32 @@ use PHPUnit\Framework\Attributes\Group;
 class TextLongHandlerTest extends TestCase {
 
   /**
-   * Tests that expand() returns the input unchanged.
+   * Tests that expand() returns a canonical list of records.
    */
-  public function testExpandReturnsValuesUnchanged(): void {
-    $handler = new TextLongHandler();
+  public function testExpandReturnsCanonicalRecordList(): void {
+    $handler = $this->createHandler();
 
     $values = [
       ['value' => 'Body copy.', 'format' => 'plain_text'],
     ];
 
     $this->assertSame($values, $handler->expand($values));
+  }
+
+  /**
+   * Creates a TextLongHandler with a fieldInfo stub for normalise().
+   */
+  protected function createHandler(): TextLongHandler {
+    $field_info = $this->createMock(FieldStorageDefinitionInterface::class);
+    $field_info->method('getMainPropertyName')->willReturn('value');
+
+    $reflection = new \ReflectionClass(TextLongHandler::class);
+    $handler = $reflection->newInstanceWithoutConstructor();
+
+    $property = new \ReflectionProperty(AbstractHandler::class, 'fieldInfo');
+    $property->setValue($handler, $field_info);
+
+    return $handler;
   }
 
 }

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/TextWithSummaryHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/TextWithSummaryHandlerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\Driver\Unit\Core\Field;
 
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Driver\Core\Field\AbstractHandler;
 use Drupal\Driver\Core\Field\TextWithSummaryHandler;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Group;
@@ -17,16 +19,32 @@ use PHPUnit\Framework\Attributes\Group;
 class TextWithSummaryHandlerTest extends TestCase {
 
   /**
-   * Tests that expand() returns the input unchanged.
+   * Tests that expand() returns a canonical list of records.
    */
-  public function testExpandReturnsValuesUnchanged(): void {
-    $handler = new TextWithSummaryHandler();
+  public function testExpandReturnsCanonicalRecordList(): void {
+    $handler = $this->createHandler();
 
     $values = [
       ['value' => 'body text', 'summary' => 'short'],
     ];
 
     $this->assertSame($values, $handler->expand($values));
+  }
+
+  /**
+   * Creates a TextWithSummaryHandler with a fieldInfo stub for normalise().
+   */
+  protected function createHandler(): TextWithSummaryHandler {
+    $field_info = $this->createMock(FieldStorageDefinitionInterface::class);
+    $field_info->method('getMainPropertyName')->willReturn('value');
+
+    $reflection = new \ReflectionClass(TextWithSummaryHandler::class);
+    $handler = $reflection->newInstanceWithoutConstructor();
+
+    $property = new \ReflectionProperty(AbstractHandler::class, 'fieldInfo');
+    $property->setValue($handler, $field_info);
+
+    return $handler;
   }
 
 }

--- a/tests/Drupal/Tests/Driver/Unit/Core/Field/TextWithSummaryHandlerTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/Core/Field/TextWithSummaryHandlerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\Driver\Unit\Core\Field;
 
-use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Driver\Core\Field\AbstractHandler;
 use Drupal\Driver\Core\Field\TextWithSummaryHandler;
 use PHPUnit\Framework\TestCase;
@@ -32,17 +31,14 @@ class TextWithSummaryHandlerTest extends TestCase {
   }
 
   /**
-   * Creates a TextWithSummaryHandler with a fieldInfo stub for normalise().
+   * Creates a TextWithSummaryHandler with the main property injected.
    */
   protected function createHandler(): TextWithSummaryHandler {
-    $field_info = $this->createMock(FieldStorageDefinitionInterface::class);
-    $field_info->method('getMainPropertyName')->willReturn('value');
-
     $reflection = new \ReflectionClass(TextWithSummaryHandler::class);
     $handler = $reflection->newInstanceWithoutConstructor();
 
-    $property = new \ReflectionProperty(AbstractHandler::class, 'fieldInfo');
-    $property->setValue($handler, $field_info);
+    $property = new \ReflectionProperty(AbstractHandler::class, 'mainProperty');
+    $property->setValue($handler, 'value');
 
     return $handler;
   }


### PR DESCRIPTION
## Summary

Field handlers gain a shared `normalise()` helper on `AbstractHandler` that converts any loose input shape a caller naturally produces — a bare scalar, a list of scalars, a single keyed record, a list of records, or a mixed list of scalars and records — into a canonical list of records. Callers never need to know whether a field is single- or multi-column, never need to type column names like `target_id` or `value` for the simple case, and the handler always returns a uniform list of records that Drupal entity storage accepts. `ImageHandler::expand()` and `DatetimeHandler::expand()` now use `normalise()` instead of in-line shape sniffing; the three text handlers (`TextHandler`, `TextLongHandler`, `TextWithSummaryHandler`) were migrated from `implements FieldHandlerInterface` to `extends AbstractHandler` so they get the same helper.

The original bug — `ImageHandler::expand()` reading `$values[0]` as a string when the parser handed it `[['target_id' => 'foo.jpg', ...]]` and triggering `TypeError` — is fixed as a consequence. The branch also fixes the `DrupalExtension smoke` workflow that kept breaking whenever `drupalextension` bumped its `minimum-stability` floor.

Consumers (drupal-extension's `EntityFieldParser`, `DrushDriver`, etc.) can now pass whatever they have without inspecting the field's column structure first. That work happens in the consumer packages.

## Changes

- **`src/Drupal/Driver/Core/Field/AbstractHandler.php`** — added `protected function normalise(mixed $values): array`. Discovers the main property via `$this->fieldInfo->getMainPropertyName()`. Accepts five shapes (bare scalar, list of scalars, single record, list of records, mixed list); throws `InvalidArgumentException` for the ambiguous "positional plus named keys at the top level" shape (e.g. `['/path', 'alt' => 'A']`) rather than silently picking an interpretation. Subclasses override `normalise()` only when they have custom shorthand (e.g. a future `NameHandler` "Family, Given" string).

- **`src/Drupal/Driver/Core/Field/ImageHandler.php`** — `expand()` now calls `$this->normalise($values)` and iterates the canonical records. Always returns a list of records (no flat-single-record return, no shape sniffing).

- **`src/Drupal/Driver/Core/Field/DatetimeHandler.php`** — `expand()` now calls `$this->normalise($values)` and iterates the canonical records. Returns a list of `['value' => …]` records with each value formatted for storage.

- **`src/Drupal/Driver/Core/Field/TextHandler.php`**, **`TextLongHandler.php`**, **`TextWithSummaryHandler.php`** — migrated from `implements FieldHandlerInterface` to `extends AbstractHandler`. `expand()` delegates to `normalise()`. Production wiring is unchanged (`Core::getFieldHandler()` already passes the stub/entity_type/field_name constructor args); test setup updated to follow the `newInstanceWithoutConstructor()` + reflection-injected `fieldInfo` pattern.

- **`tests/Drupal/Tests/Driver/Unit/Core/Field/AbstractHandlerNormaliseTest.php`** — new. Single test method `testNormalise` driven by a 16-row data provider. 12 happy-path rows cover every accepted shape against multiple main-property names (`target_id`, `value`, `uri`); 4 throw rows cover the ambiguous-key cases (numeric-0 + named extras, gappy numeric + named, ordering variants). Each row carries `(input, main_property, expected_output, expected_exception_class, expected_exception_message_fragment)` — the test branches on whether an exception class was supplied. A test-local final subclass `NormaliseTestHandler` exists in the same file solely to provide the abstract surface so reflection can invoke the inherited `normalise()`.

- **`tests/Drupal/Tests/Driver/Unit/Core/Field/ImageHandlerTest.php`** — refactored. Two data-provider tests (`testExpandUploadsFile`, `testExpandReusesManagedFile`) now cover every loose shape a caller can naturally pass: bare scalar path, list of paths, single record, list of records, multi-record, plus the same shape variations for the reuse-managed-file path. `createHandler()` injects a `fieldInfo` stub returning `'target_id'`.

- **`tests/Drupal/Tests/Driver/Unit/Core/Field/DatetimeHandlerTest.php`** — `testExpandPreservesEmptyValuesAsNull` is now data-driven (5 shape variants); `createHandler()` stubs both `getSetting('datetime_type')` and `getMainPropertyName()`.

- **`tests/Drupal/Tests/Driver/Unit/Core/Field/TextHandlerTest.php`**, **`TextLongHandlerTest.php`**, **`TextWithSummaryHandlerTest.php`** — updated to construct the handler via `newInstanceWithoutConstructor()` + reflection-injected `fieldInfo`, matching the pattern used by other handler tests.

- **Kernel tests** (`ImageHandlerKernelTest.php`, `ImageHandlerReuseKernelTest.php`, `DatetimeHandlerKernelTest.php`) — inputs use the canonical record shape, which the new `normalise()` returns unchanged.

- **`.github/workflows/ci.yml`** — `DrupalExtension smoke` job: the path repo for `drupal/drupal-driver` is now declared at version `3.0.99` (stable) instead of `3.0.99-alpha`. The previous alpha-suffixed declaration broke every time `drupalextension` bumped its `minimum-stability` floor (alpha → beta → RC). Declaring stable satisfies any floor up to and including stable, decoupling this workflow from the consumer's stability progression.

## Before / After

```
Caller decoupling — ImageHandler

Before (caller must know 'target_id' even for the trivial case):
  $stub->setValue('field_image', [['target_id' => '/path/foo.jpg']]);

After (caller passes whatever's natural; normalise() handles the rest):
  $stub->setValue('field_image', '/path/foo.jpg');                     // bare path
  $stub->setValue('field_image', ['/path/a.jpg', '/path/b.jpg']);      // list of paths
  $stub->setValue('field_image', ['target_id' => '/path/foo.jpg',      // single record
                                  'alt' => 'A', 'title' => 'B']);
  $stub->setValue('field_image', [['target_id' => '/path/foo.jpg',     // list of records
                                   'alt' => 'A']]);
  // All four call sites end up at the same canonical
  //   [['target_id' => N, 'alt' => …, 'title' => …]]
  // inside ImageHandler::expand() and produce the same stored entity.
```

```
ImageHandler::expand() shape pipeline

Before (sniff $values[0], collapse single-record return to flat assoc):
  expand($mixed_input)
    if (is_array($values[0])) treat $values as records
    else                      wrap $values as one record
    foreach each record       resolve target_id
    return count($expanded) === 1 ? $expanded[0] : $expanded
                                  ^ dual return shape

After (canonical pipeline, single return shape):
  expand($mixed_input)
    $records = $this->normalise($values)              // AbstractHandler helper
    foreach each $record                              // always a list
      resolve target_id, default alt/title to NULL
    return list of records                            // always a list
```

```
DrupalExtension smoke workflow — stability coupling

Before (recurring failure pattern):
  drupalextension main composer.json:  "minimum-stability": "RC"
  ci.yml declares path repo:           "drupal/drupal-driver": "3.0.99-alpha"
                                       (alpha < RC -> Composer refuses install)

  Every time drupalextension bumps its stability floor, ci.yml has to follow:
    alpha -> beta -> RC -> stable

After:
  ci.yml declares path repo:           "drupal/drupal-driver": "3.0.99"
                                       (stable -> satisfies any floor up to stable)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Standardized input normalization across field handlers (text, image, datetime) to consistently process various input shapes and formats.
  * Enhanced handling of empty values and mixed input formats in field handlers.

* **Tests**
  * Expanded test coverage for field handler input normalization and edge cases.

* **Chores**
  * Updated CI workflow for stable version mappings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhedstrom/DrupalDriver/pull/370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->