### PR TITLE
Fixed 'DrupalExtension smoke' checkout failing for pull requests from forks.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,12 +213,6 @@ jobs:
       - name: Checkout DrupalDriver
         uses: actions/checkout@v6
         with:
-          # Check out the branch by name (not the merge SHA) so the path
-          # repo composer adds below has a real branch to work with. The
-          # version exposed to composer is overridden in the 'Add path
-          # repository' step to match DrupalExtension's constraint, so it
-          # resolves regardless of the actual branch name.
-          ref: ${{ github.head_ref || github.ref_name }}
           path: drupaldriver
 
       - name: Checkout DrupalExtension


### PR DESCRIPTION
## Summary

The `extension` job ("DrupalExtension smoke") failed on every pull request from a fork: its "Checkout DrupalDriver" step set `ref:` to the head branch name while leaving `repository:` at the base repo `jhedstrom/DrupalDriver`, where a fork's branch does not exist, so `git fetch` matched nothing and exited 1 (observed on PR #387, branch `legacyDrush` from fork `ptmkenny/DrupalDriver`). The `ref:` override was no longer needed: the "Add path repository for DrupalDriver" step always pins `options.versions` for `drupal/drupal-driver`, and Composer's `PathRepository::initialize()` only calls the version guesser - the only code path needing a branch name - when no version is set, so it never runs; the only remaining git call computes `dist.reference` from `HEAD`, which works fine on a detached HEAD. Removing `ref:` restores the default checkout of the PR merge ref, which lives in the base repo and resolves for forks, and brings this job in line with the `lint` and `tests` jobs, which already test the merge result.

## Changes

- `.github/workflows/ci.yml`: removed the `ref: ${{ github.head_ref || github.ref_name }}` override and its explanatory comment from the `extension` job's "Checkout DrupalDriver" step, leaving the step to check out `actions/checkout@v6`'s default ref.

## Before / After

```
BEFORE
┌───────────────────────────────────────────────────┐
│ ref: ${{ github.head_ref || github.ref_name }}    │
└───────────────────────────────────────────────────┘
                        │
                        ▼
   fork PR #387 (ptmkenny/DrupalDriver, branch legacyDrush)
                resolves ref to "legacyDrush"
                        │
                        ▼
    git fetch refs/heads/legacyDrush* from jhedstrom/DrupalDriver
                        │
                        ▼
       branch only exists in the fork, not the base repo
                        │
                        ▼
               fetch matches nothing, exit 1
                        │
                        ▼
            "DrupalExtension smoke" job FAILS

AFTER
┌───────────────────────────────────────────────────┐
│ ref: (not set, actions/checkout uses its default) │
└───────────────────────────────────────────────────┘
                        │
                        ▼
      fork PR #387 -> default ref is the PR merge ref
                        │
                        ▼
     git fetch refs/pull/387/merge from jhedstrom/DrupalDriver
                        │
                        ▼
           merge ref always lives in the base repo
                        │
                        ▼
                  checkout succeeds
                        │
                        ▼
    "DrupalExtension smoke" job RUNS, same as lint and tests
```
