### PR TITLE
Fixed documentation inaccuracies surfaced during v3.0.0 release review.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,9 +62,6 @@ This repository tests the drivers and field handlers:
   bootstrap a real Drupal kernel against SQLite and exercise the
   Core driver and field handlers end-to-end.
 
-- **PhpSpec specs** (legacy) cover the base driver and exception
-  classes.
-
 ## Setting up the local environment
 
 Testing is performed automatically in GitHub Actions when a PR is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,12 +3,6 @@
 Features and bug fixes are welcome! First-time contributors can
 jump in with the issues tagged [good first issue](https://github.com/jhedstrom/DrupalDriver/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
-> **Note:** We are actively working on version 3.x which will
-> overhaul the test infrastructure, drop Drupal 6/7 support, and
-> introduce SQLite-based kernel tests. See the
-> [3.x epic](https://github.com/jhedstrom/DrupalDriver/issues/312)
-> for details.
-
 ## How this project works
 
 Drupal Driver is a PHP library that provides a common interface
@@ -57,19 +51,19 @@ Handlers that perform real transformation include:
 
 ### What are we testing?
 
-This repository tests the drivers and field handlers. The current
-test suite includes:
+This repository tests the drivers and field handlers:
 
-- **PHPUnit tests** for field handlers that can be tested without
-  a Drupal bootstrap (TimeHandler, LinkHandler, NameHandler) and
-  for driver logic (DrushDriver version detection, user ID
-  parsing).
+- **PHPUnit unit tests** (`tests/Drupal/Tests/Driver/Unit/`) cover
+  field handlers and driver logic that does not require a Drupal
+  bootstrap (TimeHandler, LinkHandler, NameHandler, DrushDriver
+  version detection, etc.).
 
-- **PhpSpec specs** (legacy) for core driver and exception classes.
+- **PHPUnit kernel tests** (`tests/Drupal/Tests/Driver/Kernel/`)
+  bootstrap a real Drupal kernel against SQLite and exercise the
+  Core driver and field handlers end-to-end.
 
-The test suite does **not** currently test handlers against a real
-Drupal installation. Integration testing with SQLite-based kernel
-tests is planned for v3.x.
+- **PhpSpec specs** (legacy) cover the base driver and exception
+  classes.
 
 ## Setting up the local environment
 
@@ -85,16 +79,17 @@ composer test
 Run a specific test:
 
 ```shell
-XDEBUG_MODE=off vendor/bin/phpunit --filter TimeHandlerTest
+vendor/bin/phpunit --filter TimeHandlerTest
 ```
 
 ### Commands
 
 | Command | Description |
 | --- | --- |
-| `composer lint` | PHP syntax check, PHPCS coding standards, Rector dry-run |
-| `composer lint-fix` | Auto-fix: Rector + PHPCBF |
-| `composer test` | PHPUnit + PhpSpec |
+| `composer lint` | parallel-lint, PHPCS, PHPStan, Rector dry-run |
+| `composer lint-fix` | Rector, PHPCBF |
+| `composer test` | PHPUnit (unit + kernel) |
+| `composer test-coverage` | PHPUnit with code coverage |
 
 ## Before submitting a change
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,11 @@ A collection of lightweight drivers with a common interface for
 interacting with [Drupal](https://www.drupal.org). These are generally
 intended for testing and are not meant to be API-complete.
 
-> **Note:** This `master` branch is under heavy development for
-> version 3.x. Drupal 6 and 7 support has been dropped. For the
-> 2.x maintenance line, use the
+> **Note:** v3 supports Drupal 10 and 11 on PHP 8.2+. Sites that
+> need Drupal 7 or PHP 8.1 should pin to the
 > [`2.x` branch](https://github.com/jhedstrom/DrupalDriver/tree/2.x).
-> See the
-> [3.x epic](https://github.com/jhedstrom/DrupalDriver/issues/312)
-> for details and progress.
+> See [UPGRADING.md](UPGRADING.md) for the v2 to v3 migration
+> guide.
 
 ## Drivers
 
@@ -43,6 +41,7 @@ composer require drupal/drupal-driver
 
 ```php
 use Drupal\Driver\DrupalDriver;
+use Drupal\Driver\Entity\EntityStub;
 
 require 'vendor/autoload.php';
 
@@ -56,12 +55,12 @@ $driver->setCoreFromVersion();
 $driver->bootstrap();
 
 // Create a node.
-$node = (object) [
-  'type' => 'article',
+$node = new EntityStub('node', 'article', [
   'uid' => 1,
   'title' => $driver->getRandom()->name(),
-];
-$driver->nodeCreate($node);
+]);
+$saved = $driver->nodeCreate($node);
+$nid = $saved->getId();
 ```
 
 ## Extending

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -86,11 +86,9 @@ old two-predicate API was insufficient to distinguish F1-F9 correctly and
 caused downstream bugs (notably with computed writable base fields like
 `moderation_state`).
 
-The accessor on `CoreInterface` is `getFieldClassifier()`. An earlier 3.x
-prerelease named it `classifier()`; that name was renamed before
-3.0.0-alpha1 for consistency with the other `getX()` accessors
-(`getRandom()`, `getModuleList()`, `getFieldHandler()`,
-`getEntityFieldTypes()`).
+The accessor on `CoreInterface` is `getFieldClassifier()`, matching
+the other `getX()` accessors (`getRandom()`, `getModuleList()`,
+`getFieldHandler()`, `getEntityFieldTypes()`).
 
 ### Field-expansion pipeline signature changes
 


### PR DESCRIPTION
## Summary

Documentation inaccuracies surfaced during the v3.0.0 release review are fixed across README.md, CONTRIBUTING.md, and UPGRADING.md. All changes are documentation only - no PHP was modified. The fixes bring the docs into alignment with what actually ships in v3: the `EntityStub` API, the kernel test suite, the real `composer test` script, stable accessor names, and the actual mix of test frameworks in use.

## Changes

### README.md

**Banner note** - removed "under heavy development for version 3.x" wording and the link to the now-closed #312 epic. Replaced with a concise statement of what v3 supports (Drupal 10/11, PHP 8.2+) and a pointer to the 2.x branch for users who need it.

**Quickstart example** - the example used the v2 `(object) [...]` cast which throws `TypeError` against v3's typed `nodeCreate(EntityStubInterface $stub)` signature. Updated to use `new EntityStub('node', 'article', [...])` with the required `use` statement, and demonstrated capturing the return value.

### CONTRIBUTING.md

**"Actively working on 3.x" announcement block** - removed. v3 work is complete.

**"What are we testing?" section** - the section previously told contributors there were no Drupal-installation tests yet, and that kernel tests were planned for v3.x. The kernel test suite (`tests/Drupal/Tests/Driver/Kernel/`) ships in v3 with 14 test files. Rewrote the section to describe both unit and kernel test suites accurately, and dropped a stale "PhpSpec specs (legacy)" bullet - the `spec/` directory does not exist in v3. The `phpspec/prophecy-phpunit` Composer dep remains, but only as a transitive runtime requirement of Drupal core's `KernelTestBase`; it is not a PhpSpec BDD framework reference.

**Commands table** - `composer test` was listed as "PHPUnit + PhpSpec" but the actual `test` script in `composer.json` is PHPUnit only. Updated the table to match `composer.json` exactly and added `composer test-coverage`. Also dropped the `XDEBUG_MODE=off` prefix from the inline phpunit example.

### UPGRADING.md

**Historical prerelease note** - an intra-v3 note explained that `classifier()` was renamed to `getFieldClassifier()` before 3.0.0-alpha1. Per project convention, docs describe what IS, not what WAS. Replaced the paragraph with a single sentence stating the current accessor name and how it fits the existing naming pattern.

## Before / After

### README.md quickstart

Before:
```php
use Drupal\Driver\DrupalDriver;

// Create a node.
$node = (object) [
  'type' => 'article',
  'uid' => 1,
  'title' => $driver->getRandom()->name(),
];
$driver->nodeCreate($node);
```

After:
```php
use Drupal\Driver\DrupalDriver;
use Drupal\Driver\Entity\EntityStub;

// Create a node.
$node = new EntityStub('node', 'article', [
  'uid' => 1,
  'title' => $driver->getRandom()->name(),
]);
$saved = $driver->nodeCreate($node);
$nid = $saved->getId();
```

### README.md banner

Before:
> **Note:** This `master` branch is under heavy development for version 3.x. Drupal 6 and 7 support has been dropped. For the 2.x maintenance line, use the [`2.x` branch](https://github.com/jhedstrom/DrupalDriver/tree/2.x). See the [3.x epic](https://github.com/jhedstrom/DrupalDriver/issues/312) for details and progress.

After:
> **Note:** v3 supports Drupal 10 and 11 on PHP 8.2+. Sites that need Drupal 7 or PHP 8.1 should pin to the [`2.x` branch](https://github.com/jhedstrom/DrupalDriver/tree/2.x). See [UPGRADING.md](UPGRADING.md) for the v2 to v3 migration guide.
