### PR TITLE
Removed the redundant default value from the 'mainProperty' field handler property.

### DIFF
--- a/src/Drupal/Driver/Core/Field/AbstractHandler.php
+++ b/src/Drupal/Driver/Core/Field/AbstractHandler.php
@@ -30,7 +30,7 @@ abstract class AbstractHandler implements FieldHandlerInterface {
    * 'name'); those handlers must override 'normalise()' to interpret
    * records themselves.
    */
-  protected ?string $mainProperty = NULL;
+  protected ?string $mainProperty;
 
   /**
    * Constructs an AbstractHandler object.


### PR DESCRIPTION
## Summary

Removed the redundant `= NULL` default from `AbstractHandler::$mainProperty` in `src/Drupal/Driver/Core/Field/AbstractHandler.php`. The property is a nullable string, but every non-throwing path through `AbstractHandler::__construct()` assigns it unconditionally from `$this->fieldInfo->getMainPropertyName()`, so the `NULL` default was never actually observed by any caller. A fresh dependency install (`vendor/` and `composer.lock` removed, then `composer update` re-resolved) pulled in `rector/rector` 2.5.8, and its `RemoveDefaultValueFromAssignedPropertyRector` rule (deadCode set) flagged the declaration as dead code.

## Changes

- `src/Drupal/Driver/Core/Field/AbstractHandler.php`: changed `protected ?string $mainProperty = NULL;` to `protected ?string $mainProperty;`, keeping the nullable type (`normalise()` still checks `$this->mainProperty === NULL` for handlers without a main property) while removing the default value that the constructor always overwrites.

## Before / After

```
BEFORE
┌──────────────────────────────────────────────────┐
│ protected ?string $mainProperty = NULL;           │
└──────────────────────────────────────────────────┘
                       │
                       ▼
           property initialized to NULL
                       │
                       ▼
              __construct() runs
                       │
                       ▼
 $this->mainProperty = $this->fieldInfo->getMainPropertyName();
                       │
                       ▼
        NULL default silently overwritten
   (redundant: every non-throwing path reaches this line)

AFTER
┌──────────────────────────────────────────────────┐
│ protected ?string $mainProperty;                  │
└──────────────────────────────────────────────────┘
                       │
                       ▼
          property left uninitialized
                       │
                       ▼
              __construct() runs
                       │
                       ▼
 $this->mainProperty = $this->fieldInfo->getMainPropertyName();
                       │
                       ▼
          first and only assignment
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified an internal property declaration without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->