### PR TITLE
Removed the dead drush stub from 'TestDrushDriver' and documented the legacy Drush removal.

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -131,6 +131,29 @@ the missing behaviour themselves. Test the capability with
 `instanceof ContentCapabilityInterface` (or the relevant capability interface)
 before calling.
 
+### DrushDriver no longer detects legacy Drush
+
+`DrushDriver` used to probe `drush version` during `bootstrap()` and cache the
+answer in a `protected static bool $isLegacyDrush` to pick between Drush 8 and
+Drush 9+ behaviour. Drupal `^10 || ^11` requires Drush 11 or newer, so the
+Drush 8 branches were unreachable. Both the probe and the flag are gone:
+
+- `DrushDriver::isLegacyDrush()` (protected) - removed.
+- `DrushDriver::$isLegacyDrush` (protected static) - removed.
+
+The behaviour they gated is now unconditional:
+
+- `drushResult()` always passes `--no-ansi`. The Drush 8 `--nocolor` spelling
+  is never emitted.
+- `cacheClear()` always takes the `cache:rebuild` path. A `'drush'` type still
+  short-circuits to `cache-clear drush`.
+- `bootstrap()` no longer shells out to Drush; it only flips the bootstrapped
+  flag.
+
+Subclasses that overrode `isLegacyDrush()` or read `static::$isLegacyDrush`
+must drop those overrides. Sites that still run Drush 8 are on Drupal 9 or
+earlier and belong on the 2.x line.
+
 ### CoreInterface expanded
 
 `Drupal\Driver\Core\CoreInterface` now extends every capability interface in

--- a/tests/Drupal/Tests/Driver/Unit/DrushDriverTest.php
+++ b/tests/Drupal/Tests/Driver/Unit/DrushDriverTest.php
@@ -101,21 +101,9 @@ class DrushDriverTest extends TestCase {
 }
 
 /**
- * Testable subclass that stubs the 'drush()' method.
+ * Testable subclass that exposes protected helpers.
  */
 class TestDrushDriver extends DrushDriver {
-
-  /**
-   * The output to return from 'drush()'.
-   */
-  public string $drushOutput = '';
-
-  /**
-   * {@inheritdoc}
-   */
-  public function drush($command, array $arguments = [], array $options = []): string {
-    return $this->drushOutput;
-  }
 
   /**
    * Exposes 'parseUserId()' for testing.


### PR DESCRIPTION
## Summary

This is a follow-up to #387, which deleted `DrushDriver`'s Drush 8 compatibility layer (the `isLegacyDrush()` probe, the `protected static bool $isLegacyDrush` cache, the legacy `cacheClear()` branch, and the `--nocolor` vs `--no-ansi` fork). Review of that PR flagged two things it left behind: a test double in `DrushDriverTest.php` that only existed to feed the now-deleted `testIsLegacyDrush`, and a gap in `UPGRADING.md` around the two removed `protected` members, which this project treats as a downstream subclassing surface. This PR removes the dead test stub and adds the missing upgrade-notes entry.

## Changes

- `tests/Drupal/Tests/Driver/Unit/DrushDriverTest.php`: Removed `TestDrushDriver::$drushOutput` and its `drush()` override. Both were added solely to stub `drush()` for `testIsLegacyDrush`, which #387 already deleted; the remaining `testParseUserId` only calls `callParseUserId()`, pure string parsing that never reaches `drush()`.
- `UPGRADING.md`: Added a "DrushDriver no longer detects legacy Drush" entry under the v3 removal notes, documenting that `DrushDriver::isLegacyDrush()` and `DrushDriver::$isLegacyDrush` are gone, and that `drushResult()`, `cacheClear()`, and `bootstrap()` now run their previously-conditional Drush 9+ behaviour unconditionally.

## Before / After

```
tests/Drupal/Tests/Driver/Unit/DrushDriverTest.php
──────────────────────────────────────────────────

┌─ BEFORE ───────────────────────────────────────────────────┐
│ class TestDrushDriver extends DrushDriver {
│
│   public string $drushOutput = '';
│   // nothing writes to this since #387 deleted
│   // testIsLegacyDrush
│
│   public function drush($command, array $arguments = [],
│       array $options = []): string {
│     return $this->drushOutput;
│   }
│
│   public function callParseUserId(string $info): ?int { ... }
│ }
└────────────────────────────────────────────────────────────┘

┌─ AFTER ────────────────────────────────────────────────────┐
│ class TestDrushDriver extends DrushDriver {
│
│   public function callParseUserId(string $info): ?int { ... }
│ }
└────────────────────────────────────────────────────────────┘

UPGRADING.md (v3 removal notes)
───────────────────────────────

┌─ BEFORE ───────────────────────────────────────────────────┐
│ ...
│ ### DrushDriver no longer supports Content or Field capabilities
│ ### CoreInterface expanded
│ ...
└────────────────────────────────────────────────────────────┘

┌─ AFTER ────────────────────────────────────────────────────┐
│ ...
│ ### DrushDriver no longer supports Content or Field capabilities
│ ### DrushDriver no longer detects legacy Drush        (added)
│   - DrushDriver::isLegacyDrush() (protected) - removed.
│   - DrushDriver::$isLegacyDrush (protected static) - removed.
│ ### CoreInterface expanded
│ ...
└────────────────────────────────────────────────────────────┘
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added upgrade guidance for changes to Drush integration behavior.
  * Clarified that bootstrapping no longer probes the Drush version.
  * Documented consistent command options and cache-rebuild behavior across supported Drush versions.
  * Noted that custom subclasses overriding legacy Drush detection may require updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
