### PR TITLE
[#379] Added optional 'attachments' parameter to 'MailCapabilityInterface::mailSend()'.

### DIFF
--- a/src/Drupal/Driver/Capability/MailCapabilityInterface.php
+++ b/src/Drupal/Driver/Capability/MailCapabilityInterface.php
@@ -43,10 +43,15 @@ interface MailCapabilityInterface {
    *   The recipient email address.
    * @param string $langcode
    *   The language code for subject and body.
+   * @param array<int, array<string, mixed>> $attachments
+   *   Optional attachments. Each is an associative array carrying at least a
+   *   'filename', following Drupal's standard attachment structure. When
+   *   provided, they are recorded on the sent message's 'params' under the
+   *   'attachments' key.
    *
    * @return bool
    *   TRUE if the message was accepted for delivery.
    */
-  public function mailSend(string $body, string $subject, string $to, string $langcode): bool;
+  public function mailSend(string $body, string $subject, string $to, string $langcode, array $attachments = []): bool;
 
 }

--- a/src/Drupal/Driver/Core/Core.php
+++ b/src/Drupal/Driver/Core/Core.php
@@ -1154,10 +1154,15 @@ class Core implements CoreInterface, CreationAliasCapabilityInterface {
   /**
    * {@inheritdoc}
    */
-  public function mailSend(string $body, string $subject, string $to, string $langcode): bool {
+  public function mailSend(string $body, string $subject, string $to, string $langcode, array $attachments = []): bool {
     // Send the mail, via the system module's hook_mail.
     $params['context']['message'] = $body;
     $params['context']['subject'] = $subject;
+
+    if ($attachments !== []) {
+      $params['attachments'] = $attachments;
+    }
+
     $mail_manager = \Drupal::service('plugin.manager.mail');
     $result = $mail_manager->mail('system', '', $to, $langcode, $params, NULL, TRUE);
     return !empty($result['result']);

--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -354,8 +354,8 @@ class DrupalDriver implements DrupalDriverInterface, CreationAliasCapabilityInte
   /**
    * {@inheritdoc}
    */
-  public function mailSend(string $body, string $subject, string $to, string $langcode): bool {
-    return $this->getCore()->mailSend($body, $subject, $to, $langcode);
+  public function mailSend(string $body, string $subject, string $to, string $langcode, array $attachments = []): bool {
+    return $this->getCore()->mailSend($body, $subject, $to, $langcode, $attachments);
   }
 
   /**

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreMailMethodsKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreMailMethodsKernelTest.php
@@ -61,8 +61,6 @@ class CoreMailMethodsKernelTest extends KernelTestBase {
     $this->assertCount(1, $mail);
     $this->assertSame('to@example.com', $mail[0]['to']);
     $this->assertSame('Subject line', $mail[0]['subject'] ?? $mail[0]['params']['context']['subject'] ?? NULL);
-    // A send without attachments must not inject an 'attachments' param.
-    $this->assertArrayNotHasKey('attachments', $mail[0]['params']);
 
     $this->core->mailClear();
     $this->assertSame([], $this->core->mailGet());
@@ -93,6 +91,20 @@ class CoreMailMethodsKernelTest extends KernelTestBase {
     $mail = $this->core->mailGet();
     $this->assertCount(1, $mail);
     $this->assertSame($attachments, $mail[0]['params']['attachments']);
+  }
+
+  /**
+   * Tests that an explicit empty attachments array omits the params key.
+   */
+  public function testMailSendWithEmptyAttachmentsOmitsKey(): void {
+    $this->core->mailStartCollecting();
+
+    $sent = $this->core->mailSend('Body text', 'Subject line', 'to@example.com', 'en', []);
+    $this->assertTrue($sent);
+
+    $mail = $this->core->mailGet();
+    $this->assertCount(1, $mail);
+    $this->assertArrayNotHasKey('attachments', $mail[0]['params']);
   }
 
   /**

--- a/tests/Drupal/Tests/Driver/Kernel/Core/CoreMailMethodsKernelTest.php
+++ b/tests/Drupal/Tests/Driver/Kernel/Core/CoreMailMethodsKernelTest.php
@@ -61,6 +61,8 @@ class CoreMailMethodsKernelTest extends KernelTestBase {
     $this->assertCount(1, $mail);
     $this->assertSame('to@example.com', $mail[0]['to']);
     $this->assertSame('Subject line', $mail[0]['subject'] ?? $mail[0]['params']['context']['subject'] ?? NULL);
+    // A send without attachments must not inject an 'attachments' param.
+    $this->assertArrayNotHasKey('attachments', $mail[0]['params']);
 
     $this->core->mailClear();
     $this->assertSame([], $this->core->mailGet());
@@ -70,6 +72,27 @@ class CoreMailMethodsKernelTest extends KernelTestBase {
     // kernel test because KernelTestBase pre-seeds the mail system.
     $this->core->mailStopCollecting();
     $this->assertSame([], $this->core->mailGet());
+  }
+
+  /**
+   * Tests that 'mailSend()' carries attachments through to the collected mail.
+   */
+  public function testMailSendCarriesAttachments(): void {
+    $this->core->mailStartCollecting();
+
+    $attachments = [
+      [
+        'filecontent' => 'PDF bytes',
+        'filename' => 'document.pdf',
+        'filemime' => 'application/pdf',
+      ],
+    ];
+    $sent = $this->core->mailSend('Body text', 'Subject line', 'to@example.com', 'en', $attachments);
+    $this->assertTrue($sent);
+
+    $mail = $this->core->mailGet();
+    $this->assertCount(1, $mail);
+    $this->assertSame($attachments, $mail[0]['params']['attachments']);
   }
 
   /**

--- a/tests/Drupal/Tests/Driver/Unit/DrupalDriverDelegationTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/DrupalDriverDelegationTest.php
@@ -182,7 +182,11 @@ class DrupalDriverDelegationTest extends TestCase {
     yield 'mailGet' => ['mailGet', [], 'mailGet'];
     yield 'mailClear' => ['mailClear', [], 'mailClear'];
     yield 'mailSend' => ['mailSend', ['body', 'subject', 'to@ex.co', 'en'], 'mailSend'];
-    yield 'mailSend with attachments' => ['mailSend', ['body', 'subject', 'to@ex.co', 'en', [['filename' => 'doc.pdf']]], 'mailSend'];
+    yield 'mailSend with attachments' => [
+      'mailSend',
+      ['body', 'subject', 'to@ex.co', 'en', [['filename' => 'doc.pdf']]],
+      'mailSend',
+    ];
     yield 'moduleInstall' => ['moduleInstall', ['node'], 'moduleInstall'];
     yield 'moduleUninstall' => ['moduleUninstall', ['node'], 'moduleUninstall'];
   }

--- a/tests/Drupal/Tests/Driver/Unit/DrupalDriverDelegationTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/DrupalDriverDelegationTest.php
@@ -182,6 +182,7 @@ class DrupalDriverDelegationTest extends TestCase {
     yield 'mailGet' => ['mailGet', [], 'mailGet'];
     yield 'mailClear' => ['mailClear', [], 'mailClear'];
     yield 'mailSend' => ['mailSend', ['body', 'subject', 'to@ex.co', 'en'], 'mailSend'];
+    yield 'mailSend with attachments' => ['mailSend', ['body', 'subject', 'to@ex.co', 'en', [['filename' => 'doc.pdf']]], 'mailSend'];
     yield 'moduleInstall' => ['moduleInstall', ['node'], 'moduleInstall'];
     yield 'moduleUninstall' => ['moduleUninstall', ['node'], 'moduleUninstall'];
   }


### PR DESCRIPTION
Closes #379

## Summary

Adds an optional `$attachments` parameter to `MailCapabilityInterface::mailSend()` and its implementations in `Core` and `DrupalDriver`, allowing callers to send mail with file attachments. When attachments are provided, `Core::mailSend()` sets `$params['attachments']` before passing params to Drupal's mail manager; when the array is empty the key is omitted entirely, keeping the no-attachment message byte-for-byte identical to the pre-patch behaviour. The parameter defaults to `[]`, so all existing four-argument call sites are unaffected.

## Changes

**`src/Drupal/Driver/Capability/MailCapabilityInterface.php`**
- Added optional `array $attachments = []` parameter to `mailSend()`.
- Added `@param` docblock entry describing each attachment as an associative array carrying at least a `filename` key, following Drupal's standard attachment structure.

**`src/Drupal/Driver/Core/Core.php`**
- Updated `mailSend()` signature to accept the new parameter.
- Conditionally sets `$params['attachments']` only when the array is non-empty, so the collected message for a plain send remains unchanged.

**`src/Drupal/Driver/DrupalDriver.php`**
- Updated `mailSend()` signature to accept and forward `$attachments` to `Core::mailSend()`.

**`tests/Drupal/Tests/Driver/Unit/DrupalDriverDelegationTest.php`**
- Added a `mailSend with attachments` data-provider row verifying that `DrupalDriver::mailSend()` forwards the attachments argument through to `Core`.

**`tests/Drupal/Tests/Driver/Kernel/Core/CoreMailMethodsKernelTest.php`**
- `testMailSendCarriesAttachments()` - kernel round-trip confirming that `$params['attachments']` on the collected message equals the array passed to `mailSend()`.
- `testMailSendWithEmptyAttachmentsOmitsKey()` - kernel round-trip confirming that an explicit `[]` leaves `$params['attachments']` absent from the collected message.
