### PR TITLE
remove legacyDrush check

### DIFF
--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -53,11 +53,6 @@ class DrushDriver implements DrushDriverInterface, CreationAliasCapabilityInterf
   protected string $arguments = '';
 
   /**
-   * Tracks legacy drush.
-   */
-  protected static bool $isLegacyDrush;
-
-  /**
    * Set drush alias or root path.
    *
    * @param string $alias
@@ -119,10 +114,6 @@ class DrushDriver implements DrushDriverInterface, CreationAliasCapabilityInterf
    * {@inheritdoc}
    */
   public function bootstrap(): void {
-    if (!isset(self::$isLegacyDrush)) {
-      self::$isLegacyDrush = $this->isLegacyDrush();
-    }
-
     $this->bootstrapped = TRUE;
   }
 
@@ -145,11 +136,6 @@ class DrushDriver implements DrushDriverInterface, CreationAliasCapabilityInterf
    * {@inheritdoc}
    */
   public function cacheClear(?string $type = 'all'): void {
-    if (self::$isLegacyDrush) {
-      $this->drush('cache-clear', [$type], []);
-      return;
-    }
-
     // Drush-only cache clear does not need a full rebuild.
     if ($type === 'drush') {
       $this->drush('cache-clear', ['drush'], []);
@@ -356,12 +342,7 @@ class DrushDriver implements DrushDriverInterface, CreationAliasCapabilityInterf
   public function drushResult(string $command, array $arguments = [], array $options = []): DrushResult {
     $argument_string = implode(' ', $arguments);
 
-    if (isset(static::$isLegacyDrush) && static::$isLegacyDrush) {
-      $options['nocolor'] = TRUE;
-    }
-    else {
-      $options['no-ansi'] = NULL;
-    }
+    $options['no-ansi'] = NULL;
 
     $option_string = static::parseArguments($options);
     $alias = isset($this->alias) ? '@' . $this->alias : '--root=' . $this->root;
@@ -461,29 +442,6 @@ class DrushDriver implements DrushDriverInterface, CreationAliasCapabilityInterf
     }
 
     return $fallback;
-  }
-
-  /**
-   * Determine if drush is a legacy version.
-   *
-   * @return bool
-   *   Returns TRUE if drush is older than drush 9.
-   */
-  protected function isLegacyDrush(): bool {
-    try {
-      // Try for a drush 9 version.
-      $output = trim($this->drush('version', [], ['format' => 'string']));
-      // On PHP 8.4, deprecation warnings from Drush dependencies may be
-      // written to stdout before the version string. Extract the actual
-      // version number from the output to avoid misdetection.
-      $version = preg_match('/(\d+\.\d+\.\d+(\.\d+)?)\s*$/', $output, $matches) ? $matches[1] : $output;
-      return version_compare($version, '9', '<=');
-    }
-    catch (\RuntimeException) {
-      // The version of drush is old enough that only `--version` was available,
-      // so this is a legacy version.
-      return TRUE;
-    }
   }
 
   /**

--- a/tests/Drupal/Tests/Driver/Unit/DrushDriverMethodsTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/DrushDriverMethodsTest.php
@@ -9,7 +9,6 @@ use Drupal\Driver\DrushDriver;
 use Drupal\Driver\Entity\EntityStub;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -27,25 +26,10 @@ use PHPUnit\Framework\TestCase;
 class DrushDriverMethodsTest extends TestCase {
 
   /**
-   * Sets 'DrushDriver::$isLegacyDrush' directly, bypassing bootstrap caching.
-   */
-  protected function forceLegacyDrush(bool $legacy): void {
-    $reflection = new \ReflectionClass(DrushDriver::class);
-    $prop = $reflection->getProperty('isLegacyDrush');
-    $prop->setValue(NULL, $legacy);
-  }
-
-  /**
    * Tests that 'bootstrap()' flips the bootstrapped flag.
-   *
-   * Runs in its own process so the static 'isLegacyDrush' cache starts
-   * uninitialised; without isolation the bootstrap's caching guard skips
-   * the version-detection assignment.
    */
-  #[RunInSeparateProcess]
   public function testBootstrapMarksAsBootstrapped(): void {
     $driver = $this->createDriver();
-    $driver->drushResponse = "12.5.2.0\n";
 
     $this->assertFalse($driver->isBootstrapped());
     $driver->bootstrap();
@@ -82,30 +66,16 @@ class DrushDriverMethodsTest extends TestCase {
   }
 
   /**
-   * Tests 'cacheClear()' on a modern Drush (cache:rebuild path).
+   * Tests 'cacheClear()' rebuilds the cache.
    */
-  public function testCacheClearOnModernDrushRebuilds(): void {
+  public function testCacheClearRebuilds(): void {
     $driver = $this->createDriver();
-    $this->forceLegacyDrush(FALSE);
 
     $driver->cacheClear();
 
     $this->assertNotEmpty($driver->invocations);
     $commands = array_column($driver->invocations, 'command');
     $this->assertContains('cache:rebuild', $commands);
-  }
-
-  /**
-   * Tests 'cacheClear()' on a legacy Drush (cache-clear path).
-   */
-  public function testCacheClearOnLegacyDrushUsesCacheClear(): void {
-    $driver = $this->createDriver();
-    $this->forceLegacyDrush(TRUE);
-
-    $driver->cacheClear('all');
-
-    $this->assertSame('cache-clear', $driver->invocations[0]['command']);
-    $this->assertSame(['all'], $driver->invocations[0]['arguments']);
   }
 
   /**
@@ -154,27 +124,16 @@ class DrushDriverMethodsTest extends TestCase {
   }
 
   /**
-   * Tests 'cacheClear()' on legacy Drush with a drush-only bin.
+   * Tests 'cacheClear()' with a drush-only bin skips the rebuild.
    */
-  public function testCacheClearDrushOnlyOnModernDrushSkipsRebuild(): void {
+  public function testCacheClearDrushOnlySkipsRebuild(): void {
     $driver = $this->createDriver();
-    $this->forceLegacyDrush(FALSE);
 
     $driver->cacheClear('drush');
 
     $this->assertCount(1, $driver->invocations);
     $this->assertSame('cache-clear', $driver->invocations[0]['command']);
     $this->assertSame(['drush'], $driver->invocations[0]['arguments']);
-  }
-
-  /**
-   * Tests 'isLegacyDrush()' treats 'version' failure as legacy.
-   */
-  public function testIsLegacyDrushTreatsExceptionAsLegacy(): void {
-    $driver = $this->createDriver();
-    $driver->drushThrows = TRUE;
-
-    $this->assertTrue($driver->callIsLegacyDrushWithThrowing());
   }
 
   /**
@@ -219,20 +178,19 @@ class DrushDriverMethodsTest extends TestCase {
   }
 
   /**
-   * Tests that 'drush()' emits the legacy '--nocolor' flag when set.
+   * Tests that 'drush()' always emits the '--no-ansi' flag.
    */
-  public function testDrushEmitsLegacyFlagWhenMarkedLegacy(): void {
+  public function testDrushAlwaysEmitsNoAnsiFlag(): void {
     $echo = $this->resolveSystemBinary('echo');
     if ($echo === NULL) {
       $this->markTestSkipped('echo binary is not available on this system.');
     }
 
-    $this->forceLegacyDrush(TRUE);
     $driver = new DrushDriver('alias', binary: $echo);
 
     $result = $driver->drush('version');
 
-    $this->assertStringContainsString('--nocolor=1', $result);
+    $this->assertStringContainsString('--no-ansi', $result);
   }
 
   /**
@@ -415,11 +373,6 @@ class RecordingDrushDriver extends DrushDriver {
   public string $drushResponse = '';
 
   /**
-   * When TRUE, 'drush()' throws a RuntimeException.
-   */
-  public bool $drushThrows = FALSE;
-
-  /**
    * {@inheritdoc}
    */
   public function drush(string $command, array $arguments = [], array $options = []): string {
@@ -429,18 +382,7 @@ class RecordingDrushDriver extends DrushDriver {
       'options' => $options,
     ];
 
-    if ($this->drushThrows) {
-      throw new \RuntimeException('drush stubbed failure');
-    }
-
     return $this->drushResponse;
-  }
-
-  /**
-   * Exposes 'isLegacyDrush()' for testing the exception-path coverage.
-   */
-  public function callIsLegacyDrushWithThrowing(): bool {
-    return $this->isLegacyDrush();
   }
 
 }

--- a/tests/Drupal/Tests/Driver/Unit/DrushDriverTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/DrushDriverTest.php
@@ -65,49 +65,6 @@ class DrushDriverTest extends TestCase {
   }
 
   /**
-   * Tests 'isLegacyDrush()' correctly detects version from noisy output.
- *
- * @dataProvider dataProviderIsLegacyDrush
- */
-  #[DataProvider('dataProviderIsLegacyDrush')]
-  public function testIsLegacyDrush(string $drush_output, bool $expected): void {
-    $driver = new TestDrushDriver('alias');
-    $driver->drushOutput = $drush_output;
-    $result = $driver->callIsLegacyDrush();
-    $this->assertSame($expected, $result);
-  }
-
-  /**
-   * Data provider for testIsLegacyDrush().
-   */
-  public static function dataProviderIsLegacyDrush(): \Iterator {
-    yield 'clean modern version' => [
-      "12.5.2.0\n",
-      FALSE,
-    ];
-    yield 'deprecation warnings before version' => [
-      "Deprecated: Drush\\Drush::shell(): Implicitly marking parameter \$env as nullable\nDeprecated: Consolidation\\Config\\Config::__construct(): ...\n12.5.2.0\n",
-      FALSE,
-    ];
-    yield 'drush 9 version' => [
-      "9.7.2\n",
-      FALSE,
-    ];
-    yield 'legacy drush version' => [
-      "8.4.12\n",
-      TRUE,
-    ];
-    yield 'legacy version with noise' => [
-      "Some warning output\n8.1.0\n",
-      TRUE,
-    ];
-    yield 'three-part modern version' => [
-      "13.0.0\n",
-      FALSE,
-    ];
-  }
-
-  /**
    * Tests 'parseUserId()' correctly extracts UID from drush output.
  *
  * @dataProvider dataProviderParseUserId
@@ -158,13 +115,6 @@ class TestDrushDriver extends DrushDriver {
    */
   public function drush($command, array $arguments = [], array $options = []): string {
     return $this->drushOutput;
-  }
-
-  /**
-   * Exposes 'isLegacyDrush()' for testing.
-   */
-  public function callIsLegacyDrush(): bool {
-    return $this->isLegacyDrush();
   }
 
   /**


### PR DESCRIPTION
 I'm on Drupal 11 with the latest Drush. My behat tests run in GHA sometimes fail because I get a RuntimeException() in bootstrap() when the runner is setting up wireguard, which causes isLegacyDrush() to resolve TRUE as it fails closed.

However, DrupalDriver now only supports Drupal 10/11, so isLegacyDrush() seems to just be dead code that can accidentally be triggered by a Drupal 11 site, which definitely can't use legacy drush.

Prepared with assistance from Claude Opus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Drush operations now consistently use the modern non-ANSI output mode.
  - Cache clearing now follows the standard cache rebuild behavior without legacy-specific handling.

- **Tests**
  - Updated coverage to verify consistent Drush flags and cache-clearing behavior.
  - Removed obsolete tests for legacy Drush detection and compatibility paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->