### PR TITLE
Fixed 'DrupalExtension smoke' CI job to resolve against both dev and stable DrupalDriver constraints.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
           # Check out the branch by name (not the merge SHA) so the path
           # repo composer adds below has a real branch to work with. The
           # version exposed to composer is overridden in the 'Add path
-          # repository' step so DrupalExtension's 'dev-master' constraint
+          # repository' step to match DrupalExtension's constraint, so it
           # resolves regardless of the actual branch name.
           ref: ${{ github.head_ref || github.ref_name }}
           path: drupaldriver
@@ -243,16 +243,28 @@ jobs:
 
       - name: Add path repository for DrupalDriver
         working-directory: drupalextension
-        # Expose the path repo at a stable version so the constraint resolves
-        # regardless of what stability floor DrupalExtension currently sets.
-        # Earlier iterations of this step hard-coded an 'alpha' suffix to
-        # match DE's then-current 'minimum-stability'; every time DE bumped
-        # the floor (alpha -> beta -> RC -> stable) the workflow had to be
-        # bumped in lockstep. Declaring stable here satisfies any floor up
-        # to and including stable, breaking that coupling. 'dev-master' is
-        # still rejected when DE's floor is above 'dev'.
+        # The version of 'drupal/drupal-driver' that DrupalExtension requires
+        # depends on the branch under test: its development branch consumes this
+        # repo's unreleased HEAD via 'dev-master as <v>', while release branches
+        # pin a stable '^<major>' range against a tagged DrupalDriver. A path
+        # repo is canonical, so the local copy must expose whichever version
+        # shape DE actually declares - no single value satisfies both (a numeric
+        # version never matches a 'dev-master' require, and a dev version never
+        # matches a stable range). Read DE's constraint and mirror its shape:
+        # a 'dev-master' source for the dev-ref case, or '<major>.99.99' (major
+        # taken from this repo's own branch-alias) for the stable-range case.
         run: |
-          composer config repositories.drupaldriver '{"type":"path","url":"../drupaldriver","options":{"versions":{"drupal/drupal-driver":"3.99.99"}}}' --json
+          constraint=$(jq -r '.require["drupal/drupal-driver"] // ""' composer.json)
+          echo "DrupalExtension requires drupal/drupal-driver: ${constraint:-<none>}"
+          if [[ "$constraint" == dev-* ]]; then
+            version='dev-master'
+          else
+            major=$(jq -r '(.extra["branch-alias"]["dev-master"] // "0") | split(".")[0]' ../drupaldriver/composer.json)
+            version="${major}.99.99"
+          fi
+          echo "Exposing DrupalDriver path repo as: $version"
+          repo=$(jq -nc --arg v "$version" '{type:"path",url:"../drupaldriver",options:{versions:{"drupal/drupal-driver":$v}}}')
+          composer config repositories.drupaldriver "$repo" --json
 
       - name: Install DrupalExtension dependencies
         working-directory: drupalextension


### PR DESCRIPTION
## Summary

The `DrupalExtension smoke` CI job checks out DrupalExtension and registers this repo as a canonical Composer path repository so DE's test suite runs against DrupalDriver HEAD. The step previously hard-coded the exposed path-repo version to `3.99.99`, which only satisfies a stable `^3.x` constraint. DrupalExtension's development branch instead requires `"drupal/drupal-driver": "dev-master as <v>"` - a dev-ref constraint that a numeric version can never match. Because a path repo is canonical (highest priority), Composer refuses to fall back to Packagist's real `dev-master`, making resolution fail with "could not be resolved ... higher repository priority". No single fixed version can satisfy both shapes (dev-ref and stable range) simultaneously.

The fix reads DrupalExtension's actual `drupal/drupal-driver` constraint at runtime via `jq` and mirrors its shape: if the constraint starts with `dev-`, the path repo is exposed as `dev-master`; otherwise it is exposed as `<major>.99.99`, deriving `<major>` from this repo's own `extra.branch-alias` (`dev-master: 3.0.x-dev` -> `3`). The stable fallback self-maintains across a future major bump without touching the workflow. The adjacent checkout-step comment was also updated to reflect that resolution works for both constraint shapes, not only `dev-master`.

## Changes

- **`.github/workflows/ci.yml` - Add path repository step**: replaced the hard-coded `3.99.99` version with a shell block that reads DrupalExtension's `require["drupal/drupal-driver"]` constraint, branches on whether it is a `dev-*` ref (expose `dev-master`) or a stable range (expose `<major>.99.99` from branch-alias), and passes the result to `composer config repositories.drupaldriver`.
- **`.github/workflows/ci.yml` - Checkout step comment**: updated wording so it no longer implies only the `dev-master` constraint shape is handled.

## Before / After

```
BEFORE
──────
DE dev branch requires:  "drupal/drupal-driver": "dev-master as 3.2.0"
Path repo exposes:        3.99.99  (hard-coded)
Result:  numeric 3.99.99 ≠ dev-master alias, but canonical repo shadows
         Packagist, so Composer cannot fall back - RESOLUTION FAILS.

DE release branch requires: "drupal/drupal-driver": "^3.5"
Path repo exposes:           3.99.99  (hard-coded)
Result:  3.99.99 satisfies ^3.5 - RESOLVES (only this case worked).

AFTER
─────
Read DE's constraint at runtime via jq:

  constraint = "dev-master as 3.2.0"  (dev-* shape)
  → expose path repo as: dev-master
  → dev-master satisfies "dev-master as 3.2.0"        RESOLVES ✓

  constraint = "^3.5"  (stable range)
  → read branch-alias from drupaldriver/composer.json: "dev-master: 3.0.x-dev" → major=3
  → expose path repo as: 3.99.99
  → 3.99.99 satisfies ^3.5                            RESOLVES ✓
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline dependency management to use dynamic version constraints instead of fixed values, ensuring better alignment with declared component versions and enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->