### PR TITLE
[#376] Added 'drushResult()' non-throwing executor returning a 'DrushResult'.

### DIFF
--- a/src/Drupal/Driver/Drush/DrushResult.php
+++ b/src/Drupal/Driver/Drush/DrushResult.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Driver\Drush;
+
+/**
+ * Immutable result of a Drush command execution.
+ *
+ * Pairs the process exit code with its captured standard output and standard
+ * error, mirroring the values a finished Symfony 'Process' exposes through
+ * 'getExitCode()', 'getOutput()', and 'getErrorOutput()'.
+ */
+final readonly class DrushResult {
+
+  /**
+   * Constructs a DrushResult.
+   *
+   * @param int $exitCode
+   *   The command exit code. Zero indicates success; a signalled process is
+   *   reported as a non-zero failure.
+   * @param string $output
+   *   The command's captured standard output.
+   * @param string $errorOutput
+   *   The command's captured standard error output.
+   */
+  public function __construct(
+    public int $exitCode,
+    public string $output,
+    public string $errorOutput,
+  ) {
+  }
+
+}

--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -6,6 +6,7 @@ namespace Drupal\Driver;
 
 use Drupal\Component\Utility\Random;
 use Drupal\Driver\Capability\CreationAliasCapabilityInterface;
+use Drupal\Driver\Drush\DrushResult;
 use Drupal\Driver\Entity\EntityStubInterface;
 use Drupal\Driver\Exception\BootstrapException;
 use Drupal\Driver\Alias\CreationAliasRegistryTrait;
@@ -340,7 +341,7 @@ class DrushDriver implements DrushDriverInterface, CreationAliasCapabilityInterf
   }
 
   /**
-   * Execute a drush command.
+   * Execute a drush command, returning its result without throwing on failure.
    *
    * @param string $command
    *   The Drush command to execute.
@@ -348,8 +349,11 @@ class DrushDriver implements DrushDriverInterface, CreationAliasCapabilityInterf
    *   Positional arguments to pass to Drush.
    * @param array<string, string|bool|null> $options
    *   Options to pass to Drush.
+   *
+   * @return \Drupal\Driver\Drush\DrushResult
+   *   The exit code together with the captured stdout and stderr.
    */
-  public function drush(string $command, array $arguments = [], array $options = []): string {
+  public function drushResult(string $command, array $arguments = [], array $options = []): DrushResult {
     $argument_string = implode(' ', $arguments);
 
     if (isset(static::$isLegacyDrush) && static::$isLegacyDrush) {
@@ -364,20 +368,42 @@ class DrushDriver implements DrushDriverInterface, CreationAliasCapabilityInterf
     $global = $this->getArguments();
 
     $cmd = sprintf('%s %s %s %s %s %s', $this->binary, $alias, $option_string, $global, $command, $argument_string);
-    $process = method_exists(Process::class, 'fromShellCommandline') ? Process::fromShellCommandline($cmd) : new Process($cmd);
-    $process->setTimeout(3600);
-    $process->run();
+    $process = $this->runProcess($cmd);
 
-    if (!$process->isSuccessful()) {
-      throw new \RuntimeException($process->getErrorOutput());
+    // A signalled process yields a NULL exit code; classify that as a failure
+    // rather than letting it read as success.
+    return new DrushResult($process->getExitCode() ?? 1, $process->getOutput(), $process->getErrorOutput());
+  }
+
+  /**
+   * Execute a drush command.
+   *
+   * @param string $command
+   *   The Drush command to execute.
+   * @param array<int, string> $arguments
+   *   Positional arguments to pass to Drush.
+   * @param array<string, string|bool|null> $options
+   *   Options to pass to Drush.
+   *
+   * @return string
+   *   The command's stdout, or its stderr when stdout is empty.
+   *
+   * @throws \RuntimeException
+   *   When the command exits with a non-zero status.
+   */
+  public function drush(string $command, array $arguments = [], array $options = []): string {
+    $result = $this->drushResult($command, $arguments, $options);
+
+    if ($result->exitCode !== 0) {
+      throw new \RuntimeException($result->errorOutput);
     }
 
     // Some Drush commands write to stderr instead of stdout.
-    if ($process->getOutput() === '' || $process->getOutput() === '0') {
-      return $process->getErrorOutput();
+    if ($result->output === '' || $result->output === '0') {
+      return $result->errorOutput;
     }
 
-    return $process->getOutput();
+    return $result->output;
   }
 
   /**
@@ -393,6 +419,23 @@ class DrushDriver implements DrushDriverInterface, CreationAliasCapabilityInterf
    */
   public function __call(string $name, array $arguments): string {
     return $this->drush($name, $arguments);
+  }
+
+  /**
+   * Builds, runs, and returns a process for the given shell command line.
+   *
+   * @param string $cmd
+   *   The full shell command line to execute.
+   *
+   * @return \Symfony\Component\Process\Process
+   *   The process after it has finished running.
+   */
+  protected function runProcess(string $cmd): Process {
+    $process = method_exists(Process::class, 'fromShellCommandline') ? Process::fromShellCommandline($cmd) : new Process($cmd);
+    $process->setTimeout(3600);
+    $process->run();
+
+    return $process;
   }
 
   /**

--- a/tests/Drupal/Tests/Driver/Unit/DrushDriverResultTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/DrushDriverResultTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\Driver\Unit;
+
+use Drupal\Driver\Drush\DrushResult;
+use Drupal\Driver\DrushDriver;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+/**
+ * Tests the non-throwing 'drushResult()' executor and the 'DrushResult' VO.
+ *
+ * @group drivers
+ * @group drush
+ */
+#[Group('drivers')]
+#[Group('drush')]
+class DrushDriverResultTest extends TestCase {
+
+  /**
+   * Tests that 'DrushResult' exposes the values it was constructed with.
+   *
+   * @param int $exit_code
+   *   The exit code to construct with.
+   * @param string $output
+   *   The standard output to construct with.
+   * @param string $error_output
+   *   The standard error output to construct with.
+   *
+   * @dataProvider dataProviderDrushResultExposesValues
+   */
+  #[DataProvider('dataProviderDrushResultExposesValues')]
+  public function testDrushResultExposesValues(int $exit_code, string $output, string $error_output): void {
+    $result = new DrushResult($exit_code, $output, $error_output);
+
+    $this->assertSame($exit_code, $result->exitCode);
+    $this->assertSame($output, $result->output);
+    $this->assertSame($error_output, $result->errorOutput);
+  }
+
+  /**
+   * Data provider for 'testDrushResultExposesValues()'.
+   */
+  public static function dataProviderDrushResultExposesValues(): \Iterator {
+    yield 'success with stdout' => [0, 'the output', ''];
+    yield 'failure with stderr' => [1, '', 'boom'];
+    yield 'both streams populated' => [3, 'partial', 'warning'];
+  }
+
+  /**
+   * Tests that 'drushResult()' maps a finished process onto a 'DrushResult'.
+   *
+   * @param int|null $exit_code
+   *   The exit code reported by the process (NULL when signalled).
+   * @param string $output
+   *   The process standard output.
+   * @param string $error_output
+   *   The process standard error output.
+   * @param int $expected_exit_code
+   *   The exit code expected on the resulting 'DrushResult'.
+   *
+   * @dataProvider dataProviderDrushResultMapsProcess
+   */
+  #[DataProvider('dataProviderDrushResultMapsProcess')]
+  public function testDrushResultMapsProcess(?int $exit_code, string $output, string $error_output, int $expected_exit_code): void {
+    $driver = new ProcessStubDrushDriver('alias');
+    $driver->stubProcess = $this->mockProcess($exit_code, $output, $error_output);
+
+    $result = $driver->drushResult('version', [], ['format' => 'json']);
+
+    $this->assertInstanceOf(DrushResult::class, $result);
+    $this->assertSame($expected_exit_code, $result->exitCode);
+    $this->assertSame($output, $result->output);
+    $this->assertSame($error_output, $result->errorOutput);
+  }
+
+  /**
+   * Data provider for 'testDrushResultMapsProcess()'.
+   */
+  public static function dataProviderDrushResultMapsProcess(): \Iterator {
+    yield 'success' => [0, 'stdout text', '', 0];
+    yield 'failure with stderr' => [2, '', 'stderr text', 2];
+    yield 'signalled process maps null exit to one' => [NULL, '', '', 1];
+  }
+
+  /**
+   * Tests that 'drush()' throws and carries stderr when the command fails.
+   */
+  public function testDrushThrowsWithErrorOutputOnFailure(): void {
+    $driver = new ProcessStubDrushDriver('alias');
+    $driver->stubProcess = $this->mockProcess(2, '', 'the failure reason');
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('the failure reason');
+
+    $driver->drush('cron');
+  }
+
+  /**
+   * Tests that 'drush()' returns stdout, or stderr when stdout is empty/'0'.
+   *
+   * @param string $output
+   *   The process standard output.
+   * @param string $error_output
+   *   The process standard error output.
+   * @param string $expected
+   *   The value 'drush()' is expected to return.
+   *
+   * @dataProvider dataProviderDrushStdoutElseStderrFallback
+   */
+  #[DataProvider('dataProviderDrushStdoutElseStderrFallback')]
+  public function testDrushStdoutElseStderrFallback(string $output, string $error_output, string $expected): void {
+    $driver = new ProcessStubDrushDriver('alias');
+    $driver->stubProcess = $this->mockProcess(0, $output, $error_output);
+
+    $this->assertSame($expected, $driver->drush('status'));
+  }
+
+  /**
+   * Data provider for 'testDrushStdoutElseStderrFallback()'.
+   */
+  public static function dataProviderDrushStdoutElseStderrFallback(): \Iterator {
+    yield 'stdout present' => ['hello', 'ignored stderr', 'hello'];
+    yield 'empty stdout falls back to stderr' => ['', 'stderr fallback', 'stderr fallback'];
+    yield 'zero-string stdout falls back to stderr' => ['0', 'stderr fallback', 'stderr fallback'];
+  }
+
+  /**
+   * Builds a finished-process double with stubbed exit code and output.
+   *
+   * @param int|null $exit_code
+   *   The exit code the process reports.
+   * @param string $output
+   *   The standard output the process reports.
+   * @param string $error_output
+   *   The standard error output the process reports.
+   *
+   * @return \Symfony\Component\Process\Process
+   *   The stubbed process.
+   */
+  protected function mockProcess(?int $exit_code, string $output, string $error_output): Process {
+    $process = $this->createMock(Process::class);
+    $process->method('getExitCode')->willReturn($exit_code);
+    $process->method('getOutput')->willReturn($output);
+    $process->method('getErrorOutput')->willReturn($error_output);
+
+    return $process;
+  }
+
+}
+
+/**
+ * Subclass of 'DrushDriver' that returns a stubbed process from 'runProcess()'.
+ *
+ * Lets the tests drive 'drushResult()' and 'drush()' deterministically without
+ * spawning a real Drush binary.
+ */
+class ProcessStubDrushDriver extends DrushDriver {
+
+  /**
+   * The process returned in place of a real execution.
+   */
+  public ?Process $stubProcess = NULL;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function runProcess(string $cmd): Process {
+    if (!$this->stubProcess instanceof Process) {
+      throw new \LogicException('A stub process must be set before the driver runs a command.');
+    }
+
+    return $this->stubProcess;
+  }
+
+}


### PR DESCRIPTION
Closes #376

## Summary

Adds a `drushResult()` executor to `DrushDriver` that runs a Drush command and returns an immutable `DrushResult` value object (exit code, stdout, stderr) instead of throwing on failure. The existing `drush()` method is refactored to delegate to `drushResult()` while preserving its exact contract: it still throws `\RuntimeException` on a non-zero exit and still returns stderr as a fallback when stdout is empty or `"0"`. A `protected runProcess()` seam was extracted around the Symfony `Process` construction and execution to make the class deterministically testable without spawning a real Drush binary.

## Changes

**`src/Drupal/Driver/Drush/DrushResult.php`** - New immutable `final readonly` value object carrying `exitCode`, `output`, and `errorOutput`. Mirrors the three `Process` accessors it wraps.

**`src/Drupal/Driver/DrushDriver.php`**
- New `drushResult()` public method: builds the command string, delegates to `runProcess()`, guards a signalled-process `null` exit code by mapping it to `1`, and returns a `DrushResult`.
- `drush()` refactored to call `drushResult()` and apply the existing throw-on-failure and stdout-else-stderr fallback logic on top of the returned VO.
- New `protected runProcess(string $cmd): Process` seam: constructs the `Process` (legacy-`fromShellCommandline` branch preserved), sets the 3600 s timeout, runs it, and returns it.

**`tests/Drupal/Tests/Driver/Unit/DrushDriverResultTest.php`** - New unit test class covering: `DrushResult` property round-trip (data-provider), `drushResult()` process-to-VO mapping including the null-exit guard (data-provider), `drush()` throw-with-stderr-on-failure, and `drush()` stdout-else-stderr fallback (data-provider). Uses a `ProcessStubDrushDriver` subclass that overrides `runProcess()` to return a `Process` mock.

## Notes

The pre-existing empty `RuntimeException` message when a failing command emits no stderr is intentionally left unchanged to keep `drush()` fully backward compatible; it can be improved in a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new structured object-based approach for retrieving Drush command execution results, enabling more flexible and reliable result handling.

* **Refactor**
  * Enhanced Drush driver's command execution architecture to improve maintainability and provide better control over process handling.

* **Tests**
  * Added comprehensive test coverage for Drush command execution, result retrieval, and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->